### PR TITLE
Feature/23 cmdstan path

### DIFF
--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -9,8 +9,7 @@ import tempfile
 
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
-from pathlib import PurePosixPath
-
+from pathlib import Path
 from typing import Dict
 
 from cmdstanpy import TMPDIR
@@ -43,7 +42,7 @@ def compile_model(
     if not overwrite and os.path.exists(exe_file):
         # print('model is up to date') # notify user or not?
         return Model(stan_file, exe_file)
-    exe_file_path = str(PurePosixPath(exe_file))
+    exe_file_path = Path(exe_file).as_posix()
     cmd = ['make', 'O={}'.format(opt_lvl), exe_file_path]
     print('compiling c++: make args {}'.format(cmd))
     try:

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -9,6 +9,8 @@ import tempfile
 
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
+from pathlib import PurePosixPath
+
 from typing import Dict
 
 from cmdstanpy import TMPDIR
@@ -24,12 +26,9 @@ def compile_model(
         raise Exception('must specify argument "stan_file"')
     if not os.path.exists(stan_file):
         raise Exception('no such stan_file {}'.format(stan_file))
-    path = os.path.abspath(os.path.dirname(stan_file))
     program_name = os.path.basename(stan_file)
-    model_name = os.path.splitext(program_name)[0]
-
-    hpp_name = model_name + '.hpp'
-    hpp_file = os.path.join(path, hpp_name)
+    exe_file, _ = os.path.splitext(os.path.abspath(stan_file))
+    hpp_file = '.'.join([exe_file, 'hpp'])
     if overwrite or not os.path.exists(hpp_file):
         print('translating to {}'.format(hpp_file))
         stanc_path = os.path.join(cmdstan_path(), 'bin', 'stanc')
@@ -39,13 +38,13 @@ def compile_model(
         if not os.path.exists(hpp_file):
             raise Exception('syntax error'.format(stan_file))
 
-    exe_file = os.path.join(path, model_name)
     if platform.system().lower().startswith('win'):
         exe_file += '.exe'
     if not overwrite and os.path.exists(exe_file):
         # print('model is up to date') # notify user or not?
         return Model(stan_file, exe_file)
-    cmd = ['make', 'O={}'.format(opt_lvl), exe_file]
+    exe_file_path = str(PurePosixPath(exe_file))
+    cmd = ['make', 'O={}'.format(opt_lvl), exe_file_path]
     print('compiling c++: make args {}'.format(cmd))
     try:
         do_command(cmd, cmdstan_path())

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -39,8 +39,8 @@ def cmdstan_path() -> str:
     if 'CMDSTAN' in os.environ:
         cmdstan_path = os.environ['CMDSTAN']
     else:
-        cmdstan_path = os.path.abspath(
-            os.path.join('.', 'releases', 'cmdstan'))
+        cmdstan_path = os.path.expanduser(
+            os.path.join('~', '.cmdstanpy', 'cmdstan'))
     validate_cmdstan_path(cmdstan_path)
     return cmdstan_path
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -13,12 +13,23 @@ CmdStanPy can be installed from GitHub
 	pip install -e git+https://github.com/stan-dev/cmdstanpy
 
 CmdStanPy requires a local install of CmdStan.
-If you don't have CmdStan installed, the script ``make_cmdstan.sh`` will install the latest version
-of CmdStan in the ``releases`` directory.  
+If you don't have CmdStan installed, you can run the script ``make_cmdstan.sh`` which
+will download CmdStan from GitHub and build the CmdStan utilities.
+By default this script installs the latest version of CmdStan into a directory named
+`.cmdstanpy` in the user's `$HOME` directory:
+
 
 .. code-block:: bash
 
 	./make_cmdstan.sh
+    ls -F ~/.cmdstanpy
+
+This script takes two optional named arguments: `-d <directory> -v <version>`
+
+.. code-block:: bash
+
+	./make_cmdstan.sh -d cmdstan -v 2.18.1
+    ls -F ~/cmdstan
 
 If you already have CmdStan installed, then set the ``CMDSTAN`` environment variable accordingly,
 either from within your Python session or setting the environment variable directly using ``bash``:

--- a/make_cmdstan.sh
+++ b/make_cmdstan.sh
@@ -1,32 +1,40 @@
 #!/usr/bin/env bash
 
-# install latest cmdstan release into subdir "releases"
-# symlink release dir as "cmdstan"
-# build binaries, compile example model to build model header
+# install a cmdstan release into a specified directory
+#  - build binaries, compile example model to build model header
+#  - symlink downloaded version as "cmdstan"
 
-if [[ ! -e releases ]]; then
-   mkdir releases
+RELDIR=$1
+if [ -z ${RELDIR} ]; then
+    RELDIR="$HOME/.cmdstanpy"
 fi
-if [[ ! -d releases ]]; then
-    echo 'cannot install cmdstan, file "releases" is not a directory'
+echo "$HOME"
+echo "${RELDIR}"
+
+if [[ ! -e ${RELDIR} ]]; then
+   mkdir ${RELDIR}
+fi
+if [[ ! -d ${RELDIR} ]]; then
+    echo "cannot install cmdstan, ${RELDIR} is not a directory"
     exit 1
 fi
-pushd releases > /dev/null
+echo "release dir: ${RELDIR}"
 
-echo "release dir: `pwd`"
-
-TAG=`curl -s https://api.github.com/repos/stan-dev/cmdstan/releases/latest | grep "tag_name"`
-echo $TAG > tmp-tag
-VER=`perl -p -e 's/"tag_name": "v//g; s/",//g' tmp-tag`
-echo $VER
-rm tmp-tag
-
-echo "latest cmdstan: $VER"
+VER=$2
+if [ -z ${VER} ]; then
+    TAG=`curl -s https://api.github.com/repos/stan-dev/cmdstan/releases/latest | grep "tag_name"`
+    echo $TAG > tmp-tag
+    VER=`perl -p -e 's/"tag_name": "v//g; s/",//g' tmp-tag`
+    rm tmp-tag
+fi
 CS=cmdstan-${VER}
+
+pushd ${RELDIR} > /dev/null
 if [[ -d $cs && -f ${CS}/bin/stanc && -f ${CS}/examples/bernoulli/bernoulli ]]; then
     echo "cmdstan already installed"
     exit 0
 fi
+echo "installing ${CS}"
 
 echo "downloading ${CS}.tar.gz from github"
 curl -s -OL https://github.com/stan-dev/cmdstan/releases/download/v${VER}/${CS}.tar.gz
@@ -52,9 +60,9 @@ ln -s ${CS} cmdstan
 pushd cmdstan > /dev/null
 echo "building cmdstan binaries"
 make -j2 build examples/bernoulli/bernoulli
-echo "installed ${CS}"
+echo "installed ${CS}; symlink: `ls -l ${RELDIR}/cmdstan`"
 
 # cleanup
 pushd -0 > /dev/null
 dirs -c > /dev/null
-echo "all installed versions in releases dir: `ls -Fd releases/* | grep -v @ | grep -v gz`"
+echo "all installed versions in ${RELDIR} dir: `ls -Fd ${RELDIR}/* | grep -v @ | grep -v gz`"

--- a/make_cmdstan.sh
+++ b/make_cmdstan.sh
@@ -4,12 +4,20 @@
 #  - build binaries, compile example model to build model header
 #  - symlink downloaded version as "cmdstan"
 
-RELDIR=$1
+while getopts ":d:v:" opt; do
+  case $opt in
+    d) RELDIR="$OPTARG"
+    ;;
+    v) VER="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+
 if [ -z ${RELDIR} ]; then
     RELDIR="$HOME/.cmdstanpy"
 fi
-echo "$HOME"
-echo "${RELDIR}"
 
 if [[ ! -e ${RELDIR} ]]; then
    mkdir ${RELDIR}
@@ -18,9 +26,8 @@ if [[ ! -d ${RELDIR} ]]; then
     echo "cannot install cmdstan, ${RELDIR} is not a directory"
     exit 1
 fi
-echo "release dir: ${RELDIR}"
+echo "cmdstan dir: ${RELDIR}"
 
-VER=$2
 if [ -z ${VER} ]; then
     TAG=`curl -s https://api.github.com/repos/stan-dev/cmdstan/releases/latest | grep "tag_name"`
     echo $TAG > tmp-tag
@@ -28,6 +35,7 @@ if [ -z ${VER} ]; then
     rm tmp-tag
 fi
 CS=cmdstan-${VER}
+echo "cmdstan version: ${VER}"
 
 pushd ${RELDIR} > /dev/null
 if [[ -d $cs && -f ${CS}/bin/stanc && -f ${CS}/examples/bernoulli/bernoulli ]]; then

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -17,19 +17,19 @@ y <- c(0, 1, 0, 0, 0, 0, 0, 0, 0, 1)
 
 class CmdStanPathTest(unittest.TestCase):
     def test_default_path(self):
-        abs_rel_path = os.path.abspath(os.path.join('releases', 'cmdstan'))
+        abs_rel_path = os.path.expanduser(os.path.join('~', '.cmdstanpy', 'cmdstan'))
         self.assertEqual(abs_rel_path, cmdstan_path())
 
     def test_set_path(self):
-        abs_rel_path = os.path.abspath(os.path.join('releases', 'cmdstan'))
+        abs_rel_path = os.path.expanduser(os.path.join('~', '.cmdstanpy', 'cmdstan'))
         self.assertEqual(abs_rel_path, cmdstan_path())
-        cur_version = os.path.abspath(
-            os.path.join('releases', 'cmdstan-2.19.1'))
-        set_cmdstan_path(cur_version)
-        self.assertEqual(cur_version, cmdstan_path())
+        install_version = os.path.expanduser(
+            os.path.join('~', '.cmdstanpy', 'cmdstan-2.19.1'))
+        set_cmdstan_path(install_version)
+        self.assertEqual(install_version, cmdstan_path())
 
     def test_validate_path(self):
-        abs_rel_path = os.path.abspath(os.path.join('releases', 'cmdstan'))
+        abs_rel_path = os.path.expanduser(os.path.join('~', '.cmdstanpy', 'cmdstan'))
         validate_cmdstan_path(abs_rel_path)
         path_foo = os.path.abspath(os.path.join('releases', 'foo'))
         with self.assertRaisesRegex(ValueError, 'no such CmdStan directory'):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
Changed default location of CmdStan install from module dir to user's home directory - default CmdStan location is now `~/.cmdstanpy/cmdstan` and script `make_cmdstan.sh` allows for 2 optional arguments:
  - location of install dir
  - version to be installed

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

