### PR TITLE
Fix setup.py import bug, ensure pandas has to_numpy method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python
 
+import os
+import re
 import setuptools
-from cmdstanpy import __version__
 
 
 def readme_contents() -> str:
     with open('README.md', 'r') as fd:
         src = fd.read()
     return src
+
+
+def get_version() -> str:
+    version_file = open(os.path.join('cmdstanpy', '_version.py'))
+    version_contents = version_file.read()
+    return re.search("__version__ = '(.*?)'", version_contents).group(1)
 
 
 _classifiers = """
@@ -21,7 +28,7 @@ Programming Language :: Python
 Topic :: Scientific/Engineering :: Information Analysis
 """
 
-INSTALL_REQUIRES = ['numpy', 'pandas']
+INSTALL_REQUIRES = ['numpy', 'pandas>=0.24.0']
 
 EXTRAS_REQUIRE = {
     'tests': ['pytest', 'pytest-cov'],
@@ -36,7 +43,7 @@ EXTRAS_REQUIRE = {
 
 setuptools.setup(
     name='cmdstanpy',
-    version=__version__,
+    version=get_version(),
     description='Python interface to CmdStan',
     long_description=readme_contents(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ Programming Language :: Python
 Topic :: Scientific/Engineering :: Information Analysis
 """
 
-INSTALL_REQUIRES = ['numpy', 'pandas>=0.24.0']
+INSTALL_REQUIRES = ['numpy', 'pandas']
 
 EXTRAS_REQUIRE = {
     'tests': ['pytest', 'pytest-cov'],

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -229,7 +229,7 @@ class SampleTest(unittest.TestCase):
         # check if  optimized_params_np returns first draw
         # (actually first row from csv)
         np.testing.assert_equal(
-            bern_fit.get_drawset().to_numpy()[0],
+            bern_fit.get_drawset().iloc[0].values,
             bern_fit.optimized_params_np
         )
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

A couple of changes to fix errors I got when trying to pip install the latest cmdstanpy.

The first error happened when I tried to install from github, but it also happens when I try `pip install -e .` in a fresh virtual environment:

```
(venv) ~/Code/cloned/cmdstanpy master $ pip install -e .
Obtaining file:///Users/tedgro/Code/cloned/cmdstanpy
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  ERROR: Complete output from command /Users/tedgro/Code/cloned/cmdstanpy/venv/bin/python3.7 /Users/tedgro/Code/cloned/cmdstanpy/venv/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/nw/nbg0t9fx0hvdhwlgwk2kb48wqkndw3/T/tmphio8017a:
  ERROR: deleting tmpfiles dir: /var/folders/nw/nbg0t9fx0hvdhwlgwk2kb48wqkndw3/T/tmpeimwh50m
  done
  Traceback (most recent call last):
    File "/Users/tedgro/Code/cloned/cmdstanpy/venv/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py", line 207, in <module>
      main()
    File "/Users/tedgro/Code/cloned/cmdstanpy/venv/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py", line 197, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/Users/tedgro/Code/cloned/cmdstanpy/venv/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py", line 54, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/private/var/folders/nw/nbg0t9fx0hvdhwlgwk2kb48wqkndw3/T/pip-build-env-sp43qz9v/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 145, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=['wheel'])
    File "/private/var/folders/nw/nbg0t9fx0hvdhwlgwk2kb48wqkndw3/T/pip-build-env-sp43qz9v/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 126, in _get_build_requires
      self.run_setup()
    File "/private/var/folders/nw/nbg0t9fx0hvdhwlgwk2kb48wqkndw3/T/pip-build-env-sp43qz9v/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 234, in run_setup
      self).run_setup(setup_script=setup_script)
    File "/private/var/folders/nw/nbg0t9fx0hvdhwlgwk2kb48wqkndw3/T/pip-build-env-sp43qz9v/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 141, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 4, in <module>
      from cmdstanpy import __version__
    File "/Users/tedgro/Code/cloned/cmdstanpy/cmdstanpy/__init__.py", line 28, in <module>
      from .utils import set_cmdstan_path, cmdstan_path, set_make_env
    File "/Users/tedgro/Code/cloned/cmdstanpy/cmdstanpy/utils.py", line 7, in <module>
      import numpy as np
  ModuleNotFoundError: No module named 'numpy'
  ----------------------------------------
ERROR: Command "/Users/tedgro/Code/cloned/cmdstanpy/venv/bin/python3.7 /Users/tedgro/Code/cloned/cmdstanpy/venv/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/nw/nbg0t9fx0hvdhwlgwk2kb48wqkndw3/T/tmphio8017a" failed with error code 1 in /Users/tedgro/Code/cloned/cmdstanpy
```

I think this happens because of the line ` from cmdstanpy import __version__` in `setup.py` - [apparently](https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package) importing the package from `setup.py` can cause problems.

The fix is the same as in #59 but leaving the file names alone avoids breaking any tests.

The other change is to ensure a version of pandas with the `to_numpy` dataframe method which is used in one of the tests.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Teddy Groves



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

