### PR TITLE
[MRG] DOC Uses correct path to data.json in cmdstanpy_tutorial.ipynb

### DIFF
--- a/cmdstanpy_tutorial.ipynb
+++ b/cmdstanpy_tutorial.ipynb
@@ -110,7 +110,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')"
+    "bernoulli_dir = os.path.join(cmdstan_path(), 'examples', 'bernoulli')\n",
+    "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')"
    ]
   },
   {
@@ -161,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bern_json = os.path.join(bernoulli_path, 'bernoulli.data.json')"
+    "bern_json = os.path.join(bernoulli_dir, 'bernoulli.data.json')"
    ]
   },
   {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
Minor correction in `cmdstanpy_tutorial.ipynb` to have `bern_json` be an existing json file. (On master `bern_json` was equal to `examples/bernoulli/bernoulli.stan/bernoulli.data.json`)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Thomas J Fan

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
