### PR TITLE
makedirs while testing if file can be written

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -131,9 +131,7 @@ class SamplerArgs(object):
                     )
                 for i, metric in enumerate(self.metric):
                     if not os.path.exists(metric):
-                        raise ValueError(
-                            'no such file {}'.format(metric)
-                        )
+                        raise ValueError('no such file {}'.format(metric))
                     if i == 0:
                         dims = read_metric(metric)
                     else:
@@ -226,11 +224,8 @@ class OptimizeArgs(object):
     OPTIMIZE_ALGOS = {"BFGS", "LBFGS", "Newton"}
 
     def __init__(
-            self,
-            algorithm: str = None,
-            init_alpha: Real = None,
-            iter: int = None
-            ) -> None:
+        self, algorithm: str = None, init_alpha: Real = None, iter: int = None
+    ) -> None:
 
         self.algorithm = algorithm
         self.init_alpha = init_alpha
@@ -240,11 +235,14 @@ class OptimizeArgs(object):
         """
         Check arguments correctness and consistency.
         """
-        if self.algorithm is not None and \
-                self.algorithm not in self.OPTIMIZE_ALGOS:
+        if (
+            self.algorithm is not None
+            and self.algorithm not in self.OPTIMIZE_ALGOS
+        ):
             raise ValueError(
-                "Please specify optimizer algorithms as one of [{}]"
-                .format(", ".join(self.OPTIMIZE_ALGOS))
+                "Please specify optimizer algorithms as one of [{}]".format(
+                    ", ".join(self.OPTIMIZE_ALGOS)
+                )
             )
 
         if self.init_alpha is not None:
@@ -334,7 +332,8 @@ class CmdStanArgs(object):
             if not os.path.exists(os.path.dirname(self.output_basename)):
                 raise ValueError(
                     'invalid path for output files: {}'.format(
-                        self.output_basename)
+                        self.output_basename
+                    )
                 )
             try:
                 with open(self.output_basename, 'w+') as fd:
@@ -343,7 +342,8 @@ class CmdStanArgs(object):
             except Exception:
                 raise ValueError(
                     'invalid path for output files: {}'.format(
-                        self.output_basename)
+                        self.output_basename
+                    )
                 )
             self.output_basename, _ = os.path.splitext(self.output_basename)
 
@@ -434,7 +434,8 @@ class CmdStanArgs(object):
             if idx < 0 or idx > len(self.chain_ids) - 1:
                 raise ValueError(
                     'index ({}) exceeds number of chains ({})'.format(
-                        idx, len(self.chain_ids))
+                        idx, len(self.chain_ids)
+                    )
                 )
             cmd = '{} id={}'.format(self.model_exe, self.chain_ids[idx])
         else:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -10,9 +10,12 @@ from typing import Dict, List, Union
 from cmdstanpy.cmdstan_args import CmdStanArgs, SamplerArgs, OptimizeArgs
 from cmdstanpy.stanfit import StanFit
 from cmdstanpy.utils import (
-    do_command, EXTENSION,
-    cmdstan_path, MaybeDictToFilePath,
-    TemporaryCopiedFile, get_logger
+    do_command,
+    EXTENSION,
+    cmdstan_path,
+    MaybeDictToFilePath,
+    TemporaryCopiedFile,
+    get_logger,
 )
 
 
@@ -25,10 +28,10 @@ class Model(object):
     """
 
     def __init__(
-            self,
-            stan_file: str = None,
-            exe_file: str = None,
-            logger: logging.Logger = None
+        self,
+        stan_file: str = None,
+        exe_file: str = None,
+        logger: logging.Logger = None,
     ) -> None:
         """Initialize object."""
         self._stan_file = stan_file
@@ -152,9 +155,7 @@ class Model(object):
                         )
                     cmd.append(
                         '--include_paths='
-                        + ','.join(
-                            (Path(p).as_posix() for p in include_paths)
-                        )
+                        + ','.join((Path(p).as_posix() for p in include_paths))
                     )
 
                 do_command(cmd, logger=self._logger)
@@ -176,13 +177,13 @@ class Model(object):
 
                 original_target_dir = os.path.dirname(self._stan_file)
                 # reconstruct the output file name
-                new_exec_name = os.path.basename(
-                    os.path.splitext(self._stan_file)[0]
-                ) + EXTENSION
+                new_exec_name = (
+                    os.path.basename(os.path.splitext(self._stan_file)[0])
+                    + EXTENSION
+                )
 
                 self._exe_file = os.path.join(
-                    original_target_dir,
-                    new_exec_name
+                    original_target_dir, new_exec_name
                 )
 
                 # copy the generated file back to the original directory
@@ -193,14 +194,14 @@ class Model(object):
         self._logger.info('compiled model file: %s', self._exe_file)
 
     def optimize(
-            self,
-            data: Union[Dict, str] = None,
-            seed: int = None,
-            inits: Union[Dict, float, str] = None,
-            csv_basename: str = None,
-            algorithm: str = None,
-            init_alpha: float = None,
-            iter: int = None
+        self,
+        data: Union[Dict, str] = None,
+        seed: int = None,
+        inits: Union[Dict, float, str] = None,
+        csv_basename: str = None,
+        algorithm: str = None,
+        init_alpha: float = None,
+        iter: int = None,
     ) -> StanFit:
         """
         Wrapper for optimize call
@@ -242,9 +243,7 @@ class Model(object):
         """
 
         optimize_args = OptimizeArgs(
-            algorithm=algorithm,
-            init_alpha=init_alpha,
-            iter=iter
+            algorithm=algorithm, init_alpha=init_alpha, iter=iter
         )
 
         with MaybeDictToFilePath(data, inits) as (_data, _inits):
@@ -436,9 +435,7 @@ class Model(object):
             )
         if cores > cores_avail:
             self._logger.warning(
-                'requested %u cores, only %u available',
-                cores,
-                cpu_count()
+                'requested %u cores, only %u available', cores, cpu_count()
             )
             cores = cores_avail
 

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -383,8 +383,7 @@ class StanFit(object):
             dir = '.'
         test_path = os.path.join(dir, '.{}-test.tmp'.format(basename))
         try:
-            if not os.path.exists(dir):
-                os.makedirs(dir, exist_ok=True)
+            os.makedirs(dir, exist_ok=True)
             with open(test_path, 'w') as fd:
                 pass
             os.remove(test_path)  # cleanup

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -13,7 +13,8 @@ from cmdstanpy.utils import (
     check_csv,
     EXTENSION,
     cmdstan_path,
-    do_command, get_logger
+    do_command,
+    get_logger,
 )
 from cmdstanpy.cmdstan_args import CmdStanArgs, OptimizeArgs
 
@@ -22,10 +23,7 @@ class StanFit(object):
     """Record of running NUTS sampler on a model."""
 
     def __init__(
-            self,
-            args: CmdStanArgs,
-            chains: int = 4,
-            logger: logging.Logger = None
+        self, args: CmdStanArgs, chains: int = 4, logger: logging.Logger = None
     ) -> None:
         """Initialize object."""
         self._args = args
@@ -210,13 +208,11 @@ class StanFit(object):
         for i in range(self._chains):
             if i == 0:
                 dzero = check_csv(
-                    self.csv_files[i],
-                    is_optimizing=self.is_optimizing
+                    self.csv_files[i], is_optimizing=self.is_optimizing
                 )
             else:
                 d = check_csv(
-                    self.csv_files[i],
-                    is_optimizing=self.is_optimizing
+                    self.csv_files[i], is_optimizing=self.is_optimizing
                 )
                 for key in dzero:
                     if key not in ('id', 'first_draw') and dzero[key] != d[key]:
@@ -402,9 +398,7 @@ class StanFit(object):
                 )
             try:
                 self._logger.debug(
-                    'saving tmpfile: "%s" as: "%s"',
-                    self.csv_files[i],
-                    to_path
+                    'saving tmpfile: "%s" as: "%s"', self.csv_files[i], to_path
                 )
                 shutil.move(self.csv_files[i], to_path)
                 self.csv_files[i] = to_path

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -383,6 +383,8 @@ class StanFit(object):
             dir = '.'
         test_path = os.path.join(dir, '.{}-test.tmp'.format(basename))
         try:
+            if not os.path.exists(dir):
+                os.makedirs(dir, exist_ok=True)
             with open(test_path, 'w') as fd:
                 pass
             os.remove(test_path)  # cleanup

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -45,10 +45,7 @@ def get_latest_cmdstan(dot_dir: str) -> str:
 
 
 class MaybeDictToFilePath(object):
-    def __init__(
-            self,
-            *objs: Union[str, dict],
-            logger: logging.Logger = None):
+    def __init__(self, *objs: Union[str, dict], logger: logging.Logger = None):
         self._unlink = [False] * len(objs)
         self._paths = [""] * len(objs)
         self._logger = logger or get_logger()
@@ -56,7 +53,7 @@ class MaybeDictToFilePath(object):
         for o in objs:
             if isinstance(o, dict):
                 with tempfile.NamedTemporaryFile(
-                        mode='w+', suffix='.json', dir=TMPDIR, delete=False
+                    mode='w+', suffix='.json', dir=TMPDIR, delete=False
                 ) as fd:
                     data_file = fd.name
                     self._logger.debug('input tempfile: %s', fd.name)
@@ -104,8 +101,8 @@ class TemporaryCopiedFile(object):
             tmpdir = tempfile.mkdtemp()
             if " " in tmpdir:
                 raise RuntimeError(
-                    "Unable to generate temporary path without spaces! \n" +
-                    "Please move your stan file to location without spaces."
+                    "Unable to generate temporary path without spaces! \n"
+                    + "Please move your stan file to location without spaces."
                 )
 
             _, path = tempfile.mkstemp(suffix=".stan", dir=tmpdir)
@@ -210,7 +207,7 @@ def check_csv(path: str, is_optimizing: bool = False) -> Dict:
     if is_optimizing:
         draws_spec = 1
     else:
-        draws_spec = int(meta.get('num_samples',1000))
+        draws_spec = int(meta.get('num_samples', 1000))
         if 'thin' in meta:
             draws_spec = int(math.ceil(draws_spec / meta['thin']))
     if meta['draws'] != draws_spec:
@@ -350,11 +347,7 @@ def scan_metric(fp: TextIO, config_dict: Dict, lineno: int) -> int:
         return lineno
 
 
-def scan_draws(
-        fp: TextIO,
-        config_dict: Dict,
-        lineno: int
-) -> int:
+def scan_draws(fp: TextIO, config_dict: Dict, lineno: int) -> int:
     """
     Parse draws, check elements per draw, save num draws to config_dict.
     """

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -2,8 +2,12 @@ import os
 import unittest
 
 from cmdstanpy import TMPDIR
-from cmdstanpy.cmdstan_args import SamplerArgs, CmdStanArgs, \
-    FixedParamArgs, OptimizeArgs
+from cmdstanpy.cmdstan_args import (
+    SamplerArgs,
+    CmdStanArgs,
+    FixedParamArgs,
+    OptimizeArgs,
+)
 
 datafiles_path = os.path.join("test", "data")
 
@@ -197,7 +201,8 @@ class CmdStanArgsTest(unittest.TestCase):
             model_name='bernoulli',
             model_exe=exe,
             chain_ids=[1, 2, 3, 4],
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         with self.assertRaises(ValueError):
             cmdstan_args.compose_command(idx=4, csv_file='foo')
         with self.assertRaises(ValueError):
@@ -213,7 +218,8 @@ class CmdStanArgsTest(unittest.TestCase):
             model_exe=exe,
             chain_ids=None,
             inits=jinits,
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         self.assertIn("init=", cmdstan_args.compose_command(None, "out.csv"))
 
         with self.assertRaises(ValueError):
@@ -223,7 +229,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 chain_ids=None,
                 seed=[1, 2, 3],
                 inits=jinits,
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             CmdStanArgs(
@@ -231,7 +238,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe=exe,
                 chain_ids=None,
                 inits=[jinits],
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
     def test_args_good(self):
         exe = os.path.join(datafiles_path, 'bernoulli')
@@ -243,7 +251,8 @@ class CmdStanArgsTest(unittest.TestCase):
             model_exe=exe,
             chain_ids=[1, 2, 3, 4],
             data=jdata,
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
         self.assertIn('id=1 random seed=', cmd)
         self.assertIn('data file=', cmd)
@@ -255,7 +264,8 @@ class CmdStanArgsTest(unittest.TestCase):
             model_exe=exe,
             chain_ids=[7, 11, 18, 29],
             data=jdata,
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
         self.assertIn('id=7 random seed=', cmd)
 
@@ -274,7 +284,8 @@ class CmdStanArgsTest(unittest.TestCase):
             chain_ids=[1, 2, 3, 4],
             data=jdata,
             inits=jinits,
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
         self.assertIn('init=', cmd)
 
@@ -284,7 +295,8 @@ class CmdStanArgsTest(unittest.TestCase):
             chain_ids=[1, 2],
             data=jdata,
             inits=[jinits1, jinits2],
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
         self.assertIn('bernoulli.init_1.json', cmd)
         cmd = cmdstan_args.compose_command(idx=1, csv_file='bern-output-1.csv')
@@ -296,7 +308,8 @@ class CmdStanArgsTest(unittest.TestCase):
             chain_ids=[1, 2, 3, 4],
             data=jdata,
             inits=0,
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
         self.assertIn('init=0', cmd)
 
@@ -306,7 +319,8 @@ class CmdStanArgsTest(unittest.TestCase):
             chain_ids=[1, 2, 3, 4],
             data=jdata,
             inits=3.33,
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
         self.assertIn('init=3.33', cmd)
 
@@ -316,14 +330,14 @@ class CmdStanArgsTest(unittest.TestCase):
         with self.assertRaises(Exception):
             # missing
             cmdstan_args = CmdStanArgs(
-                model_name='bernoulli',
-                model_exe='bernoulli.exe')
+                model_name='bernoulli', model_exe='bernoulli.exe'
+            )
 
         with self.assertRaises(Exception):
             # missing
             cmdstan_args = CmdStanArgs(
-                model_name='bernoulli',
-                model_exe='bernoulli.exe')
+                model_name='bernoulli', model_exe='bernoulli.exe'
+            )
 
         with self.assertRaises(ValueError):
             # bad filepath
@@ -332,7 +346,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 data='no/such/path/to.file',
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad chain id
@@ -340,7 +355,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_name='bernoulli',
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, -4],
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad seed
@@ -349,7 +365,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 seed=4294967299,
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad seed
@@ -358,7 +375,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 seed=[1, 2, 3],
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad seed
@@ -367,7 +385,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 seed=-3,
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad seed
@@ -376,7 +395,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 seed='badseed',
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad inits
@@ -385,7 +405,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 inits=-5,
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad inits
@@ -394,7 +415,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 inits='no/such/path/to.file',
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad inits
@@ -403,7 +425,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 inits='no/such/path/to.file',
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         jinits = os.path.join(datafiles_path, 'bernoulli.init.json')
         jinits1 = os.path.join(datafiles_path, 'bernoulli.init_1.json')
@@ -416,7 +439,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 inits=[jinits, jinits],
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad inits - files must be unique
@@ -425,7 +449,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 inits=[jinits, jinits1, jinits2],
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
         with self.assertRaises(ValueError):
             # bad output basename
@@ -434,7 +459,8 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 output_basename='no/such/path/to.file',
-                method_args=sampler_args)
+                method_args=sampler_args,
+            )
 
 
 if __name__ == '__main__':

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -111,7 +111,8 @@ class OptimizeTest(unittest.TestCase):
             inits=jinit,
             algorithm="BFGS",
             init_alpha=0.001,
-            iter=100)
+            iter=100,
+        )
 
         # check if calling sample related stuff fails
         with self.assertRaises(RuntimeError):
@@ -127,26 +128,23 @@ class OptimizeTest(unittest.TestCase):
 
         # test pandas output
         self.assertEqual(
-            fit.optimized_params_np[0],
-            fit.optimized_params_pd["lp__"][0]
+            fit.optimized_params_np[0], fit.optimized_params_pd["lp__"][0]
         )
         self.assertEqual(
-            fit.optimized_params_np[1],
-            fit.optimized_params_pd["theta"][0]
+            fit.optimized_params_np[1], fit.optimized_params_pd["theta"][0]
         )
 
         # test dict output
         self.assertEqual(
-            fit.optimized_params_np[0],
-            fit.optimized_params_dict["lp__"]
+            fit.optimized_params_np[0], fit.optimized_params_dict["lp__"]
         )
         self.assertEqual(
-            fit.optimized_params_np[1],
-            fit.optimized_params_dict["theta"]
+            fit.optimized_params_np[1], fit.optimized_params_dict["theta"]
         )
 
     def test_optimize_works_dict(self):
         import json
+
         exe = os.path.join(datafiles_path, 'bernoulli')
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         model = Model(stan_file=stan, exe_file=exe)
@@ -160,7 +158,8 @@ class OptimizeTest(unittest.TestCase):
             inits=init,
             algorithm="BFGS",
             init_alpha=0.001,
-            iter=100)
+            iter=100,
+        )
 
         # test numpy output
         self.assertAlmostEqual(fit.optimized_params_np[0], -5, places=2)
@@ -175,11 +174,9 @@ class SampleTest(unittest.TestCase):
         bern_model.compile()
 
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        bern_fit = bern_model.sample(data=jdata,
-                                     chains=4,
-                                     cores=2,
-                                     seed=12345,
-                                     sampling_iters=100)
+        bern_fit = bern_model.sample(
+            data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100
+        )
 
         for i in range(bern_fit.chains):
             csv_file = bern_fit.csv_files[i]
@@ -209,12 +206,14 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(bern_fit.metric.shape, (4, 1))
 
         output = os.path.join(datafiles_path, 'test1-bernoulli-output')
-        bern_fit = bern_model.sample(data=jdata,
-                                     chains=4,
-                                     cores=2,
-                                     seed=12345,
-                                     sampling_iters=100,
-                                     csv_basename=output)
+        bern_fit = bern_model.sample(
+            data=jdata,
+            chains=4,
+            cores=2,
+            seed=12345,
+            sampling_iters=100,
+            csv_basename=output,
+        )
         for i in range(bern_fit.chains):
             csv_file = bern_fit.csv_files[i]
             txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
@@ -227,28 +226,23 @@ class SampleTest(unittest.TestCase):
             os.remove(bern_fit.console_files[i])
 
         rdata = os.path.join(datafiles_path, 'bernoulli.data.R')
-        bern_fit = bern_model.sample(data=rdata,
-                                     chains=4,
-                                     cores=2,
-                                     seed=12345,
-                                     sampling_iters=100)
+        bern_fit = bern_model.sample(
+            data=rdata, chains=4, cores=2, seed=12345, sampling_iters=100
+        )
         bern_sample = bern_fit.sample
         self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
 
         data_dict = {'N': 10, 'y': [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
-        bern_fit = bern_model.sample(data=data_dict,
-                                     chains=4,
-                                     cores=2,
-                                     seed=12345,
-                                     sampling_iters=100)
+        bern_fit = bern_model.sample(
+            data=data_dict, chains=4, cores=2, seed=12345, sampling_iters=100
+        )
         bern_sample = bern_fit.sample
         self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
 
         # check if  optimized_params_np returns first draw
         # (actually first row from csv)
         np.testing.assert_equal(
-            bern_fit.get_drawset().iloc[0].values,
-            bern_fit.optimized_params_np
+            bern_fit.get_drawset().iloc[0].values, bern_fit.optimized_params_np
         )
 
     def test_bernoulli_bad(self):
@@ -258,10 +252,9 @@ class SampleTest(unittest.TestCase):
         bern_model.compile()
 
         with self.assertRaisesRegex(Exception, 'Error during sampling'):
-            bern_fit = bern_model.sample(chains=4,
-                                         cores=2,
-                                         seed=12345,
-                                         sampling_iters=100)
+            bern_fit = bern_model.sample(
+                chains=4, cores=2, seed=12345, sampling_iters=100
+            )
 
 
 if __name__ == '__main__':

--- a/test/test_stanfit.py
+++ b/test/test_stanfit.py
@@ -166,17 +166,7 @@ class StanFitTest(unittest.TestCase):
         for i in range(bern_fit.chains):  # cleanup default dir
             os.remove(bern_fit.csv_files[i])
             os.remove(bern_fit.console_files[i])
-
-        # regenerate to tmpdir, save to no such dir
-        bern_fit = bern_model.sample(data=jdata,
-                                     chains=4,
-                                     cores=2,
-                                     seed=12345,
-                                     sampling_iters=200)
-        with self.assertRaisesRegex(Exception, 'cannot save'):
-            bern_fit.save_csvfiles(
-                dir=os.path.join('no', 'such', 'dir'), basename=basename
-            )
+                
 
     def test_diagnose_divergences(self):
         exe = os.path.join(datafiles_path, 'bernoulli')  # fake out validation

--- a/test/test_stanfit.py
+++ b/test/test_stanfit.py
@@ -21,7 +21,8 @@ class StanFitTest(unittest.TestCase):
             model_exe=exe,
             chain_ids=[1, 2, 3, 4],
             data=jdata,
-            method_args=sampler_args)
+            method_args=sampler_args,
+        )
         fit = StanFit(args=cmdstan_args, chains=4)
         retcodes = fit._retcodes
         self.assertEqual(4, len(retcodes))
@@ -42,9 +43,7 @@ class StanFitTest(unittest.TestCase):
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         output = os.path.join(goodfiles_path, 'bern')
         sampler_args = SamplerArgs(
-            sampling_iters=100,
-            max_treedepth=11,
-            adapt_delta=0.95
+            sampling_iters=100, max_treedepth=11, adapt_delta=0.95
         )
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -53,7 +52,7 @@ class StanFitTest(unittest.TestCase):
             seed=12345,
             data=jdata,
             output_basename=output,
-            method_args=sampler_args
+            method_args=sampler_args,
         )
         fit = StanFit(args=cmdstan_args, chains=4)
         retcodes = fit._retcodes
@@ -69,15 +68,23 @@ class StanFitTest(unittest.TestCase):
 
         df = fit.get_drawset()
         self.assertEqual(
-            df.shape,
-            (
-                fit.chains * fit.draws,
-                len(fit.column_names),
-            ),
+            df.shape, (fit.chains * fit.draws, len(fit.column_names))
         )
         _ = fit.summary()
 
-        self.assertIsNone(fit.diagnose())
+        # TODO - use cmdstan test files instead
+        expected = '\n'.join(
+            [
+                'Checking sampler transitions treedepth.',
+                'Treedepth satisfactory for all transitions.',
+                '\nChecking sampler transitions for divergences.',
+                'No divergent transitions found.',
+                '\nChecking E-BFMI - sampler transitions HMC potential energy.',
+                'E-BFMI satisfactory for all transitions.',
+                '\nEffective sample size satisfactory.',
+            ]
+        )
+        self.assertIn(expected, fit.diagnose())
 
     def test_validate_big_run(self):
         exe = os.path.join(datafiles_path, 'bernoulli')  # fake out validation
@@ -89,7 +96,7 @@ class StanFitTest(unittest.TestCase):
             chain_ids=[1, 2],
             seed=12345,
             output_basename=output,
-            method_args=sampler_args
+            method_args=sampler_args,
         )
         fit = StanFit(args=cmdstan_args, chains=2)
         fit._validate_csv_files()
@@ -129,11 +136,9 @@ class StanFitTest(unittest.TestCase):
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         bern_model = Model(stan_file=stan, exe_file=exe)
         bern_model.compile()
-        bern_fit = bern_model.sample(data=jdata,
-                                     chains=4,
-                                     cores=2,
-                                     seed=12345,
-                                     sampling_iters=200)
+        bern_fit = bern_model.sample(
+            data=jdata, chains=4, cores=2, seed=12345, sampling_iters=200
+        )
 
         for i in range(bern_fit.chains):
             csv_file = bern_fit.csv_files[i]
@@ -154,11 +159,9 @@ class StanFitTest(unittest.TestCase):
             os.remove(bern_fit.console_files[i])
 
         # regenerate to tmpdir, save to good dir
-        bern_fit = bern_model.sample(data=jdata,
-                                     chains=4,
-                                     cores=2,
-                                     seed=12345,
-                                     sampling_iters=200)
+        bern_fit = bern_model.sample(
+            data=jdata, chains=4, cores=2, seed=12345, sampling_iters=200
+        )
         bern_fit.save_csvfiles(basename=basename)  # default dir
         for i in range(bern_fit.chains):
             csv_file = bern_fit.csv_files[i]
@@ -166,7 +169,6 @@ class StanFitTest(unittest.TestCase):
         for i in range(bern_fit.chains):  # cleanup default dir
             os.remove(bern_fit.csv_files[i])
             os.remove(bern_fit.console_files[i])
-                
 
     def test_diagnose_divergences(self):
         exe = os.path.join(datafiles_path, 'bernoulli')  # fake out validation
@@ -179,18 +181,18 @@ class StanFitTest(unittest.TestCase):
             model_exe=exe,
             chain_ids=[1],
             output_basename=output,
-            method_args=sampler_args
+            method_args=sampler_args,
         )
         fit = StanFit(args=cmdstan_args, chains=1)
         # TODO - use cmdstan test files instead
-        expected = ''.join(
+        expected = '\n'.join(
             [
-                '424 of 1000 (42%) transitions hit the maximum ',
-                'treedepth limit of 8, or 2^8 leapfrog steps. ',
-                'Trajectories that are prematurely terminated ',
-                'due to this limit will result in slow ',
-                'exploration and you should increase the ',
-                'limit to ensure optimal performance.',
+                'Checking sampler transitions treedepth.',
+                '424 of 1000 (42%) transitions hit the maximum '
+                'treedepth limit of 8, or 2^8 leapfrog steps.',
+                'Trajectories that are prematurely terminated '
+                'due to this limit will result in slow exploration.',
+                'For optimal performance, increase this limit.',
             ]
         )
         self.assertIn(expected, fit.diagnose())
@@ -199,9 +201,7 @@ class StanFitTest(unittest.TestCase):
         exe = os.path.join(datafiles_path, 'bernoulli')
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         sampler_args = SamplerArgs(
-            sampling_iters=100,
-            max_treedepth=11,
-            adapt_delta=0.95
+            sampling_iters=100, max_treedepth=11, adapt_delta=0.95
         )
 
         # some chains had errors
@@ -213,7 +213,7 @@ class StanFitTest(unittest.TestCase):
             seed=12345,
             data=jdata,
             output_basename=output,
-            method_args=sampler_args
+            method_args=sampler_args,
         )
         fit = StanFit(args=cmdstan_args, chains=4)
         with self.assertRaisesRegex(Exception, 'Exception'):
@@ -228,7 +228,7 @@ class StanFitTest(unittest.TestCase):
             seed=12345,
             data=jdata,
             output_basename=output,
-            method_args=sampler_args
+            method_args=sampler_args,
         )
         fit = StanFit(args=cmdstan_args, chains=4)
         retcodes = fit._retcodes
@@ -247,7 +247,7 @@ class StanFitTest(unittest.TestCase):
             seed=12345,
             data=jdata,
             output_basename=output,
-            method_args=sampler_args
+            method_args=sampler_args,
         )
         fit = StanFit(args=cmdstan_args, chains=4)
         retcodes = fit._retcodes
@@ -266,7 +266,7 @@ class StanFitTest(unittest.TestCase):
             seed=12345,
             data=jdata,
             output_basename=output,
-            method_args=sampler_args
+            method_args=sampler_args,
         )
         fit = StanFit(args=cmdstan_args, chains=4)
         retcodes = fit._retcodes

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,7 +13,7 @@ from cmdstanpy.utils import (
     check_csv,
     MaybeDictToFilePath,
     read_metric,
-    TemporaryCopiedFile
+    TemporaryCopiedFile,
 )
 
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Call `os.makedirs(dir, exist_ok=True)` in try-except block to have a possibility to create csv-files in a new dir. 
If this fail, then it will raise OSError and it is handled correctly.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

