### PR TITLE
Fix spaces problem in source path

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -50,7 +50,7 @@ def validate_cmdstan_path(path: str) -> None:
         )
 
 
-class TemporaryMovedFile(object):
+class TemporaryCopiedFile(object):
     def __init__(self, file_path: str):
         self._path = None
         self._tmpdir = None

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -11,7 +11,6 @@ import subprocess
 import shutil
 import tempfile
 
-from contextlib import contextmanager
 from typing import Dict, TextIO, List
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
@@ -391,7 +390,7 @@ def do_command(cmd: str, cwd: str = None) -> str:
     stdout, stderr = proc.communicate()
     if proc.returncode:
         if stderr:
-            msg = 'ERROR\n {} '.format(stderr.strip())
+            msg = 'ERROR\n {} '.format(stderr.decode('utf-8').strip())
         raise Exception(msg)
     if stdout:
         return stdout.decode('utf-8').strip()

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -8,7 +8,10 @@ import numpy as np
 import platform
 import re
 import subprocess
+import shutil
+import tempfile
 
+from contextlib import contextmanager
 from typing import Dict, TextIO, List
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
@@ -45,6 +48,35 @@ def validate_cmdstan_path(path: str) -> None:
             'no CmdStan binaries found, '
             'run command line script "install_cmdstan"'
         )
+
+
+class TemporaryMovedFile(object):
+    def __init__(self, file_path: str):
+        self._path = None
+        self._tmpdir = None
+        if " " in file_path:
+            tmpdir = tempfile.mkdtemp()
+            if " " in tmpdir:
+                raise RuntimeError(
+                    "Unable to generate temporary path without spaces! \n" +
+                    "Please move your stan file to location without spaces."
+                )
+
+            _, path = tempfile.mkstemp(suffix=".stan", dir=tmpdir)
+
+            shutil.copy(file_path, path)
+            self._path = path
+            self._tmpdir = tmpdir
+        else:
+            self._changed = False
+            self._path = file_path
+
+    def __enter__(self):
+        return self._path, self._tmpdir is not None
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
 
 
 def set_cmdstan_path(path: str) -> None:
@@ -359,7 +391,7 @@ def do_command(cmd: str, cwd: str = None) -> str:
     stdout, stderr = proc.communicate()
     if proc.returncode:
         if stderr:
-            msg = 'ERROR\n {} '.format(stderr.decode('utf-8').strip())
+            msg = 'ERROR\n {} '.format(stderr.strip())
         raise Exception(msg)
     if stdout:
         return stdout.decode('utf-8').strip()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(code, model.code())
 
     def test_model_compile(self):
-        stan = os.path.join(datafiles_path, 'bernoulli.stan')
+        stan = os.path.join(datafiles_path, 'bernoulli space.stan')
         exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
         model = Model(stan_file=stan)
         self.assertEqual(None, model.exe_file)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -72,7 +72,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(code, model.code())
 
     def test_model_compile(self):
-        stan = os.path.join(datafiles_path, 'bernoulli space.stan')
+        stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
         model = Model(stan_file=stan)
         self.assertEqual(None, model.exe_file)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,9 +1,9 @@
 import os
 import os.path
 import unittest
-import json
+import tempfile
+import shutil
 
-from cmdstanpy import TMPDIR
 from cmdstanpy.utils import (
     cmdstan_path,
     set_cmdstan_path,
@@ -11,6 +11,7 @@ from cmdstanpy.utils import (
     get_latest_cmdstan,
     check_csv,
     read_metric,
+    TemporaryMovedFile
 )
 
 
@@ -27,6 +28,39 @@ class CmdStanPathTest(unittest.TestCase):
             os.path.join('~', '.cmdstanpy', 'cmdstan')
         )
         self.assertTrue(cmdstan_path().startswith(abs_rel_path))
+
+    def test_non_spaces_location(self):
+        good_path = "/tmp/"
+        with TemporaryMovedFile(good_path) as (p, is_changed):
+            self.assertEqual(p, good_path)
+            self.assertFalse(is_changed)
+
+        # prepare files for test
+        bad_path = os.path.join(tempfile.mkdtemp(), "bad dir")
+        os.mkdir(bad_path)
+        stan = os.path.join(datafiles_path, 'bernoulli.stan')
+        stan_bad = os.path.join(bad_path, "bad name.stan")
+        shutil.copy(stan, stan_bad)
+
+        stan_copied = None
+        try:
+            with TemporaryMovedFile(stan_bad) as (p, is_changed):
+                stan_copied = p
+                self.assertTrue(os.path.exists(stan_copied))
+                self.assertTrue(" " not in stan_copied)
+                self.assertTrue(is_changed)
+                raise RuntimeError
+        except RuntimeError:
+            pass
+
+        print(stan_copied)
+        self.assertFalse(os.path.exists(stan_copied))
+
+        # cleanup after test
+        shutil.rmtree(bad_path, ignore_errors=True)
+
+
+        print(bad_path)
 
     def test_set_path(self):
         install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,7 +11,7 @@ from cmdstanpy.utils import (
     get_latest_cmdstan,
     check_csv,
     read_metric,
-    TemporaryMovedFile
+    TemporaryCopiedFile
 )
 
 
@@ -31,7 +31,7 @@ class CmdStanPathTest(unittest.TestCase):
 
     def test_non_spaces_location(self):
         good_path = "/tmp/"
-        with TemporaryMovedFile(good_path) as (p, is_changed):
+        with TemporaryCopiedFile(good_path) as (p, is_changed):
             self.assertEqual(p, good_path)
             self.assertFalse(is_changed)
 
@@ -44,7 +44,7 @@ class CmdStanPathTest(unittest.TestCase):
 
         stan_copied = None
         try:
-            with TemporaryMovedFile(stan_bad) as (p, is_changed):
+            with TemporaryCopiedFile(stan_bad) as (p, is_changed):
                 stan_copied = p
                 self.assertTrue(os.path.exists(stan_copied))
                 self.assertTrue(" " not in stan_copied)
@@ -53,14 +53,10 @@ class CmdStanPathTest(unittest.TestCase):
         except RuntimeError:
             pass
 
-        print(stan_copied)
         self.assertFalse(os.path.exists(stan_copied))
 
         # cleanup after test
         shutil.rmtree(bad_path, ignore_errors=True)
-
-
-        print(bad_path)
 
     def test_set_path(self):
         install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
According to this issue: https://github.com/stan-dev/cmdstanpy/issues/17
when the source file is in path that contains spaces (e.g. the model file itself can be named that way) the `make` command will fail. 
In order to mitigate this we will copy the source file to a temporary location, compile it, and then copy back generated model to the original directory.

There is still a possibility where the generated temporary path might contain spaces (e.g. under Windows) and we will simply throw an exception.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

- Salesforce

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

