### PR TITLE
Automatically set number of used cores

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -419,21 +419,22 @@ class Model(object):
                             ' found {}'.format(chain_ids[i])
                         )
 
+        cores_avail = cpu_count()
+
         if cores is None:
-            # leave at least 2 cores for the OS
-            cores = min(cpu_count() - 2, chains)
+            cores = max(min(cores_avail - 2, chains), 1)
 
         if cores < 1:
             raise ValueError(
                 'cores must be a positive integer value, found {}'.format(cores)
             )
-        if cores > cpu_count():
+        if cores > cores_avail:
             print(
                 'requested {} cores, only {} available'.format(
                     cores, cpu_count()
                 )
             )
-            cores = cpu_count()
+            cores = cores_avail
 
             # TODO:  issue 49: inits can be initialization function
 

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -271,7 +271,7 @@ class Model(object):
         self,
         data: Union[Dict, str] = None,
         chains: int = 4,
-        cores: int = 1,
+        cores: Union[int, None] = None,
         seed: Union[int, List[int]] = None,
         chain_ids: Union[int, List[int]] = None,
         inits: Union[Dict, float, str, List[str]] = None,
@@ -309,6 +309,8 @@ class Model(object):
 
         :param cores: Number of processes to run in parallel. Must be an
             integer between 1 and the number of CPUs in the system.
+            If none then set automatically to `chains` but no more
+            than `total_cpu_count - 2`
 
         :param seed: The seed for random number generator or a list of per-chain
             seeds. Must be an integer between 0 and 2^32 - 1. If unspecified,
@@ -416,6 +418,10 @@ class Model(object):
                             'chain_id must be a positive integer value,'
                             ' found {}'.format(chain_ids[i])
                         )
+
+        if cores is None:
+            # leave at least 2 cores for the OS
+            cores = min(cpu_count() - 2, chains)
 
         if cores < 1:
             raise ValueError(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
Instead of having number of cores set to 1 by default, let's set it to the number of chains with the limitation of `cpu_count - 2` (to leave some cores for the OS).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

- Salesforce

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

