### PR TITLE
Allow to instantiate Model without Stan source

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -24,25 +24,35 @@ class Model(object):
     def __init__(self, stan_file: str = None, exe_file: str = None) -> None:
         """Initialize object."""
         self._stan_file = stan_file
+        self._name = None
         if stan_file is None:
-            raise ValueError('must specify Stan program file')
-        if not os.path.exists(stan_file):
-            raise ValueError('no such file {}'.format(self._stan_file))
-        _, filename = os.path.split(stan_file)
-        if len(filename) < 6 or not filename.endswith('.stan'):
-            raise ValueError('invalid stan filename {}'.format(self._stan_file))
-        self._name, _ = os.path.splitext(filename)
-        self._exe_file = None
+            if exe_file is None:
+                raise ValueError(
+                    'must specify Stan source or executable program file'
+                )
+        else:
+            if not os.path.exists(stan_file):
+                raise ValueError('no such file {}'.format(self._stan_file))
+            _, filename = os.path.split(stan_file)
+            if len(filename) < 6 or not filename.endswith('.stan'):
+                raise ValueError(
+                    'invalid stan filename {}'.format(self._stan_file)
+                )
+            self._name, _ = os.path.splitext(filename)
+            self._exe_file = None
         if exe_file is not None:
             if not os.path.exists(exe_file):
                 raise ValueError('no such file {}'.format(self._exe_file))
             _, exename = os.path.split(exe_file)
-            if self._name != ''.join([exename, EXTENSION]):
-                raise ValueError(
-                    'name mismatch between Stan file and compiled'
-                    ' executable, expecting basename: {}'
-                    ' found: {}'.format(self._name, exename)
-                )
+            if self._name is None:
+                self._name, _ = os.path.splitext(exename)
+            else:
+                if self._name != ''.join([exename, EXTENSION]):
+                    raise ValueError(
+                        'name mismatch between Stan file and compiled'
+                        ' executable, expecting basename: {}'
+                        ' found: {}'.format(self._name, exename)
+                    )
             self._exe_file = exe_file
 
     def __repr__(self) -> str:
@@ -52,6 +62,9 @@ class Model(object):
 
     def code(self) -> str:
         """Return Stan program as a string."""
+        if not self._stan_file:
+            raise RuntimeError("Please specify source file")
+
         code = None
         try:
             with open(self._stan_file, 'r') as fd:
@@ -94,6 +107,9 @@ class Model(object):
         :param include_paths: List of paths to directories where Stan should
             look for files to include in compilation of the C++ executable.
         """
+        if not self._stan_file:
+            raise RuntimeError("Please specify source file")
+
         if self._exe_file is not None and not overwrite:
             print('model is already compiled')
             return

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -37,6 +37,21 @@ class ModelTest(unittest.TestCase):
         model = Model(stan_file=stan, exe_file=exe)
         self.assertEqual(exe, model.exe_file)
 
+    def test_model_good_no_source(self):
+        exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
+        model = Model(exe_file=exe)
+        self.assertEqual(exe, model.exe_file)
+        self.assertEqual('bernoulli', model.name)
+
+        with self.assertRaises(RuntimeError):
+            model.code()
+        with self.assertRaises(RuntimeError):
+            model.compile()
+
+    def test_model_none(self):
+        with self.assertRaises(ValueError):
+            _ = Model(exe_file=None, stan_file=None)
+
     def test_model_bad(self):
         with self.assertRaises(Exception):
             model = Model(stan_file='xdlfkjx', exe_file='sdfndjsds')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
In some cases user might want to use `cmdstanpy` without the source and using only the compiled executable. 
A good example might be Prophet library where compilation should be done during the installation phrase.
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

- Salesforce

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

