### PR TITLE
Define w_iters if warmup_iters is defined

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -495,6 +495,8 @@ class CmdStanModel(object):
                     num_updates = 200
                     if warmup_iters is None:
                         w_iters = 1000
+                    else:
+                        w_iters = warmup_iters
                 s_iters = sampling_iters
                 if s_iters is None:
                     s_iters = 1000


### PR DESCRIPTION
Fixes #142 

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Minimal change, define w_iters if warmup_iters is defined.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

