### PR TITLE
Use concurrent.futures.ThreadPoolExecutor

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -3,7 +3,7 @@ import subprocess
 import shutil
 import logging
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Dict, List, Union


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Change `multiprocessing.ThreadPool` to `concurrent.futures.ThreadPoolExecutor`

Currently nothing changes, but it is a newer library and gives us opportunity to handle more with each thread.

https://docs.python.org/3/library/concurrent.futures.html

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

