### PR TITLE
Default value for warmup_iter

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -51,6 +51,14 @@ class SamplerArgs(object):
                 "sampler expects number of chains to be greater than 0"
             )
 
+        if self.sampling_iters is not None:
+            if self.sampling_iters < 0:
+                raise ValueError(
+                    'sampling_iters must be a non-negative integer'.format(
+                        self.sampling_iters
+                    )
+                )
+
         if self.warmup_iters is not None:
             if self.warmup_iters < 0:
                 raise ValueError(
@@ -63,14 +71,8 @@ class SamplerArgs(object):
                     'adaptation requested but 0 warmup iterations specified, '
                     'must run warmup iterations'
                 )
-
-        if self.sampling_iters is not None:
-            if self.sampling_iters < 0:
-                raise ValueError(
-                    'sampling_iters must be a non-negative integer'.format(
-                        self.sampling_iters
-                    )
-                )
+        elif self.sampling_iters is not None:
+            self.warmup_iters = self.sampling_iters // 2
 
         if self.thin is not None:
             if self.thin < 1:

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -57,6 +57,7 @@ class SamplerArgsTest(unittest.TestCase):
         )
         args.validate(chains=4)
         cmd = args.compose(1, '')
+        self.assertEqual(args.warmup_iters, 10)
         self.assertIn('method=sample', cmd)
         self.assertIn('num_warmup=10', cmd)
         self.assertIn('num_samples=20', cmd)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
In pystan the default value for warmup iterations is half of sampling iterations, let's have the same behavior in cmdstanpy as well then.
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

- Salesforce

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

