### PR TITLE
changed class StanFit to StanMCMC, added __repr__ methods

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -26,6 +26,6 @@ def cleanup_tmpdir():
 atexit.register(cleanup_tmpdir)
 
 from .utils import set_cmdstan_path, cmdstan_path, set_make_env, install_cmdstan
-from .stanfit import StanFit, StanMLE, StanQuantities, StanVariational
+from .stanfit import StanMCMC, StanMLE, StanQuantities, StanVariational
 from .model import Model
 from ._version import __version__

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -285,7 +285,6 @@ class OptimizeArgs(object):
     def compose(self, idx: int, cmd: str) -> str:
         """compose command string for CmdStan for non-default arg values.
         """
-
         cmd = cmd + ' method=optimize'
         if self.algorithm:
             cmd += ' algorithm={}'.format(self.algorithm.lower())

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -21,7 +21,7 @@ from cmdstanpy.cmdstan_args import (
 )
 from cmdstanpy.stanfit import (
     RunSet,
-    StanFit,
+    StanMCMC,
     StanMLE,
     StanQuantities,
     StanVariational
@@ -312,7 +312,7 @@ class Model(object):
         fixed_param: bool = False,
         csv_basename: str = None,
         show_progress: Union[bool, str] = False,
-    ) -> StanFit:
+    ) -> StanMCMC:
         """
         Run or more chains of the NUTS sampler to produce a set of draws
         from the posterior distribution of a model conditioned on some data.
@@ -323,7 +323,7 @@ class Model(object):
         Unspecified arguments are not included in the call to CmdStan, i.e.,
         those arguments will have CmdStan default values.
 
-        For each chain, the ``StanFit`` object records the command,
+        For each chain, the ``StanMCMC`` object records the command,
         the return code, the sampler output file paths, and the corresponding
         subprocess console outputs, if any.
 
@@ -425,7 +425,7 @@ class Model(object):
             If show_progress=='notebook' use tqdm_notebook
             (needs nodejs for jupyter).
 
-        :return: StanFit object
+        :return: StanMCMC object
         """
 
         if chains is None:
@@ -610,9 +610,9 @@ class Model(object):
                             msg, i, runset._retcode(i)
                         )
                 raise RuntimeError(msg)
-            stanfit = StanFit(runset, fixed_param)
-            stanfit._validate_csv_files()
-        return stanfit
+            mcmc = StanMCMC(runset, fixed_param)
+            mcmc._validate_csv_files()
+        return mcmc
 
     def run_generated_quantities(
         self,
@@ -622,7 +622,7 @@ class Model(object):
         gq_csv_basename: str = None,
     ) -> StanQuantities:
         """
-        Wrapper for generated quantities call.  Given a StanFit object
+        Wrapper for generated quantities call.  Given a StanMCMC object
         containing a sample from the fitted model, along with the
         corresponding dataset for that fit, run just the generated quantities
         block of the model in order to get additional quantities of interest.

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -67,13 +67,6 @@ class RunSet(object):
         ]
         self._retcodes = [-1 for _ in range(chains)]
 
-    def __repr__(self) -> str:
-        repr = 'RunSet(args={}, chains={}'.format(self._args, self._chains)
-        repr = '{}\n csv_files={}\nconsole_files={})'.format(
-            repr, '\n\t'.join(self._csv_files), '\n\t'.join(self._console_files)
-        )
-        return repr
-
     @property
     def model(self) -> str:
         """Stan model name."""
@@ -181,7 +174,7 @@ class RunSet(object):
                 ) from e
 
 
-class StanFit(object):
+class StanMCMC(object):
     """
     Container for outputs from CmdStan sampler run.
     """
@@ -202,6 +195,19 @@ class StanFit(object):
         self._stepsize = None
         self._sample = None
         self._is_fixed_param = is_fixed_param
+
+    def __repr__(self) -> str:
+        repr = 'StanMCMC: model={} chains={}{}'.format(
+            self.runset.model,
+            self.runset.chains,
+            self.runset._args.method_args.compose(0, ''),
+        )
+        repr = '{}\n csv_files:\n\t{}\n console_files\n\t{}'.format(
+            repr,
+            '\n\t'.join(self.runset.csv_files),
+            '\n\t'.join(self.runset.console_files),
+        )
+        return repr
 
     @property
     def chains(self) -> int:
@@ -462,6 +468,17 @@ class StanMLE(object):
         self._column_names = ()
         self._mle = {}
 
+    def __repr__(self) -> str:
+        repr = 'StanMLE: model={}{}'.format(
+            self.runset.model, self.runset._args.method_args.compose(0, '')
+        )
+        repr = '{}\n csv_file:\n\t{}\n console_file\n\t{}'.format(
+            repr,
+            '\n\t'.join(self.runset.csv_files),
+            '\n\t'.join(self.runset.console_files),
+        )
+        return repr
+
     def _set_mle_attrs(self, sample_csv_0: str) -> None:
         meta = scan_optimize_csv(sample_csv_0)
         self._column_names = meta['column_names']
@@ -521,6 +538,19 @@ class StanQuantities(object):
             )
         self.runset = runset
         self._column_names = None
+
+    def __repr__(self) -> str:
+        repr = 'StanQuantities: model={} chains={}{}'.format(
+            self.runset.model,
+            self.runset.chains,
+            self.runset._args.method_args.compose(0, ''),
+        )
+        repr = '{}\n csv_files:\n\t{}\n console_files\n\t{}'.format(
+            repr,
+            '\n\t'.join(self.runset.csv_files),
+            '\n\t'.join(self.runset.console_files),
+        )
+        return repr
 
     @property
     def chains(self) -> int:
@@ -594,6 +624,17 @@ class StanVariational(object):
         self._column_names = ()
         self._variational_mean = {}
         self._output_samples = None
+
+    def __repr__(self) -> str:
+        repr = 'StanVariational: model={}{}'.format(
+            self.runset.model, self.runset._args.method_args.compose(0, '')
+        )
+        repr = '{}\n csv_file:\n\t{}\n console_file\n\t{}'.format(
+            repr,
+            '\n\t'.join(self.runset.csv_files),
+            '\n\t'.join(self.runset.console_files),
+        )
+        return repr
 
     def _set_variational_attrs(self, sample_csv_0: str) -> None:
         meta = scan_variational_csv(sample_csv_0)

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -67,13 +67,13 @@ class RunSet(object):
         ]
         self._retcodes = [-1 for _ in range(chains)]
 
-    def __repr__(self) -> str:		
-         repr = 'RunSet: chains={}'.format(self._chains)		
-         repr = '{}\n cmd:\n\t{}'.format(repr, self._cmds[0])
-         repr = '{}\n csv_files:\n\t{}\n console_files:\n\t{}'.format(		
-             repr, '\n\t'.join(self._csv_files), '\n\t'.join(self._console_files)		
-         )		
-         return repr
+    def __repr__(self) -> str:
+        repr = 'RunSet: chains={}'.format(self._chains)
+        repr = '{}\n cmd:\n\t{}'.format(repr, self._cmds[0])
+        repr = '{}\n csv_files:\n\t{}\n console_files:\n\t{}'.format(
+            repr, '\n\t'.join(self._csv_files), '\n\t'.join(self._console_files)
+            )
+        return repr
 
     @property
     def model(self) -> str:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -67,6 +67,14 @@ class RunSet(object):
         ]
         self._retcodes = [-1 for _ in range(chains)]
 
+    def __repr__(self) -> str:		
+         repr = 'RunSet: chains={}'.format(self._chains)		
+         repr = '{}\n cmd: {}'.format(repr, self._cmds[0])
+         repr = '{}\n csv_files={}\n console_files={}'.format(		
+             repr, '\n\t'.join(self._csv_files), '\n\t'.join(self._console_files)		
+         )		
+         return repr
+
     @property
     def model(self) -> str:
         """Stan model name."""

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -69,8 +69,8 @@ class RunSet(object):
 
     def __repr__(self) -> str:		
          repr = 'RunSet: chains={}'.format(self._chains)		
-         repr = '{}\n cmd: {}'.format(repr, self._cmds[0])
-         repr = '{}\n csv_files={}\n console_files={}'.format(		
+         repr = '{}\n cmd:\n\t{}'.format(repr, self._cmds[0])
+         repr = '{}\n csv_files:\n\t{}\n console_files:\n\t{}'.format(		
              repr, '\n\t'.join(self._csv_files), '\n\t'.join(self._console_files)		
          )		
          return repr

--- a/cmdstanpy_tutorial.ipynb
+++ b/cmdstanpy_tutorial.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "#### Run the NUTS-HMC sampler to obtain the full posterior density\n",
     "\n",
-    "  + The `Model` class method `sample` invokes Stan's NUTS-HMC sampler which conditions the model on the input data and returns a `StanFit` object. The `StanFit` object contains the set of draws from the posterior plus metadata.\n",
+    "  + The `Model` class method `sample` invokes Stan's NUTS-HMC sampler which conditions the model on the input data and returns a `StanMCMC` object. The `StanMCMC` object contains the set of draws from the posterior plus metadata.\n",
     "  + Runs any number of chains - default is 4 chains.\n",
     "  + The output of each chain is stored on disk as a Stan csv file.\n",
     "\n",
@@ -34,8 +34,8 @@
     "\n",
     "### Summarize and check the sample\n",
     "\n",
-    "   + The `StanFit` class method `summary` invokes CmdStan's `stansummary` utility. Returns a Pandas DataFrame with estimates of posterior means, standard deviations, Monte-Carlo standard error, effective sample size, and convergence diagnostic statistic for all parameters in the model.\n",
-    "   + The `StanFit` class method `diagnose` invokes CmdStan's `diagnose` utility which checks for the following problems:\n",
+    "   + The `StanMCMC` class method `summary` invokes CmdStan's `stansummary` utility. Returns a Pandas DataFrame with estimates of posterior means, standard deviations, Monte-Carlo standard error, effective sample size, and convergence diagnostic statistic for all parameters in the model.\n",
+    "   + The `StanMCMC` class method `diagnose` invokes CmdStan's `diagnose` utility which checks for the following problems:\n",
     "    + transitions that hit the maximum treedepth\n",
     "    + divergent transitions\n",
     "    + low E-BFMI values (sampler transitions HMC potential energy)\n",
@@ -44,7 +44,7 @@
     "   + See the Stan reference manual section on [posterior analysis](https://mc-stan.org/docs/reference-manual/analysis-chapter.html) for further details.\n",
     "\n",
     "###  Assemble the sample in-memory\n",
-    "  + The resulting sample is accessed via the `StanFit` object:\n",
+    "  + The resulting sample is accessed via the `StanMCMC` object:\n",
     "    + `sample`  - all draws from all chains, stored as a 3-D numpy.ndarray.\n",
     "    + `chains` - number of chains run by sampler\n",
     "    + `draws` - draws per chain\n",
@@ -96,7 +96,7 @@
    "source": [
     "import os\n",
     "import os.path\n",
-    "from cmdstanpy import Model, StanFit, cmdstan_path"
+    "from cmdstanpy import Model, StanMCMC, cmdstan_path"
    ]
   },
   {
@@ -184,7 +184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Model` method `sample` runs the NUTS-HMC sampler and returns a `StanFit` object.  By default, `sample` runs 4 sampler chains."
+    "The `Model` method `sample` runs the NUTS-HMC sampler and returns a `StanMCMC` object.  By default, `sample` runs 4 sampler chains."
    ]
   },
   {
@@ -200,7 +200,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Access the sample: the `StanFit` object attributes and methods"
+    "### Access the sample: the `StanMCMC` object attributes and methods"
    ]
   },
   {
@@ -209,7 +209,7 @@
    "source": [
     "#### Summarize the results\n",
     "\n",
-    "The `StanFit` method `summary` returns output of CmdStan bin/stansummary as pandas.DataFrame.  The `summary` report provides estimates of both the parameter value and the goodness of fit."
+    "The `StanMCMC` method `summary` returns output of CmdStan bin/stansummary as pandas.DataFrame.  The `summary` report provides estimates of both the parameter value and the goodness of fit."
    ]
   },
   {
@@ -227,7 +227,7 @@
    "source": [
     "#### Run sampler diagnostics\n",
     "\n",
-    "The `StanFit` method `diagnose` prints the output of CmdStan bin/stansummary to the console.  This is useful when the summary report shows `R_hat` values outside of the range of .99 to 1.01, or the number of effective samples (`N_eff` value) is below 5% of the total draws in the sample. "
+    "The `StanMCMC` method `diagnose` prints the output of CmdStan bin/stansummary to the console.  This is useful when the summary report shows `R_hat` values outside of the range of .99 to 1.01, or the number of effective samples (`N_eff` value) is below 5% of the total draws in the sample. "
    ]
   },
   {
@@ -245,7 +245,7 @@
    "source": [
     "#### Assemble all draws from all chains as an in-memory pandas DataFrame\n",
     "\n",
-    "The `StanFit` method `get_drawset` returns a pandas.DataFrame, one draw per row."
+    "The `StanMCMC` method `get_drawset` returns a pandas.DataFrame, one draw per row."
    ]
   },
   {
@@ -312,7 +312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `StanFit` property `sample` is a 3-D numpy ndarray which contains all draws across all chains.  This array is created only as needed; therefore the first time that this property is accessed CmdStanPy will read in the contents of the sampler's csv output files.  Because the csv output files also contain stepsize and metric information, the `stepsize` and `metric` arrays will also be created.\n",
+    "The `StanMCMC` property `sample` is a 3-D numpy ndarray which contains all draws across all chains.  This array is created only as needed; therefore the first time that this property is accessed CmdStanPy will read in the contents of the sampler's csv output files.  Because the csv output files also contain stepsize and metric information, the `stepsize` and `metric` arrays will also be created.\n",
     "\n",
     "The numpy ndarray is stored column major format so that values for each parameter are stored contiguously in memory, likewise all draws from a chain are contiguous.  Thus the dimensions of the ndarray are arranged as follows:  (draws, chains, columns):"
    ]
@@ -355,7 +355,7 @@
     "\n",
     "##### stepsize\n",
     "\n",
-    "The `StanFit` property `stepsize` property is a 1-D numpy ndarray which contains the stepsize used by the sampler for each chain.  This array is created at the same time as the `sample` and `metric` arrays are created.\n",
+    "The `StanMCMC` property `stepsize` property is a 1-D numpy ndarray which contains the stepsize used by the sampler for each chain.  This array is created at the same time as the `sample` and `metric` arrays are created.\n",
     "\n",
     "At the end of adaptation, the stepsize for the 4 chains in this example is:"
    ]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,10 +13,10 @@ Model
 .. autoclass:: cmdstanpy.Model
    :members:
 
-StanFit
+StanMCMC
 =======
 
-.. autoclass:: cmdstanpy.StanFit
+.. autoclass:: cmdstanpy.StanMCMC
    :members:
 
 StanMLE

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -176,7 +176,7 @@ Run the HMC-NUTS sampler
 ------------------------
 
 The ``Model`` method ``sample`` runs the Stan HMC-NUTS sampler on the model and data
-and returns a ``StanFit`` object:
+and returns a ``StanMCMC`` object:
 
 .. code-block:: python
 
@@ -192,7 +192,7 @@ when the current Python session is terminated.
 Summarize or save the results
 -----------------------------
 
-The ``StanFit`` object records the results of each sampler chain.
+The ``StanMCMC`` object records the results of each sampler chain.
 The ``get_drawset`` method returns the draws from
 all chains as a ``pandas.DataFrame``, one draw per row, one column per
 model parameter, transformed parameter, generated quantity variable.
@@ -204,12 +204,12 @@ columns to just the specified parameter names.
     bern_fit.get_drawset(params=['theta'])
 
 Underlyingly, this information is stored in the ``sample`` property
-of a ``StanFit`` object as a 3-D ``numpy.ndarray`` (i.e., a multi-dimensional array)
+of a ``StanMCMC`` object as a 3-D ``numpy.ndarray`` (i.e., a multi-dimensional array)
 with dimensions: (draws, chains, columns).
 Python's index slicing operations can be used to access the information by chain.
 For example, to select all draws and all output columns from the first chain,
 we specify the chain index (2nd index dimension).  As arrays indexing starts at 0,
-the index '0' corresponds to the first chain in the ``StanFit``:
+the index '0' corresponds to the first chain in the ``StanMCMC``:
 
 .. code-block:: python
 
@@ -222,7 +222,7 @@ the index '0' corresponds to the first chain in the ``StanFit``:
 
 CmdStan is distributed with a posterior analysis utility ``stansummary``
 that reads the outputs of all chains and computes summary statistics
-on the model fit for all parameters. The ``StanFit`` method ``summary``
+on the model fit for all parameters. The ``StanMCMC`` method ``summary``
 runs the CmdStan ``stansummary`` utility and returns the output as a pandas.DataFrame:
 
 .. code-block:: python
@@ -239,7 +239,7 @@ potential problems:
 + Low effective sample sizes
 + High R-hat values
 
-The ``StanFit`` method ``diagnose`` runs the CmdStan ``diagnose`` utility
+The ``StanMCMC`` method ``diagnose`` runs the CmdStan ``diagnose`` utility
 and prints the output to the console.
 
 .. code-block:: python

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -49,6 +49,8 @@ class GenerateQuantitiesTest(unittest.TestCase):
         self.assertEqual(
             bern_gqs.runset._args.method, Method.GENERATE_QUANTITIES
         )
+        self.assertIn('StanQuantities: model=bernoulli_ppc', bern_gqs.__repr__())
+        self.assertIn('method=generate_quantities', bern_gqs.__repr__())
 
         # check results - ouput files, quantities of interest, draws
         self.assertEqual(bern_gqs.runset.chains, 4)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -33,6 +33,9 @@ class StanMLETest(unittest.TestCase):
         )
         runset = RunSet(args=cmdstan_args, chains=1)
         mle = StanMLE(runset)
+        self.assertIn('StanMLE: model=rosenbrock', mle.__repr__())
+        self.assertIn('method=optimize', mle.__repr__())
+
         self.assertEqual(mle._column_names,())
         self.assertEqual(mle._mle,{})
 

--- a/test/test_runset.py
+++ b/test/test_runset.py
@@ -22,6 +22,9 @@ class RunSetTest(unittest.TestCase):
             method_args=sampler_args,
         )
         runset = RunSet(args=cmdstan_args, chains=4)
+        self.assertIn('RunSet: chains=4', runset.__repr__())
+        self.assertIn('method=sample', runset.__repr__())
+
         retcodes = runset._retcodes
         self.assertEqual(4, len(retcodes))
         for i in range(len(retcodes)):

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -7,7 +7,7 @@ from multiprocessing import cpu_count
 
 from cmdstanpy.cmdstan_args import Method, SamplerArgs, CmdStanArgs
 from cmdstanpy.utils import EXTENSION
-from cmdstanpy.stanfit import RunSet, StanFit
+from cmdstanpy.stanfit import RunSet, StanMCMC
 from cmdstanpy.model import Model
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -18,14 +18,16 @@ badfiles_path = os.path.join(datafiles_path, 'runset-bad')
 class SampleTest(unittest.TestCase):
     def test_bernoulli_good(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
-        exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
-        bern_model = Model(stan_file=stan, exe_file=exe)
+        bern_model = Model(stan_file=stan)
         bern_model.compile()
 
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         bern_fit = bern_model.sample(
             data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100
         )
+        self.assertIn('StanMCMC: model=bernoulli', bern_fit.__repr__())
+        self.assertIn('method=sample', bern_fit.__repr__())
+
         self.assertEqual(bern_fit.runset._args.method, Method.SAMPLE)
 
         for i in range(bern_fit.runset.chains):
@@ -90,8 +92,7 @@ class SampleTest(unittest.TestCase):
 
     def test_bernoulli_bad(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
-        exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
-        bern_model = Model(stan_file=stan, exe_file=exe)
+        bern_model = Model(stan_file=stan)
         bern_model.compile()
 
         with self.assertRaisesRegex(Exception, 'Error during sampling'):
@@ -245,7 +246,7 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(datagen_fit.stepsize, None)
 
 
-class StanFitTest(unittest.TestCase):
+class StanMCMCTest(unittest.TestCase):
     def test_validate_good_run(self):
         # construct fit using existing sampler output
         exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
@@ -270,7 +271,7 @@ class StanFitTest(unittest.TestCase):
             runset._set_retcode(i, 0)
         self.assertTrue(runset._check_retcodes())
 
-        fit = StanFit(runset)
+        fit = StanMCMC(runset)
         fit._validate_csv_files()
         self.assertEqual(100, fit.draws)
         self.assertEqual(8, len(fit.column_names))
@@ -300,7 +301,7 @@ class StanFitTest(unittest.TestCase):
     def test_validate_big_run(self):
         exe = os.path.join(
             datafiles_path, 'bernoulli' + EXTENSION
-        )  # fake out validation
+        )
         output = os.path.join(datafiles_path, 'runset-big', 'output_icar_nyc')
         sampler_args = SamplerArgs()
         cmdstan_args = CmdStanArgs(
@@ -312,7 +313,7 @@ class StanFitTest(unittest.TestCase):
             method_args=sampler_args,
         )
         runset = RunSet(args=cmdstan_args, chains=2)
-        fit = StanFit(runset)
+        fit = StanMCMC(runset)
         fit._validate_csv_files()
         sampler_state = [
             'lp__',
@@ -346,9 +347,8 @@ class StanFitTest(unittest.TestCase):
 
     def test_save_csv(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
-        exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        bern_model = Model(stan_file=stan, exe_file=exe)
+        bern_model = Model(stan_file=stan)
         bern_model.compile()
         bern_fit = bern_model.sample(
             data=jdata, chains=4, cores=2, seed=12345, sampling_iters=200
@@ -400,7 +400,7 @@ class StanFitTest(unittest.TestCase):
             method_args=sampler_args,
         )
         sampler_runset = RunSet(args=cmdstan_args, chains=1)
-        fit = StanFit(sampler_runset)
+        fit = StanMCMC(sampler_runset)
         # TODO - use cmdstan test files instead
         expected = '\n'.join(
             [
@@ -452,7 +452,7 @@ class StanFitTest(unittest.TestCase):
         for i in range(len(retcodes)):
             runset._set_retcode(i, 0)
         self.assertTrue(runset._check_retcodes())
-        fit = StanFit(runset)
+        fit = StanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'header mismatch'):
             fit._validate_csv_files()
 
@@ -472,7 +472,7 @@ class StanFitTest(unittest.TestCase):
         for i in range(len(retcodes)):
             runset._set_retcode(i, 0)
         self.assertTrue(runset._check_retcodes())
-        fit = StanFit(runset)
+        fit = StanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'draws'):
             fit._validate_csv_files()
 
@@ -492,7 +492,7 @@ class StanFitTest(unittest.TestCase):
         for i in range(len(retcodes)):
             runset._set_retcode(i, 0)
         self.assertTrue(runset._check_retcodes())
-        fit = StanFit(runset)
+        fit = StanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'bad draw'):
             fit._validate_csv_files()
 

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -33,6 +33,8 @@ class StanVariationalTest(unittest.TestCase):
         )
         runset = RunSet(args=cmdstan_args, chains=1)
         vi = StanVariational(runset)
+        self.assertIn('StanVariational: model=eta_should_be_big', vi.__repr__())
+        self.assertIn('method=variational', vi.__repr__())
 
         # check StanVariational.__init__ state
         self.assertEqual(vi._column_names,())


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Changed name of class `StanFit` to `StanMCMC` in code, docs, and ipython notebooks.

Added `__repr__` function to classes `StanMCMC`, `StanMLE`, `StanQuantities`, and `StanVariational`.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

