### PR TITLE
Allow user to specify include path for stan files

### DIFF
--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -21,7 +21,7 @@ from cmdstanpy.utils import cmdstan_path
 
 
 def compile_model(
-    stan_file: str = None, opt_lvl: int = 1, overwrite: bool = False
+        stan_file: str = None, opt_lvl: int = 1, overwrite: bool = False, include_paths: List[str] = None
 ) -> Model:
     """
     Compile the given Stan model file to an executable.
@@ -35,6 +35,9 @@ def compile_model(
 
     :param overwrite: When True, existing executible will be overwritten.
       Defaults to False.
+    
+    :param include_paths: list of paths to directories where Stan should look 
+      for files to include.
     """
     if stan_file is None:
         raise Exception('must specify argument "stan_file"')
@@ -47,6 +50,8 @@ def compile_model(
         print('translating to {}'.format(hpp_file))
         stanc_path = os.path.join(cmdstan_path(), 'bin', 'stanc')
         cmd = [stanc_path, '--o={}'.format(hpp_file), stan_file]
+        if include_paths is not None:
+            cmd = cmd.append('--include_paths=' + ','.join(include_paths))
         print('stan to c++: make args {}'.format(cmd))
         do_command(cmd)
         if not os.path.exists(hpp_file):

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -52,6 +52,8 @@ def compile_model(
         stanc_path = os.path.join(cmdstan_path(), 'bin', 'stanc')
         cmd = [stanc_path, '--o={}'.format(hpp_file), stan_file]
         if include_paths is not None:
+            if any([not os.path.exists(d) for d in include_paths]):
+                raise Exception('no such include path {}'.format(d))
             cmd = cmd.append('--include_paths=' + ','.join(include_paths))
         print('stan to c++: make args {}'.format(cmd))
         do_command(cmd)

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -54,7 +54,7 @@ def compile_model(
         if include_paths is not None:
             if any([not os.path.exists(d) for d in include_paths]):
                 raise Exception('no such include path {}'.format(d))
-            cmd += ['--include_paths=' + ','.join(include_paths)]
+            cmd.append('--include_paths=' + ','.join(include_paths))
         print('stan to c++: make args {}'.format(cmd))
         do_command(cmd)
         if not os.path.exists(hpp_file):

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -21,7 +21,8 @@ from cmdstanpy.utils import cmdstan_path
 
 
 def compile_model(
-        stan_file: str = None, opt_lvl: int = 1, overwrite: bool = False, include_paths: List[str] = None
+    stan_file: str = None, opt_lvl: int = 1, overwrite: bool = False,
+    include_paths: List[str] = None
 ) -> Model:
     """
     Compile the given Stan model file to an executable.

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -36,8 +36,8 @@ def compile_model(
 
     :param overwrite: When True, existing executible will be overwritten.
       Defaults to False.
-    
-    :param include_paths: list of paths to directories where Stan should look 
+
+    :param include_paths: list of paths to directories where Stan should look
       for files to include.
     """
     if stan_file is None:
@@ -52,8 +52,11 @@ def compile_model(
         stanc_path = os.path.join(cmdstan_path(), 'bin', 'stanc')
         cmd = [stanc_path, '--o={}'.format(hpp_file), stan_file]
         if include_paths is not None:
-            if any([not os.path.exists(d) for d in include_paths]):
-                raise Exception('no such include path {}'.format(d))
+            bad_paths = [d for d in include_paths if not os.path.exists(d)]
+            if any(bad_paths):
+                raise Exception(
+                    'invalid include paths: {}'.format(', '.join(bad_paths))
+                )
             cmd.append('--include_paths=' + ','.join(include_paths))
         print('stan to c++: make args {}'.format(cmd))
         do_command(cmd)

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -54,7 +54,7 @@ def compile_model(
         if include_paths is not None:
             if any([not os.path.exists(d) for d in include_paths]):
                 raise Exception('no such include path {}'.format(d))
-            cmd = cmd.append('--include_paths=' + ','.join(include_paths))
+            cmd += ['--include_paths=' + ','.join(include_paths)]
         print('stan to c++: make args {}'.format(cmd))
         do_command(cmd)
         if not os.path.exists(hpp_file):

--- a/test/data/bernoulli_include.stan
+++ b/test/data/bernoulli_include.stan
@@ -1,0 +1,15 @@
+functions {
+#include divide_real_by_two.stan
+}
+data {
+  int<lower=0> N;
+  int<lower=0,upper=1> y[N];
+}
+parameters {
+  real<lower=0,upper=1> theta;
+}
+model {
+  theta ~ beta(divide_real_by_two(2),1);
+  for (n in 1:N)
+    y[n] ~ bernoulli(theta);
+}

--- a/test/data/divide_real_by_two.stan
+++ b/test/data/divide_real_by_two.stan
@@ -1,0 +1,3 @@
+real divide_real_by_two(real x){
+  return x / 2;
+}

--- a/test/test_cmds.py
+++ b/test/test_cmds.py
@@ -22,6 +22,18 @@ class CompileTest(unittest.TestCase):
         self.assertEqual(stan, model.stan_file)
         self.assertTrue(model.exe_file.endswith(exe))
 
+    def test_include(self):
+        stan = os.path.join(datafiles_path, 'bernoulli_include.stan')
+        exe = os.path.join(datafiles_path, 'bernoulli_include')
+        here = os.path.dirname(os.path.abspath(__file__))
+        datafiles_abspath = os.path.join(here, 'data')
+        include_paths = [datafiles_abspath]
+        if os.path.exists(exe):
+            os.remove(exe)
+        model = compile_model(stan, include_paths=include_paths)
+        self.assertEqual(stan, model.stan_file)
+        self.assertTrue(model.exe_file.endswith(exe))
+
     def test_bad(self):
         stan = os.path.join(TMPDIR, 'bbad.stan')
         with self.assertRaises(Exception):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests 
- [x] Declare copyright holder and open-source license: see below

#### Summary
This change allows a user to specify one or more include paths using the method introduced [here](https://github.com/stan-dev/stan/pull/2635) when calling the `compile_model` function using the following syntax:

```
model = compile_model(stan_file, include_paths=['path/to/directory'])
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Technical University of Denmark



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

