### PR TITLE
use Fortran order for utils.jsondumps

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -193,9 +193,12 @@ def _rdump_array(key: str, val: np.ndarray) -> str:
 def jsondump(path: str, data: Dict) -> None:
     """Dump a dict of data to a JSON file."""
     for key, val in data.items():
-        if isinstance(val, np.ndarray) and val.size > 1:
-            # .T for Fortran order
-            data[key] = val.T.tolist()
+        if isinstance(val, np.ndarray):
+            if val.size > 1:
+                # .T for Fortran order
+                data[key] = val.T.tolist()
+            else:
+                data[key] = []
     with open(path, 'w') as fd:
         json.dump(data, fd)
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -193,7 +193,7 @@ def _rdump_array(key: str, val: np.ndarray) -> str:
 def jsondump(path: str, data: Dict) -> None:
     """Dump a dict of data to a JSON file."""
     for key, val in data.items():
-        if isinstance(val, np.ndarray):
+        if isinstance(val, np.ndarray) and val.size > 1:
             # .T for Fortran order
             data[key] = val.T.tolist()
     with open(path, 'w') as fd:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -193,8 +193,9 @@ def _rdump_array(key: str, val: np.ndarray) -> str:
 def jsondump(path: str, data: Dict) -> None:
     """Dump a dict of data to a JSON file."""
     for key, val in data.items():
-        if isinstance(val, np.ndarray) and val.size > 1:
-            data[key] = val.tolist()
+        if isinstance(val, np.ndarray):
+            # .T for Fortran order
+            data[key] = val.T.tolist()
     with open(path, 'w') as fd:
         json.dump(data, fd)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,6 +7,8 @@ import shutil
 import string
 import random
 
+import numpy as np
+
 from cmdstanpy import TMPDIR
 from cmdstanpy.utils import (
     cmdstan_path,
@@ -21,6 +23,7 @@ from cmdstanpy.utils import (
     rdump,
     rload,
     parse_rdump_value,
+    jsondump,
 )
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -334,6 +337,23 @@ class RloadTest(unittest.TestCase):
         self.assertEqual(v_s3[7, 0], 8)
         self.assertEqual(v_s3[0, 1], 9)
         self.assertEqual(v_s3[6, 1], 15)
+
+
+class NumpyToListTest(unittest.TestCase):
+    """Check correct order."""
+
+    def test_jsondumps_order(self):
+        path_handle = tempfile.NamedTemporaryFile(suffix=".json", dir=TMPDIR)
+        path = path_handle.name
+        path_handle.close()
+
+        numpy_array = np.random.randn(10, 11, 3).round(3)
+        jsondump(path, {'theta': numpy_array})
+        with open(path, "r") as fd:
+            # create with fortran order
+            new_numpy_array = np.array(json.load(fd)['theta']).T
+        np.testing.assert_array_equal(numpy_array, new_numpy_array)
+        os.remove(path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Transform nD arrays with Fortran order

    np.array(...).T.tolist()

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

