### PR TITLE
fix windows behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,21 @@ CmdStan's source-code repository is hosted here on GitHub.
 ### Licensing
 
 The CmdStanPy, CmdStan, and the core Stan C++ code are licensed under new BSD.
+
+### Example
+
+::
+
+    import os
+    from cmdstanpy import cmdstan_path, compile_model, RunSet, sample, summary
+
+    # create model
+    bernoulli_stan = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
+    bernoulli_model = compile_model(bernoulli_stan)
+
+    # setup data and fit the model
+    bernoulli_data = { "N" : 10, "y" : [0,1,0,0,0,0,0,0,0,1] }
+    bernoulli_fit = sample(bernoulli_model, data=bernoulli_data)
+
+    # print summary
+    print(summary(bern_fit))

--- a/bin/install_cmdstan
+++ b/bin/install_cmdstan
@@ -19,6 +19,7 @@ from pathlib import Path
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
+
 @contextlib.contextmanager
 def pushd(new_dir):
     previous_dir = os.getcwd()
@@ -33,7 +34,8 @@ def usage():
         -v (--version) :CmdStan version
         -d (--dir) : install directory
         -h (--help) : this message
-        """)
+        """
+    )
 
 
 def install_version(cmdstan_version):
@@ -41,8 +43,6 @@ def install_version(cmdstan_version):
         print('Building {} binaries'.format(cmdstan_version))
         make = os.getenv('MAKE', 'make')
         cmd = [make, 'build']
-        #if platform.system() == "Windows":
-        #    cmd = ["sh"] + cmd #["cmd.exe", "/c"] + cmd
         proc = subprocess.Popen(
             cmd, cwd=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
@@ -54,11 +54,14 @@ def install_version(cmdstan_version):
                 print(stderr.decode('utf-8').strip())
             sys.exit(3)
         print('Test model compilation')
-        cmd = [make, Path(os.path.join('examples', 'bernoulli', 'bernoulli' + EXTENSION)).as_posix()]
-        #if platform.system() == "Windows":
-        #    cmd = ["sh"] + cmd #["cmd.exe", "/c"] + cmd
+        cmd = [
+            make,
+            Path(
+                os.path.join('examples', 'bernoulli', 'bernoulli' + EXTENSION)
+            ).as_posix(),
+        ]
         proc = subprocess.Popen(
-            cmd, cwd=None, #stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd, cwd=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         proc.wait()
         stdout, stderr = proc.communicate()
@@ -73,14 +76,18 @@ def install_version(cmdstan_version):
 def is_installed(cmdstan_version):
     if not os.path.exists(os.path.join(cmdstan_version, 'bin')):
         return False
-    return os.path.exists(os.path.join(
-            cmdstan_version, 'examples', 'bernoulli', 'bernoulli' + EXTENSION))
+    return os.path.exists(
+        os.path.join(
+            cmdstan_version, 'examples', 'bernoulli', 'bernoulli' + EXTENSION
+        )
+    )
 
 
 def latest_version():
     try:
         file_tmp, _ = urllib.request.urlretrieve(
-            'https://api.github.com/repos/stan-dev/cmdstan/releases/latest')
+            'https://api.github.com/repos/stan-dev/cmdstan/releases/latest'
+        )
     except urllib.error.URLError as err:
         print('Cannot connect to github.')
         print(err)
@@ -94,22 +101,27 @@ def latest_version():
 
 def retrieve_latest_version(version):
     print('Downloading CmdStan version {}'.format(version))
-    url = 'https://github.com/stan-dev/cmdstan/releases/download/'\
-      'v{0}/cmdstan-{0}.tar.gz'.format(version)
+    url = (
+        'https://github.com/stan-dev/cmdstan/releases/download/'
+        'v{0}/cmdstan-{0}.tar.gz'.format(version)
+    )
     try:
         file_tmp, _ = urllib.request.urlretrieve(url, filename=None)
     except urllib.error.URLError as err:
-        print('Failed to download CmdStan version {} from github.com'.format(
-            version))
+        print(
+            'Failed to download CmdStan version {} from github.com'.format(
+                version
+            )
+        )
         print(err)
         sys.exit(3)
     print('Download successful, file: {}'.format(file_tmp))
     try:
         tar = tarfile.open(file_tmp)
         target = os.getcwd()
-        if platform.system() == "Windows":
+        if platform.system() == 'Windows':
             # fixes long-path limitation on Windows
-            target = r"\\?\{}".format(target)
+            target = r'\\?\{}'.format(target)
         tar.extractall(target)
     except Exception as err:
         print('Failed to unpack download')
@@ -127,18 +139,20 @@ def validate_dir(install_dir):
         except OSError as e:
             raise ValueError(
                 'Cannot create directory: {}'.format(install_dir)
-                ) from e
+            ) from e
     else:
         if not os.path.isdir(install_dir):
             raise ValueError(
-                'File {} is not a directory: {}'.format(install_dir))
+                'File {} is not a directory: {}'.format(install_dir)
+            )
         try:
             with open('tmp_test_w', 'w') as fd:
                 pass
             os.remove('tmp_test_w')  # cleanup
         except OSError as e:
-            raise ValueError('Cannot write files to directory {}'.format(
-                install_dir)) from e
+            raise ValueError(
+                'Cannot write files to directory {}'.format(install_dir)
+            ) from e
 
 
 def main():

--- a/bin/install_cmdstan
+++ b/bin/install_cmdstan
@@ -8,14 +8,16 @@ Optional command line arguments:
 import argparse
 import contextlib
 import os
-import os.path
+import platform
 import re
 import shutil
 import subprocess
 import sys
 import tarfile
 import urllib.request
+from pathlib import Path
 
+EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
 @contextlib.contextmanager
 def pushd(new_dir):
@@ -37,7 +39,10 @@ def usage():
 def install_version(cmdstan_version):
     with pushd(cmdstan_version):
         print('Building {} binaries'.format(cmdstan_version))
-        cmd = ['make', 'build']
+        make = os.getenv('MAKE', 'make')
+        cmd = [make, 'build']
+        #if platform.system() == "Windows":
+        #    cmd = ["sh"] + cmd #["cmd.exe", "/c"] + cmd
         proc = subprocess.Popen(
             cmd, cwd=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
@@ -49,9 +54,11 @@ def install_version(cmdstan_version):
                 print(stderr.decode('utf-8').strip())
             sys.exit(3)
         print('Test model compilation')
-        cmd = ['make', os.path.join('examples', 'bernoulli', 'bernoulli')]
+        cmd = [make, Path(os.path.join('examples', 'bernoulli', 'bernoulli' + EXTENSION)).as_posix()]
+        #if platform.system() == "Windows":
+        #    cmd = ["sh"] + cmd #["cmd.exe", "/c"] + cmd
         proc = subprocess.Popen(
-            cmd, cwd=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd, cwd=None, #stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         proc.wait()
         stdout, stderr = proc.communicate()
@@ -66,13 +73,8 @@ def install_version(cmdstan_version):
 def is_installed(cmdstan_version):
     if not os.path.exists(os.path.join(cmdstan_version, 'bin')):
         return False
-    if os.path.exists(os.path.join(
-            cmdstan_version, 'examples', 'bernoulli', 'bernoulli')):
-        return True
-    if os.path.exists(os.path.join(
-            cmdstan_version, 'examples', 'bernoulli', 'bernoulli.exe')):
-        return True
-    return False
+    return os.path.exists(os.path.join(
+            cmdstan_version, 'examples', 'bernoulli', 'bernoulli' + EXTENSION))
 
 
 def latest_version():
@@ -104,7 +106,11 @@ def retrieve_latest_version(version):
     print('Download successful, file: {}'.format(file_tmp))
     try:
         tar = tarfile.open(file_tmp)
-        tar.extractall(os.getcwd())
+        target = os.getcwd()
+        if platform.system() == "Windows":
+            # fixes long-path limitation on Windows
+            target = r"\\?\{}".format(target)
+        tar.extractall(target)
     except Exception as err:
         print('Failed to unpack download')
         print(err)

--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -27,6 +27,6 @@ atexit.register(cleanup_tmpdir)
 
 from .cmds import compile_model, sample, summary, diagnose, get_drawset
 from .cmds import save_csvfiles
-from .utils import set_cmdstan_path, cmdstan_path, jsondump, rdump
+from .utils import set_cmdstan_path, cmdstan_path, set_make_env, jsondump, rdump
 from .lib import Model, RunSet
 from ._version import __version__

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -47,6 +47,7 @@ def compile_model(
         raise Exception('no such stan_file {}'.format(stan_file))
     program_name = os.path.basename(stan_file)
     exe_file, _ = os.path.splitext(os.path.abspath(stan_file))
+    exe_file = Path(exe_file).as_posix()
     hpp_file = '.'.join([exe_file, 'hpp'])
     hpp_file = Path(hpp_file).as_posix()
     if overwrite or not os.path.exists(hpp_file):
@@ -77,13 +78,13 @@ def compile_model(
     if not overwrite and os.path.exists(exe_file):
         # print('model is up to date') # notify user or not?
         return Model(stan_file, exe_file)
-    exe_file_path = Path(exe_file).as_posix()
-    cmd = ['make', 'O={}'.format(opt_lvl), exe_file_path]
+    make = os.getenv("MAKE", "make")
+    cmd = [make, 'O={}'.format(opt_lvl), exe_file]
     print('compiling c++: make args {}'.format(cmd))
     try:
         do_command(cmd, cmdstan_path())
     except Exception as e:
-        print("make failed", e)
+        print("make failed\n", e)
         return Model(stan_file)
     return Model(stan_file, exe_file)
 

--- a/cmdstanpy/cmds.py
+++ b/cmdstanpy/cmds.py
@@ -78,13 +78,13 @@ def compile_model(
     if not overwrite and os.path.exists(exe_file):
         # print('model is up to date') # notify user or not?
         return Model(stan_file, exe_file)
-    make = os.getenv("MAKE", "make")
+    make = os.getenv('MAKE', 'make')
     cmd = [make, 'O={}'.format(opt_lvl), exe_file]
     print('compiling c++: make args {}'.format(cmd))
     try:
         do_command(cmd, cmdstan_path())
     except Exception as e:
-        print("make failed\n", e)
+        print('make cmd failed\n', e)
         return Model(stan_file)
     return Model(stan_file, exe_file)
 

--- a/cmdstanpy/lib.py
+++ b/cmdstanpy/lib.py
@@ -157,7 +157,7 @@ class SamplerArgs(object):
                 if self.chain_ids[i] < 1:
                     raise ValueError(
                         'invalid chain_id {}'.format(self.chain_ids[i])
-                        )
+                    )
 
         if self.output_file is not None:
             if not os.path.exists(os.path.dirname(self.output_file)):
@@ -183,13 +183,13 @@ class SamplerArgs(object):
                 raise ValueError(
                     'seed must be an integer between 0 and 2**32-1,'
                     ' found {}'.format(self.seed)
-                    )
+                )
             elif isinstance(self.seed, int):
                 if self.seed < 0 or self.seed > 2 ** 32 - 1:
                     raise ValueError(
                         'seed must be an integer between 0 and 2**32-1,'
                         ' found {}'.format(self.seed)
-                        )
+                    )
             else:
                 if len(self.seed) != len(self.chain_ids):
                     raise ValueError(
@@ -215,7 +215,7 @@ class SamplerArgs(object):
                 if self.inits < 0:
                     raise ValueError(
                         'inits must be > 0, found {}'.format(self.inits)
-                        )
+                    )
             elif isinstance(self.inits, str):
                 if not os.path.exists(self.inits):
                     raise ValueError('no such file {}'.format(self.inits))
@@ -232,7 +232,7 @@ class SamplerArgs(object):
                     raise ValueError(
                         'each chain must have its own init file,'
                         ' found duplicates in inits files list.'
-                        )
+                    )
                 for i in range(len(self.inits)):
                     if not os.path.exists(self.inits[i]):
                         raise ValueError(
@@ -307,7 +307,7 @@ class SamplerArgs(object):
                 if self.step_size < 0:
                     raise ValueError(
                         'step_size must be > 0, found {}'.format(self.step_size)
-                        )
+                    )
             else:
                 if len(self.step_size) != len(self.chain_ids):
                     raise ValueError(
@@ -348,7 +348,7 @@ class SamplerArgs(object):
                     raise ValueError(
                         'each chain must have its own metric file,'
                         ' found duplicates in metric files list.'
-                        )
+                    )
                 for i in range(len(self.metric)):
                     if not os.path.exists(self.metric[i]):
                         raise ValueError(
@@ -497,7 +497,7 @@ class RunSet(object):
         self._sample = None
 
     def __repr__(self) -> str:
-        repr = 'RunSet(args={}, chains={}'.format(self.args, self._chains)
+        repr = 'RunSet(args={}, chains={}'.format(self._args, self._chains)
         repr = '{}\n csv_files={}\nconsole_files={})'.format(
             repr, '\n\t'.join(self.csv_files), '\n\t'.join(self.console_files)
         )

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -8,7 +8,7 @@ import platform
 import re
 from typing import Dict, TextIO, List
 
-EXTENSION = ".exe" if platform.system() == "Windows" else ""
+EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
 
 def get_latest_cmdstan(dot_dir: str) -> str:
@@ -50,6 +50,13 @@ def set_cmdstan_path(path: str) -> None:
     """
     validate_cmdstan_path(path)
     os.environ['CMDSTAN'] = path
+
+
+def set_make_env(make: str) -> None:
+    """
+    set MAKE environmental variable.
+    """
+    os.environ['MAKE'] = make
 
 
 def cmdstan_path() -> str:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -206,7 +206,7 @@ def scan_metric(fp: TextIO, config_dict: Dict, lineno: int) -> int:
     lineno += 1
     if not line == '# Adaptation terminated':
         raise ValueError(
-            'line {}: expecting metric, ' 'found:\n\t "{}"'.format(lineno, line)
+            'line {}: expecting metric, found:\n\t "{}"'.format(lineno, line)
         )
     line = fp.readline().strip()
     lineno += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 80
+skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import setuptools
 from cmdstanpy import __version__
 
+
 def readme_contents() -> str:
     with open('README.md', 'r') as fd:
         src = fd.read()
@@ -23,16 +24,14 @@ Topic :: Scientific/Engineering :: Information Analysis
 INSTALL_REQUIRES = ['numpy', 'pandas']
 
 EXTRAS_REQUIRE = {
-    'tests': [
-        'pytest',
-        'pytest-cov'],
+    'tests': ['pytest', 'pytest-cov'],
     'docs': [
         'sphinx',
         'sphinx-gallery',
         'sphinx_rtd_theme',
         'numpydoc',
-        'matplotlib'
-    ]
+        'matplotlib',
+    ],
 }
 
 setuptools.setup(

--- a/test/test_cmds.py
+++ b/test/test_cmds.py
@@ -52,32 +52,42 @@ class SampleTest(unittest.TestCase):
         model = Model(stan, exe_file=exe)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(datafiles_path, 'test1-bernoulli-output')
-        post_sample = sample(model,
-                                 chains=4,
-                                 cores=2,
-                                 seed=12345,
-                                 sampling_iters=100,
-                                 data=jdata,
-                                 csv_output_file=output,
-                                 max_treedepth=11,
-                                 adapt_delta=0.95)
+        post_sample = sample(
+            model,
+            chains=4,
+            cores=2,
+            seed=12345,
+            sampling_iters=100,
+            data=jdata,
+            csv_output_file=output,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         for i in range(post_sample.chains):
             csv_file = post_sample.csv_files[i]
             txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
             self.assertTrue(os.path.exists(csv_file))
             self.assertTrue(os.path.exists(txt_file))
 
-        self.assertEqual(post_sample.chains,4)
-        self.assertEqual(post_sample.draws,100)
-        column_names = ['lp__','accept_stat__','stepsize__','treedepth__',
-                            'n_leapfrog__','divergent__','energy__', 'theta']
+        self.assertEqual(post_sample.chains, 4)
+        self.assertEqual(post_sample.draws, 100)
+        column_names = [
+            'lp__',
+            'accept_stat__',
+            'stepsize__',
+            'treedepth__',
+            'n_leapfrog__',
+            'divergent__',
+            'energy__',
+            'theta',
+        ]
         self.assertEqual(post_sample.column_names, tuple(column_names))
 
         post_sample.assemble_sample()
         self.assertEqual(post_sample.sample.shape, (100, 4, len(column_names)))
         self.assertEqual(post_sample.metric_type, 'diag_e')
-        self.assertEqual(post_sample.stepsize.shape,(4,))
-        self.assertEqual(post_sample.metric.shape,(4, 1))
+        self.assertEqual(post_sample.stepsize.shape, (4,))
+        self.assertEqual(post_sample.metric.shape, (4, 1))
 
     def test_bernoulli_2(self):
         # tempfile for outputs
@@ -87,14 +97,16 @@ class SampleTest(unittest.TestCase):
             compile_model(stan)
         model = Model(stan, exe_file=exe)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        post_sample = sample(model,
-                                 chains=4,
-                                 cores=2,
-                                 seed=12345,
-                                 sampling_iters=100,
-                                 data=jdata,
-                                 max_treedepth=11,
-                                 adapt_delta=0.95)
+        post_sample = sample(
+            model,
+            chains=4,
+            cores=2,
+            seed=12345,
+            sampling_iters=100,
+            data=jdata,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         for i in range(post_sample.chains):
             csv_file = post_sample.csv_files[i]
             txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
@@ -114,7 +126,7 @@ class SampleTest(unittest.TestCase):
             self.assertTrue(os.path.exists(txt_file))
 
     def test_bernoulli_data(self):
-        data_dict = { 'N' : 10, 'y' : [0,1,0,0,0,0,0,0,0,1] }
+        data_dict = {'N': 10, 'y': [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         output = os.path.join(TMPDIR, 'test3-bernoulli-output')
         model = compile_model(stan)
@@ -141,17 +153,18 @@ class DrawsetTest(unittest.TestCase):
             compile_model(stan)
         model = Model(stan, exe_file=exe)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        post_sample = sample(model,
-                                 chains=4,
-                                 cores=2,
-                                 seed=12345,
-                                 sampling_iters=200,
-                                 data=jdata)
+        post_sample = sample(
+            model, chains=4, cores=2, seed=12345, sampling_iters=200, data=jdata
+        )
         post_sample.assemble_sample()
         df = get_drawset(post_sample)
-        self.assertEqual(df.shape,
-                             (post_sample.chains * post_sample.draws,
-                                        len(post_sample.column_names)))
+        self.assertEqual(
+            df.shape,
+            (
+                post_sample.chains * post_sample.draws,
+                len(post_sample.column_names),
+            ),
+        )
 
     def test_sample_big(self):
         # construct runset using existing sampler output
@@ -159,30 +172,35 @@ class DrawsetTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(datafiles_path, 'runset-big', 'output_icar_nyc')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               output_file=output)
+        args = SamplerArgs(model, chain_ids=[1, 2], output_file=output)
         runset = RunSet(chains=2, args=args)
         runset.validate_csv_files()
         runset.assemble_sample()
-        sampler_state = ['lp__','accept_stat__','stepsize__','treedepth__',
-                             'n_leapfrog__','divergent__','energy__']
-        phis = ['phi.{}'.format(str(x+1)) for x in range(2095)]
+        sampler_state = [
+            'lp__',
+            'accept_stat__',
+            'stepsize__',
+            'treedepth__',
+            'n_leapfrog__',
+            'divergent__',
+            'energy__',
+        ]
+        phis = ['phi.{}'.format(str(x + 1)) for x in range(2095)]
         column_names = sampler_state + phis
         self.assertEqual(runset.columns, len(column_names))
         self.assertEqual(runset.column_names, tuple(column_names))
         self.assertEqual(runset.metric_type, 'diag_e')
-        self.assertEqual(runset.stepsize.shape,(2,))
-        self.assertEqual(runset.metric.shape,(2, 2095))
-        self.assertEqual((1000,2,2102), runset.sample.shape)
+        self.assertEqual(runset.stepsize.shape, (2,))
+        self.assertEqual(runset.metric.shape, (2, 2095))
+        self.assertEqual((1000, 2, 2102), runset.sample.shape)
         phis = get_drawset(runset, params=['phi'])
-        self.assertEqual((2000,2095), phis.shape)
+        self.assertEqual((2000, 2095), phis.shape)
         phi1 = get_drawset(runset, params=['phi.1'])
-        self.assertEqual((2000,1), phi1.shape)
+        self.assertEqual((2000, 1), phi1.shape)
         mo_phis = get_drawset(runset, params=['phi.1', 'phi.10', 'phi.100'])
-        self.assertEqual((2000,3), mo_phis.shape)
+        self.assertEqual((2000, 3), mo_phis.shape)
         phi2095 = get_drawset(runset, params=['phi.2095'])
-        self.assertEqual((2000,1), phi2095.shape)
+        self.assertEqual((2000, 1), phi2095.shape)
         with self.assertRaises(Exception):
             get_drawset(runset, params=['phi.2096'])
         with self.assertRaises(Exception):
@@ -197,12 +215,9 @@ class SummaryTest(unittest.TestCase):
             compile_model(stan)
         model = Model(stan, exe_file=exe)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        post_sample = sample(model,
-                                 chains=4,
-                                 cores=2,
-                                 seed=12345,
-                                 sampling_iters=200,
-                                 data=jdata)
+        post_sample = sample(
+            model, chains=4, cores=2, seed=12345, sampling_iters=200, data=jdata
+        )
         df = summary(post_sample)
         self.assertTrue(df.shape == (2, 9))
 
@@ -215,12 +230,9 @@ class DiagnoseTest(unittest.TestCase):
             compile_model(stan)
         model = Model(stan, exe_file=exe)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        post_sample = sample(model,
-                                 chains=4,
-                                 cores=2,
-                                 seed=12345,
-                                 sampling_iters=200,
-                                 data=jdata)
+        post_sample = sample(
+            model, chains=4, cores=2, seed=12345, sampling_iters=200, data=jdata
+        )
         capturedOutput = io.StringIO()
         sys.stdout = capturedOutput
         diagnose(post_sample)
@@ -231,27 +243,30 @@ class DiagnoseTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        output = os.path.join(datafiles_path, 'diagnose-good',
-                                  'corr_gauss_depth8')
-        args = SamplerArgs(model,
-                               chain_ids=[1],
-                               output_file=output)
+        output = os.path.join(
+            datafiles_path, 'diagnose-good', 'corr_gauss_depth8'
+        )
+        args = SamplerArgs(model, chain_ids=[1], output_file=output)
         runset = RunSet(args=args, chains=1)
 
         # TODO - use cmdstan test files instead
-        expected = ''.join([
-            '424 of 1000 (42%) transitions hit the maximum ',
-            'treedepth limit of 8, or 2^8 leapfrog steps. ',
-            'Trajectories that are prematurely terminated ',
-            'due to this limit will result in slow ',
-            'exploration and you should increase the ',
-            'limit to ensure optimal performance.\n'])
+        expected = ''.join(
+            [
+                '424 of 1000 (42%) transitions hit the maximum ',
+                'treedepth limit of 8, or 2^8 leapfrog steps. ',
+                'Trajectories that are prematurely terminated ',
+                'due to this limit will result in slow ',
+                'exploration and you should increase the ',
+                'limit to ensure optimal performance.\n',
+            ]
+        )
 
         capturedOutput = io.StringIO()
         sys.stdout = capturedOutput
         diagnose(runset)
         sys.stdout = sys.__stdout__
         self.assertEqual(capturedOutput.getvalue(), expected)
+
 
 class SaveCsvfilesTest(unittest.TestCase):
     def test_bernoulli(self):
@@ -261,12 +276,9 @@ class SaveCsvfilesTest(unittest.TestCase):
             compile_model(stan)
         model = Model(stan, exe_file=exe)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        post_sample = sample(model,
-                                 chains=4,
-                                 cores=2,
-                                 seed=12345,
-                                 sampling_iters=200,
-                                 data=jdata)
+        post_sample = sample(
+            model, chains=4, cores=2, seed=12345, sampling_iters=200, data=jdata
+        )
         for i in range(post_sample.chains):
             csv_file = post_sample.csv_files[i]
             txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
@@ -274,24 +286,25 @@ class SaveCsvfilesTest(unittest.TestCase):
             self.assertTrue(os.path.exists(txt_file))
 
         basename = 'bern_save_csvfiles_test'
-        save_csvfiles(post_sample, datafiles_path, basename) # good
+        save_csvfiles(post_sample, datafiles_path, basename)  # good
         for i in range(post_sample.chains):
             csv_file = post_sample.csv_files[i]
             self.assertTrue(os.path.exists(csv_file))
 
         with self.assertRaisesRegex(Exception, 'cannot save'):
-            save_csvfiles(post_sample,
-                              os.path.join('no', 'such', 'dir'), basename)
+            save_csvfiles(
+                post_sample, os.path.join('no', 'such', 'dir'), basename
+            )
 
         with self.assertRaisesRegex(Exception, 'file exists'):
             save_csvfiles(post_sample, datafiles_path, basename)
 
-        save_csvfiles(post_sample, basename=basename) # default dir
+        save_csvfiles(post_sample, basename=basename)  # default dir
         for i in range(post_sample.chains):
             csv_file = post_sample.csv_files[i]
             self.assertTrue(os.path.exists(csv_file))
 
-        for i in range(post_sample.chains):    # cleanup
+        for i in range(post_sample.chains):  # cleanup
             os.remove(post_sample.csv_files[i])
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,7 +6,7 @@ from cmdstanpy.cmds import compile_model
 
 datafiles_path = os.path.join('test', 'data')
 
-code = ('''data {
+code = '''data {
   int<lower=0> N;
   int<lower=0,upper=1> y[N];
 }
@@ -18,7 +18,7 @@ model {
   for (n in 1:N)
     y[n] ~ bernoulli(theta);
 }
-''')
+'''
 
 
 class ModelTest(unittest.TestCase):

--- a/test/test_runset.py
+++ b/test/test_runset.py
@@ -16,13 +16,16 @@ class RunSetTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(goodfiles_path, 'bern')
-        args = SamplerArgs(model, chain_ids=[1,2,3,4],
-                           seed=12345,
-                           data=jdata,
-                           output_file=output,
-                           sampling_iters=100,
-                           max_treedepth=11,
-                           adapt_delta=0.95)
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2, 3, 4],
+            seed=12345,
+            data=jdata,
+            output_file=output,
+            sampling_iters=100,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         runset = RunSet(chains=4, args=args)
         retcodes = runset.retcodes
         self.assertEqual(4, len(retcodes))
@@ -44,13 +47,16 @@ class RunSetTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(goodfiles_path, 'bern')
-        args = SamplerArgs(model, chain_ids=[1,2,3,4],
-                           seed=12345,
-                           data=jdata,
-                           output_file=output,
-                           sampling_iters=100,
-                           max_treedepth=11,
-                           adapt_delta=0.95)
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2, 3, 4],
+            seed=12345,
+            data=jdata,
+            output_file=output,
+            sampling_iters=100,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         runset = RunSet(chains=4, args=args)
         retcodes = runset.retcodes
         for i in range(len(retcodes)):
@@ -69,13 +75,16 @@ class RunSetTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(badfiles_path, 'bad-transcript-bern')
-        args = SamplerArgs(model, chain_ids=[1,2,3,4],
-                           seed=12345,
-                           data=jdata,
-                           output_file=output,
-                           sampling_iters=100,
-                           max_treedepth=11,
-                           adapt_delta=0.95)
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2, 3, 4],
+            seed=12345,
+            data=jdata,
+            output_file=output,
+            sampling_iters=100,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         runset = RunSet(chains=4, args=args)
         with self.assertRaisesRegex(Exception, 'Exception'):
             runset.check_console_msgs()
@@ -86,13 +95,16 @@ class RunSetTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(badfiles_path, 'bad-hdr-bern')
-        args = SamplerArgs(model, chain_ids=[1,2,3,4],
-                           seed=12345,
-                           data=jdata,
-                           output_file=output,
-                           sampling_iters=100,
-                           max_treedepth=11,
-                           adapt_delta=0.95)
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2, 3, 4],
+            seed=12345,
+            data=jdata,
+            output_file=output,
+            sampling_iters=100,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         runset = RunSet(chains=4, args=args)
         retcodes = runset.retcodes
         for i in range(len(retcodes)):
@@ -108,13 +120,16 @@ class RunSetTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(badfiles_path, 'bad-draws-bern')
-        args = SamplerArgs(model, chain_ids=[1,2,3,4],
-                           seed=12345,
-                           data=jdata,
-                           output_file=output,
-                           sampling_iters=100,
-                           max_treedepth=11,
-                           adapt_delta=0.95)
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2, 3, 4],
+            seed=12345,
+            data=jdata,
+            output_file=output,
+            sampling_iters=100,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         runset = RunSet(chains=4, args=args)
         retcodes = runset.retcodes
         for i in range(len(retcodes)):
@@ -130,13 +145,16 @@ class RunSetTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(badfiles_path, 'bad-cols-bern')
-        args = SamplerArgs(model, chain_ids=[1,2,3,4],
-                           seed=12345,
-                           data=jdata,
-                           output_file=output,
-                           sampling_iters=100,
-                           max_treedepth=11,
-                           adapt_delta=0.95)
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2, 3, 4],
+            seed=12345,
+            data=jdata,
+            output_file=output,
+            sampling_iters=100,
+            max_treedepth=11,
+            adapt_delta=0.95,
+        )
         runset = RunSet(chains=4, args=args)
         retcodes = runset.retcodes
         for i in range(len(retcodes)):

--- a/test/test_sampler_args.py
+++ b/test/test_sampler_args.py
@@ -14,11 +14,9 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(TMPDIR, 'bernoulli.output')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               output_file=output)
+        args = SamplerArgs(model, chain_ids=[1, 2], output_file=output)
         args.validate()
-        cmd = args.compose_command(0, ''.join([output,'-1.csv']))
+        cmd = args.compose_command(0, ''.join([output, '-1.csv']))
         self.assertIn('id=1', cmd)
 
     def test_args_good(self):
@@ -27,18 +25,21 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         rdata = os.path.join(datafiles_path, 'bernoulli.data.R')
         output = os.path.join(TMPDIR, 'bernoulli.output')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               seed=12345,
-                               data=rdata,
-                               output_file=output,
-                               max_treedepth=15,
-                               adapt_delta=0.99)
-        cmd = args.compose_command(0, ''.join([output,'-1.csv']))
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2],
+            seed=12345,
+            data=rdata,
+            output_file=output,
+            max_treedepth=15,
+            adapt_delta=0.99,
+        )
+        cmd = args.compose_command(0, ''.join([output, '-1.csv']))
         self.assertIn('random seed=12345', cmd)
         self.assertIn('data file=', cmd)
         self.assertIn(
-            'algorithm=hmc engine=nuts max_depth=15 adapt delta=0.99', cmd)
+            'algorithm=hmc engine=nuts max_depth=15 adapt delta=0.99', cmd
+        )
 
     def test_args_typical(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -46,21 +47,24 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(TMPDIR, 'bernoulli.output')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               seed=12345,
-                               sampling_iters=100,
-                               data=jdata,
-                               output_file=output,
-                               max_treedepth=11,
-                               adapt_delta=0.9)
-        cmd = args.compose_command(0, ''.join([output,'-1.csv']))
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2],
+            seed=12345,
+            sampling_iters=100,
+            data=jdata,
+            output_file=output,
+            max_treedepth=11,
+            adapt_delta=0.9,
+        )
+        cmd = args.compose_command(0, ''.join([output, '-1.csv']))
         self.assertIn('bernoulli', cmd)
         self.assertIn('seed=12345', cmd)
         self.assertIn('num_samples=100', cmd)
         self.assertIn('bernoulli.data.json', cmd)
-        self.assertIn('algorithm=hmc engine=nuts max_depth=11 adapt delta=0.9',
-                      cmd)
+        self.assertIn(
+            'algorithm=hmc engine=nuts max_depth=11 adapt delta=0.9', cmd
+        )
 
     def test_args_many_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -69,20 +73,22 @@ class SamplerArgsTest(unittest.TestCase):
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
         output = os.path.join(TMPDIR, 'bernoulli.output')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               seed=12345,
-                               warmup_iters=100,
-                               sampling_iters=100,
-                               save_warmup=True,
-                               thin=2,
-                               metric=jmetric,
-                               step_size=1.5,
-                               data=jdata,
-                               output_file=output,
-                               max_treedepth=11,
-                               adapt_delta=0.9)
-        cmd = args.compose_command(0, ''.join([output,'-1.csv']))
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2],
+            seed=12345,
+            warmup_iters=100,
+            sampling_iters=100,
+            save_warmup=True,
+            thin=2,
+            metric=jmetric,
+            step_size=1.5,
+            data=jdata,
+            output_file=output,
+            max_treedepth=11,
+            adapt_delta=0.9,
+        )
+        cmd = args.compose_command(0, ''.join([output, '-1.csv']))
         s1 = 'test/data/bernoulli id=1 random seed=12345 data file=test/data/bernoulli.data.json'
         s2 = 'method=sample num_samples=100 num_warmup=100 save_warmup=1 thin=2'
         s3 = 'algorithm=hmc engine=nuts max_depth=11 stepsize=1.5 metric=diag_e metric_file="test/data/bernoulli.metric.json" adapt delta=0.9'
@@ -95,9 +101,7 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        args = SamplerArgs(model,
-                               chain_ids=[7,9],
-                               data=jdata)
+        args = SamplerArgs(model, chain_ids=[7, 9], data=jdata)
         cmd = args.compose_command(0, 'output')
         self.assertIn('bernoulli', cmd)
         self.assertIn('bernoulli.data.json', cmd)
@@ -110,8 +114,7 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaisesRegex(ValueError, 'invalid chain_id -99'):
-            args = SamplerArgs(model,
-                                   chain_ids=[7,-99])
+            args = SamplerArgs(model, chain_ids=[7, -99])
 
     def test_args_missing_args_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -130,10 +133,9 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(TMPDIR, 'bernoulli.output')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   output_file=output,
-                                   seed='badseed')
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], output_file=output, seed='badseed'
+            )
 
     def test_args_bad_seed_2(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -141,10 +143,9 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(TMPDIR, 'bernoulli.output')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   output_file=output,
-                                   seed=-10)
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], output_file=output, seed=-10
+            )
 
     def test_args_bad_seed_3(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -152,10 +153,9 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(TMPDIR, 'bernoulli.output')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   output_file=output,
-                                   seed=[1, 2, 3])
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], output_file=output, seed=[1, 2, 3]
+            )
 
     def test_args_bad_seed_4(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -163,10 +163,9 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(TMPDIR, 'bernoulli.output')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   output_file=output,
-                                   seed=4294967299)
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], output_file=output, seed=4294967299
+            )
 
     def test_args_bad_data(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -174,10 +173,12 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(TMPDIR, 'bernoulli.output')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   output_file=output,
-                                   data='/no/such/path/to.file')
+            args = SamplerArgs(
+                model,
+                chain_ids=[1, 2],
+                output_file=output,
+                data='/no/such/path/to.file',
+            )
 
     def test_args_inits_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -185,10 +186,7 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         jinits = os.path.join(datafiles_path, 'bernoulli.init.json')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               data=jdata,
-                               inits=jinits)
+        args = SamplerArgs(model, chain_ids=[1, 2], data=jdata, inits=jinits)
         cmd = args.compose_command(0, 'output')
         s1 = 'data file=test/data/bernoulli.data.json init=test/data/bernoulli.init.json'
         self.assertIn(s1, cmd)
@@ -198,10 +196,7 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               data=jdata,
-                               inits=0)
+        args = SamplerArgs(model, chain_ids=[1, 2], data=jdata, inits=0)
         cmd = args.compose_command(0, 'output')
         s1 = 'data file=test/data/bernoulli.data.json init=0'
         self.assertIn(s1, cmd)
@@ -211,10 +206,7 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               data=jdata,
-                               inits=3.33)
+        args = SamplerArgs(model, chain_ids=[1, 2], data=jdata, inits=3.33)
         cmd = args.compose_command(0, 'output')
         s1 = 'data file=test/data/bernoulli.data.json init=3.33'
         self.assertIn(s1, cmd)
@@ -226,10 +218,9 @@ class SamplerArgsTest(unittest.TestCase):
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         jinits1 = os.path.join(datafiles_path, 'bernoulli.init_1.json')
         jinits2 = os.path.join(datafiles_path, 'bernoulli.init_2.json')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               data=jdata,
-                               inits=[jinits1, jinits2])
+        args = SamplerArgs(
+            model, chain_ids=[1, 2], data=jdata, inits=[jinits1, jinits2]
+        )
         cmd = args.compose_command(0, 'output')
         s1 = 'data file=test/data/bernoulli.data.json init=test/data/bernoulli.init_1.json'
         self.assertIn(s1, cmd)
@@ -239,18 +230,16 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   inits=-5)
+            args = SamplerArgs(model, chain_ids=[1, 2], inits=-5)
 
     def test_args_bad_inits_file(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   inits='/no/such/path/to.file')
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], inits='/no/such/path/to.file'
+            )
 
     def test_args_bad_inits_files_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -260,9 +249,9 @@ class SamplerArgsTest(unittest.TestCase):
         jinits2 = os.path.join(datafiles_path, 'bernoulli.init_2.json')
         jinits3 = os.path.join(datafiles_path, 'bernoulli.init.json')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   inits=[jinits1, jinits2, jinits3])
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], inits=[jinits1, jinits2, jinits3]
+            )
 
     def test_args_bad_inits_files_2(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -270,9 +259,9 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jinits = os.path.join(datafiles_path, 'bernoulli.init.json')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   inits=[jinits, 'no/such/file.json'])
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], inits=[jinits, 'no/such/file.json']
+            )
 
     def test_args_bad_inits_files_3(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -280,17 +269,13 @@ class SamplerArgsTest(unittest.TestCase):
         model = Model(exe_file=exe, stan_file=stan)
         jinits = os.path.join(datafiles_path, 'bernoulli.init.json')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   inits=[jinits, jinits])
+            args = SamplerArgs(model, chain_ids=[1, 2], inits=[jinits, jinits])
 
     def test_args_iters_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               warmup_iters=123)
+        args = SamplerArgs(model, chain_ids=[1, 2], warmup_iters=123)
         cmd = args.compose_command(0, 'output')
         self.assertIn('num_warmup=123', cmd)
 
@@ -298,9 +283,7 @@ class SamplerArgsTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               sampling_iters=123)
+        args = SamplerArgs(model, chain_ids=[1, 2], sampling_iters=123)
         cmd = args.compose_command(0, 'output')
         self.assertIn('num_samples=123', cmd)
 
@@ -309,37 +292,34 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                warmup_iters=-123)
+            args = SamplerArgs(model, chain_ids=[1, 2], warmup_iters=-123)
 
     def test_args_iters_4(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                sampling_iters=-123)
+            args = SamplerArgs(model, chain_ids=[1, 2], sampling_iters=-123)
 
     def test_args_iters_5(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                warmup_iters=0,
-                                adapt_engaged=True)
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], warmup_iters=0, adapt_engaged=True
+            )
 
     def test_args_warmup_schedule_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               warmup_iters=200,
-                               warmup_schedule=(0.1, 0.8, 0.1))
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2],
+            warmup_iters=200,
+            warmup_schedule=(0.1, 0.8, 0.1),
+        )
         cmd = args.compose_command(0, 'output')
         s1 = 'algorithm=hmc adapt init_buffer=20 term_buffer=20'
 
@@ -348,46 +328,45 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                warmup_schedule=(-0.1, 0.8, 0.1))
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], warmup_schedule=(-0.1, 0.8, 0.1)
+            )
 
     def test_args_warmup_schedule_3(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                warmup_schedule=(8.1, 0.8, 0.1))
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], warmup_schedule=(8.1, 0.8, 0.1)
+            )
 
     def test_args_iters_schedule_mismatch(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                warmup_iters=0,
-                                warmup_schedule=(0.1, 0.8, 0.1))
+            args = SamplerArgs(
+                model,
+                chain_ids=[1, 2],
+                warmup_iters=0,
+                warmup_schedule=(0.1, 0.8, 0.1),
+            )
 
     def test_args_iters_adapt_mismatch(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                warmup_iters=0,
-                                adapt_engaged=True)
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], warmup_iters=0, adapt_engaged=True
+            )
 
     def test_args_save_warmup_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               save_warmup=True)
+        args = SamplerArgs(model, chain_ids=[1, 2], save_warmup=True)
         cmd = args.compose_command(0, 'output')
         self.assertIn('save_warmup=1', cmd)
 
@@ -395,9 +374,7 @@ class SamplerArgsTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               save_warmup=False)
+        args = SamplerArgs(model, chain_ids=[1, 2], save_warmup=False)
         cmd = args.compose_command(0, 'output')
         self.assertNotIn('save_warmup', cmd)
 
@@ -406,12 +383,14 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         output = os.path.join(TMPDIR, 'bernoulli.output')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               output_file=output,
-                               sampling_iters=3,
-                               warmup_iters=7)
-        cmd = args.compose_command(0, ''.join([output,'-1.csv']))
+        args = SamplerArgs(
+            model,
+            chain_ids=[1, 2],
+            output_file=output,
+            sampling_iters=3,
+            warmup_iters=7,
+        )
+        cmd = args.compose_command(0, ''.join([output, '-1.csv']))
         self.assertIn('num_samples=3', cmd)
         self.assertIn('num_warmup=7', cmd)
 
@@ -419,9 +398,7 @@ class SamplerArgsTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               thin=3)
+        args = SamplerArgs(model, chain_ids=[1, 2], thin=3)
         cmd = args.compose_command(0, 'output')
         self.assertIn('thin=3', cmd)
 
@@ -430,17 +407,13 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                thin=-3)
+            args = SamplerArgs(model, chain_ids=[1, 2], thin=-3)
 
     def test_args_max_treedepth_good(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               max_treedepth=15)
+        args = SamplerArgs(model, chain_ids=[1, 2], max_treedepth=15)
         cmd = args.compose_command(0, 'output')
         self.assertIn('max_depth=15', cmd)
 
@@ -449,17 +422,13 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                max_treedepth=-3)
+            args = SamplerArgs(model, chain_ids=[1, 2], max_treedepth=-3)
 
     def test_args_metric_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               metric='diag')
+        args = SamplerArgs(model, chain_ids=[1, 2], metric='diag')
         cmd = args.compose_command(0, 'output')
         s1 = 'metric=diag_e'
         self.assertIn(s1, cmd)
@@ -468,9 +437,7 @@ class SamplerArgsTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               metric='diag_e')
+        args = SamplerArgs(model, chain_ids=[1, 2], metric='diag_e')
         cmd = args.compose_command(0, 'output')
         s1 = 'metric=diag_e'
         self.assertIn(s1, cmd)
@@ -479,9 +446,7 @@ class SamplerArgsTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               metric='dense')
+        args = SamplerArgs(model, chain_ids=[1, 2], metric='dense')
         cmd = args.compose_command(0, 'output')
         s1 = 'metric=dense_e'
         self.assertIn(s1, cmd)
@@ -490,9 +455,7 @@ class SamplerArgsTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               metric='dense_e')
+        args = SamplerArgs(model, chain_ids=[1, 2], metric='dense_e')
         cmd = args.compose_command(0, 'output')
         s1 = 'metric=dense_e'
         self.assertIn(s1, cmd)
@@ -502,55 +465,52 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               metric=jmetric)
+        args = SamplerArgs(model, chain_ids=[1, 2], metric=jmetric)
         cmd = args.compose_command(0, 'output')
         s1 = 'metric=diag_e metric_file="test/data/bernoulli.metric.json'
         self.assertIn(s1, cmd)
-        
+
     def test_args_metric_file_2(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
         jmetric2 = os.path.join(datafiles_path, 'bernoulli.metric-2.json')
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               metric=[jmetric, jmetric2])
+        args = SamplerArgs(model, chain_ids=[1, 2], metric=[jmetric, jmetric2])
         cmd = args.compose_command(1, 'output')
         s1 = 'metric=diag_e metric_file="test/data/bernoulli.metric-2.json'
         self.assertIn(s1, cmd)
-                               
+
     def test_args_bad_metric_file(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   metric='/no/such/path/to.file')
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], metric='/no/such/path/to.file'
+            )
 
-                               
     def test_args_bad_metric_file_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   metric=[jmetric, '/no/such/path/to.file'])
-                               
+            args = SamplerArgs(
+                model,
+                chain_ids=[1, 2],
+                metric=[jmetric, '/no/such/path/to.file'],
+            )
+
     def test_args_bad_metric_file_2(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   metric=[jmetric, jmetric])
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], metric=[jmetric, jmetric]
+            )
 
     def test_args_bad_metric_file_3(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -559,17 +519,13 @@ class SamplerArgsTest(unittest.TestCase):
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
         jmetric2 = os.path.join(datafiles_path, 'bernoulli.metric-2.json')
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1],
-                                   metric=[jmetric, jmetric2])
+            args = SamplerArgs(model, chain_ids=[1], metric=[jmetric, jmetric2])
 
     def test_args_step_size_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               step_size=1.3)
+        args = SamplerArgs(model, chain_ids=[1, 2], step_size=1.3)
         cmd = args.compose_command(0, 'output')
         self.assertIn('stepsize=1.3', cmd)
 
@@ -577,9 +533,7 @@ class SamplerArgsTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               step_size=[1.31, 1.29])
+        args = SamplerArgs(model, chain_ids=[1, 2], step_size=[1.31, 1.29])
         cmd = args.compose_command(1, 'output')
         self.assertIn('stepsize=1.29', cmd)
 
@@ -588,35 +542,27 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                step_size=-0.99)
+            args = SamplerArgs(model, chain_ids=[1, 2], step_size=-0.99)
 
     def test_args_step_size_bad_2(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                step_size=[1.31, -0.99])
+            args = SamplerArgs(model, chain_ids=[1, 2], step_size=[1.31, -0.99])
 
     def test_args_step_size_bad_3(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                step_size=[2])
+            args = SamplerArgs(model, chain_ids=[1, 2], step_size=[2])
 
     def test_args_adapt_delta_1(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
-        args = SamplerArgs(model,
-                               chain_ids=[1,2],
-                               adapt_delta=.93)
+        args = SamplerArgs(model, chain_ids=[1, 2], adapt_delta=0.93)
         cmd = args.compose_command(0, 'output')
         self.assertIn('adapt delta=0.93', cmd)
 
@@ -625,27 +571,23 @@ class SamplerArgsTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                adapt_delta=-3)
+            args = SamplerArgs(model, chain_ids=[1, 2], adapt_delta=-3)
 
     def test_args_adapt_delta_3(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                chain_ids=[1,2],
-                                adapt_delta=1.3)
+            args = SamplerArgs(model, chain_ids=[1, 2], adapt_delta=1.3)
 
     def test_args_bad_output(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli')
         model = Model(exe_file=exe, stan_file=stan)
         with self.assertRaises(ValueError):
-            args = SamplerArgs(model,
-                                   chain_ids=[1,2],
-                                   output_file='/no/such/path/to.file')
+            args = SamplerArgs(
+                model, chain_ids=[1, 2], output_file='/no/such/path/to.file'
+            )
 
 
 if __name__ == '__main__':

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,32 +5,43 @@ import json
 
 from cmdstanpy import TMPDIR
 from cmdstanpy.lib import StanData
-from cmdstanpy.utils import cmdstan_path, set_cmdstan_path, validate_cmdstan_path, get_latest_cmdstan, check_csv, read_metric
+from cmdstanpy.utils import (
+    cmdstan_path,
+    set_cmdstan_path,
+    validate_cmdstan_path,
+    get_latest_cmdstan,
+    check_csv,
+    read_metric,
+)
 
 
 datafiles_path = os.path.join('test', 'data')
 
-rdump = ('''N <- 10
+rdump = '''N <- 10
 y <- c(0, 1, 0, 0, 0, 0, 0, 0, 0, 1)
-''')
+'''
 
 
 class CmdStanPathTest(unittest.TestCase):
     def test_default_path(self):
-        abs_rel_path = os.path.expanduser(os.path.join('~', '.cmdstanpy', 'cmdstan'))
+        abs_rel_path = os.path.expanduser(
+            os.path.join('~', '.cmdstanpy', 'cmdstan')
+        )
         self.assertTrue(cmdstan_path().startswith(abs_rel_path))
 
     def test_set_path(self):
         install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
         install_version = os.path.expanduser(
-            os.path.join(install_dir, get_latest_cmdstan(install_dir)))
+            os.path.join(install_dir, get_latest_cmdstan(install_dir))
+        )
         set_cmdstan_path(install_version)
         self.assertEqual(install_version, cmdstan_path())
 
     def test_validate_path(self):
         install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
         install_version = os.path.expanduser(
-            os.path.join(install_dir, get_latest_cmdstan(install_dir)))
+            os.path.join(install_dir, get_latest_cmdstan(install_dir))
+        )
         set_cmdstan_path(install_version)
         validate_cmdstan_path(install_version)
         path_foo = os.path.abspath(os.path.join('releases', 'foo'))
@@ -39,7 +50,6 @@ class CmdStanPathTest(unittest.TestCase):
         path_test = os.path.abspath('test')
         with self.assertRaisesRegex(ValueError, 'no CmdStan binaries'):
             validate_cmdstan_path(path_test)
-
 
 
 class StanDataTest(unittest.TestCase):
@@ -91,8 +101,7 @@ class ReadStanCsvTest(unittest.TestCase):
 
     def test_check_csv_metric_1(self):
         csv_bad = os.path.join(datafiles_path, 'output_bad_metric_1.csv')
-        with self.assertRaisesRegex(Exception,
-                                   'expecting metric'):
+        with self.assertRaisesRegex(Exception, 'expecting metric'):
             dict = check_csv(csv_bad)
 
     def test_check_csv_metric_2(self):
@@ -102,15 +111,18 @@ class ReadStanCsvTest(unittest.TestCase):
 
     def test_check_csv_metric_3(self):
         csv_bad = os.path.join(datafiles_path, 'output_bad_metric_3.csv')
-        with self.assertRaisesRegex(Exception,
-                                    'invalid or missing mass matrix specification'):
+        with self.assertRaisesRegex(
+            Exception, 'invalid or missing mass matrix specification'
+        ):
             dict = check_csv(csv_bad)
 
     def test_check_csv_metric_4(self):
         csv_bad = os.path.join(datafiles_path, 'output_bad_metric_4.csv')
-        with self.assertRaisesRegex(Exception,
-                                    'invalid or missing mass matrix specification'):
+        with self.assertRaisesRegex(
+            Exception, 'invalid or missing mass matrix specification'
+        ):
             dict = check_csv(csv_bad)
+
 
 class ReadMetricTest(unittest.TestCase):
     def test_metric_json_vec(self):
@@ -139,26 +151,28 @@ class ReadMetricTest(unittest.TestCase):
 
     def test_metric_json_bad(self):
         metric_file = os.path.join(datafiles_path, 'metric_bad.data.json')
-        with self.assertRaisesRegex(Exception,
-                                    'bad or missing entry "inv_metric"'):
+        with self.assertRaisesRegex(
+            Exception, 'bad or missing entry "inv_metric"'
+        ):
             dims = read_metric(metric_file)
 
     def test_metric_rdump_bad_1(self):
         metric_file = os.path.join(datafiles_path, 'metric_bad_1.data.R')
-        with self.assertRaisesRegex(Exception,
-                                    'bad or missing entry "inv_metric"'):
+        with self.assertRaisesRegex(
+            Exception, 'bad or missing entry "inv_metric"'
+        ):
             dims = read_metric(metric_file)
 
     def test_metric_rdump_bad_2(self):
         metric_file = os.path.join(datafiles_path, 'metric_bad_2.data.R')
-        with self.assertRaisesRegex(Exception,
-                                    'bad or missing entry "inv_metric"'):
+        with self.assertRaisesRegex(
+            Exception, 'bad or missing entry "inv_metric"'
+        ):
             dims = read_metric(metric_file)
 
     def test_metric_missing(self):
         metric_file = os.path.join(datafiles_path, 'no_such_file.json')
-        with self.assertRaisesRegex(Exception,
-                                    'No such file or directory'):
+        with self.assertRaisesRegex(Exception, 'No such file or directory'):
             dims = read_metric(metric_file)
 
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Created `EXTENSION` constant that is `".exe"` on Windows and otherwise `""`

Added `Path(path).as_posix()` in some places.

There was bug in repr (`self.args` --> `self._args`)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

