### PR TITLE
reverting to ThreadPool, not using concurrent futures

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -3,8 +3,8 @@ import subprocess
 import shutil
 import logging
 
-from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import cpu_count
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import Dict, List, Union
 from cmdstanpy.cmdstan_args import CmdStanArgs, SamplerArgs,\
@@ -470,9 +470,13 @@ class Model(object):
             )
 
             stanfit = StanFit(args=args, chains=chains)
-            with ThreadPoolExecutor(max_workers=cores) as executor:
+            try:
+                tp = ThreadPool(cores)
                 for i in range(chains):
-                    executor.submit(self._run_cmdstan(stanfit, i))
+                    tp.apply_async(self._run_cmdstan, (stanfit, i))
+            finally:
+                tp.close()
+                tp.join()
             if not stanfit._check_retcodes():
                 msg = 'Error during sampling'
                 for i in range(chains):
@@ -540,9 +544,13 @@ class Model(object):
 
             cores_avail = cpu_count()
             cores = max(min(cores_avail - 2, chains), 1)
-            with ThreadPoolExecutor(max_workers=cores) as executor:
+            try:
+                tp = ThreadPool(cores)
                 for i in range(chains):
-                    executor.submit(self._run_cmdstan(stanfit, i))
+                    tp.apply_async(self._run_cmdstan, (stanfit, i))
+            finally:
+                tp.close()
+                tp.join()
             if not stanfit._check_retcodes():
                 msg = 'Error during sampling'
                 for i in range(chains):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

concurrent futures should work but doesn't - needs investigation.
reverting to using ThreadPool.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

