### PR TITLE
Use logging module instead of print

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -2,13 +2,11 @@
 CmdStan arguments
 """
 import os
-import tempfile
-from numbers import Integral, Real
-from typing import List, Union, Tuple
-
 import numpy as np
 
-from cmdstanpy.utils import check_csv, read_metric
+from numbers import Integral, Real
+from typing import List, Union
+from cmdstanpy.utils import read_metric
 
 
 class SamplerArgs(object):

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -130,7 +130,7 @@ class Model(object):
             hpp_file = os.path.splitext(stan_file)[0] + '.hpp'
             hpp_file = Path(hpp_file).as_posix()
             if overwrite or not os.path.exists(hpp_file):
-                self._logger.info('translating to {}'.format(hpp_file))
+                self._logger.info('stan to c++ ({})'.format(hpp_file))
                 stanc_path = os.path.join(
                     cmdstan_path(), 'bin', 'stanc' + EXTENSION
                 )
@@ -156,7 +156,7 @@ class Model(object):
                             (Path(p).as_posix() for p in include_paths)
                         )
                     )
-                self._logger.info('stan to c++')
+
                 do_command(cmd, logger=self._logger)
                 if not os.path.exists(hpp_file):
                     raise Exception('syntax error'.format(stan_file))

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -170,7 +170,7 @@ class Model(object):
             try:
                 do_command(cmd, cmdstan_path(), self._logger)
             except Exception as e:
-                self._logger.error('make cmd failed\n', e)
+                self._logger.error('make cmd failed %s', e)
 
             if is_copied:
 

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -320,7 +320,7 @@ class StanFit(object):
     def diagnose(self) -> str:
         """
         Run cmdstan/bin/diagnose over all output csv files.
-        Echo diagnose stdout/stderr to console.
+        Returns output of diagnose (stdout/stderr)
 
         The diagnose utility reads the outputs of all chains
         and checks for the following potential problems:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -2,18 +2,18 @@ import os
 import re
 import shutil
 import tempfile
-from typing import Dict, List, Union, Tuple
+from typing import List, Tuple
 from collections import OrderedDict
 import numpy as np
 import pandas as pd
+import logging
 
 from cmdstanpy import TMPDIR
 from cmdstanpy.utils import (
     check_csv,
-    read_metric,
     EXTENSION,
     cmdstan_path,
-    do_command,
+    do_command, get_logger
 )
 from cmdstanpy.cmdstan_args import CmdStanArgs, OptimizeArgs
 
@@ -21,11 +21,17 @@ from cmdstanpy.cmdstan_args import CmdStanArgs, OptimizeArgs
 class StanFit(object):
     """Record of running NUTS sampler on a model."""
 
-    def __init__(self, args: CmdStanArgs, chains: int = 4) -> None:
+    def __init__(
+            self,
+            args: CmdStanArgs,
+            chains: int = 4,
+            logger: logging.Logger = None
+    ) -> None:
         """Initialize object."""
         self._args = args
         self._is_optimizing = isinstance(self._args.method_args, OptimizeArgs)
         self._chains = chains
+        self._logger = logger or get_logger()
         if chains < 1:
             raise ValueError(
                 'chains must be positive integer value, '
@@ -303,14 +309,15 @@ class StanFit(object):
         cmd = '{} --csv_file={} {}'.format(
             cmd_path, tmp_csv_path, ' '.join(self.csv_files)
         )
-        do_command(cmd.split())  # breaks on all whitespace
+        # breaks on all whitespace
+        do_command(cmd.split(), logger=self._logger)
         summary_data = pd.read_csv(
             tmp_csv_path, delimiter=',', header=0, index_col=0, comment='#'
         )
         mask = [x == 'lp__' or not x.endswith('__') for x in summary_data.index]
         return summary_data[mask]
 
-    def diagnose(self) -> None:
+    def diagnose(self) -> str:
         """
         Run cmdstan/bin/diagnose over all output csv files.
         Echo diagnose stdout/stderr to console.
@@ -323,17 +330,18 @@ class StanFit(object):
         + Low E-BFMI values (sampler transitions HMC potential energy)
         + Low effective sample sizes
         + High R-hat values
+
+        :return str empty if no problems found
         """
         self._sampling_only()
 
         cmd_path = os.path.join(cmdstan_path(), 'bin', 'diagnose' + EXTENSION)
         csv_files = ' '.join(self.csv_files)
         cmd = '{} {} '.format(cmd_path, csv_files)
-        result = do_command(cmd=cmd.split())
-        if result is None:
-            print('No problems detected.')
-        else:
-            print(result)
+        result = do_command(cmd=cmd.split(), logger=self._logger)
+        if result:
+            self._logger.warning(result)
+        return result
 
     def get_drawset(self, params: List[str] = None) -> pd.DataFrame:
         """
@@ -392,7 +400,7 @@ class StanFit(object):
                     'file exists, not overwriting: {}'.format(to_path)
                 )
             try:
-                print(
+                self._logger.debug(
                     'saving tmpfile: "{}" as: "{}"'.format(
                         self.csv_files[i], to_path
                     )

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,9 +1,6 @@
-import io
 import os
-import sys
 import unittest
 
-from cmdstanpy import TMPDIR
 from cmdstanpy.utils import EXTENSION
 from cmdstanpy.model import Model
 import numpy as np

--- a/test/test_stanfit.py
+++ b/test/test_stanfit.py
@@ -37,7 +37,7 @@ class StanFitTest(unittest.TestCase):
         self.assertTrue(fit._check_retcodes())
 
     def test_validate_good_run(self):
-        # construct fit using existing sampler outputv
+        # construct fit using existing sampler output
         exe = os.path.join(datafiles_path, 'bernoulli')
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(goodfiles_path, 'bern')

--- a/test/test_stanfit.py
+++ b/test/test_stanfit.py
@@ -1,6 +1,4 @@
-import io
 import os
-import sys
 import unittest
 
 from cmdstanpy.cmdstan_args import SamplerArgs, CmdStanArgs
@@ -39,7 +37,7 @@ class StanFitTest(unittest.TestCase):
         self.assertTrue(fit._check_retcodes())
 
     def test_validate_good_run(self):
-        # construct fit using existing sampler output
+        # construct fit using existing sampler outputv
         exe = os.path.join(datafiles_path, 'bernoulli')
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(goodfiles_path, 'bern')
@@ -77,13 +75,9 @@ class StanFitTest(unittest.TestCase):
                 len(fit.column_names),
             ),
         )
-        df = fit.summary()
-        self.assertTrue(df.shape == (2, 9))
-        capturedOutput = io.StringIO()
-        sys.stdout = capturedOutput
-        fit.diagnose()
-        sys.stdout = sys.__stdout__
-        self.assertEqual(capturedOutput.getvalue(), 'No problems detected.\n')
+        _ = fit.summary()
+
+        self.assertIsNone(fit.diagnose())
 
     def test_validate_big_run(self):
         exe = os.path.join(datafiles_path, 'bernoulli')  # fake out validation
@@ -206,14 +200,10 @@ class StanFitTest(unittest.TestCase):
                 'Trajectories that are prematurely terminated ',
                 'due to this limit will result in slow ',
                 'exploration and you should increase the ',
-                'limit to ensure optimal performance.\n',
+                'limit to ensure optimal performance.',
             ]
         )
-        capturedOutput = io.StringIO()
-        sys.stdout = capturedOutput
-        fit.diagnose()
-        sys.stdout = sys.__stdout__
-        self.assertEqual(capturedOutput.getvalue(), expected)
+        self.assertIn(expected, fit.diagnose())
 
     def test_validate_bad_run(self):
         exe = os.path.join(datafiles_path, 'bernoulli')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
- Replaced `print` calls with `logger.[...]`
- `diagnose` will return string directly if problems found, otherwise `None`

Related issue: https://github.com/stan-dev/cmdstanpy/issues/74
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

- Salesforce

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

