### PR TITLE
Enable TBB on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,9 +61,11 @@ install:
   - "python -m pip install --quiet -r requirements.txt"
   - "python -m pip install --quiet -r requirements-test.txt"
 
-  - "python .\\cmdstanpy\\install_cmdstan.py"
-
   - "python -m pip install --quiet ."
+
+  - "python -m cmdstanpy.install_cmdstan"
+  - "python ./scripts/clean_examples.py"
+
   - "pip freeze"
 
 build: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,3 +78,4 @@ test_script:
   - "python -m pytest ../test"
   - "python -m pip install -r ../requirements-optional.txt"
   - "python ../test/example_script.py"
+  - "python ../scripts/clean_examples.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script:
   - pytest ../test
   - python -m pip install -r ../requirements-optional.txt
   - python ../test/example_script.py
+  - python ../scripts/clean_examples.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ cache:
 install:
   - pip install --quiet -r requirements.txt
   - pip install --quiet -r requirements-test.txt
-  - python cmdstanpy/install_cmdstan.py
   # install cmdstanpy
   - pip install .
+  # install cmdstan
+  - python -m cmdstanpy.install_cmdstan
+  - python ./scripts/clean_examples.py
 
 after install:
 

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -182,12 +182,13 @@ class SamplerArgs(object):
                 )
 
         if self.fixed_param and (
-                (self.warmup_iters is not None and self.warmup_iters > 0) or
-                self.save_warmup or
-                self.max_treedepth is not None or
-                self.metric is not None or
-                self.step_size is not None or
-                self.adapt_delta is not None):
+            (self.warmup_iters is not None and self.warmup_iters > 0)
+            or self.save_warmup
+            or self.max_treedepth is not None
+            or self.metric is not None
+            or self.step_size is not None
+            or self.adapt_delta is not None
+        ):
             raise ValueError(
                 'when fixed_param=True, cannot specify warmup or'
                 ' or any adaptation parameters.'

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -45,7 +45,11 @@ def install_version(cmdstan_version):
         make = os.getenv('MAKE', 'make')
         cmd = [make, 'build']
         proc = subprocess.Popen(
-            cmd, cwd=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd,
+            cwd=None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ,
         )
         stdout, stderr = proc.communicate()
         if proc.returncode:
@@ -61,7 +65,11 @@ def install_version(cmdstan_version):
             ).as_posix(),
         ]
         proc = subprocess.Popen(
-            cmd, cwd=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd,
+            cwd=None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ,
         )
         stdout, stderr = proc.communicate()
         if proc.returncode:

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -42,7 +42,9 @@ def usage():
 def install_version(cmdstan_version):
     with pushd(cmdstan_version):
         print('Building {} binaries'.format(cmdstan_version))
-        make = os.getenv('MAKE', 'make')
+        make = os.getenv(
+            'MAKE', 'make' if platform.system() != "Windows" else "mingw32-make"
+        )
         cmd = [make, 'build']
         proc = subprocess.Popen(
             cmd,

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -76,7 +76,11 @@ def install_version(installation_dir, installation_file, version, silent):
         cmd.extend(get_config(installation_dir, silent))
         print(' '.join(cmd))
         proc = subprocess.Popen(
-            cmd, cwd=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd,
+            cwd=None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ,
         )
         while proc.poll() is None:
             output = proc.stdout.readline().decode('utf-8').strip()

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -89,7 +89,9 @@ class Model(object):
             # Add tbb to the $PATH on Windows
             libtbb = os.getenv("STAN_TBB")
             if libtbb is None:
-                libtbb = os.path.join(cmdstan_path(), "stan","lib","stan_math", "lib", "tbb")
+                libtbb = os.path.join(
+                    cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb"
+                )
             os.environ["PATH"] = "{};{}".format(libtbb, os.getenv("PATH"))
 
     def __repr__(self) -> str:
@@ -125,9 +127,7 @@ class Model(object):
         return self._exe_file
 
     def compile(
-        self,
-        opt_lvl: int = 3,
-        include_paths: List[str] = None,
+        self, opt_lvl: int = 3, include_paths: List[str] = None
     ) -> None:
         """
         Compile the given Stan program file.  Translates the Stan code to
@@ -196,7 +196,12 @@ class Model(object):
                         compilation_failed = True
 
                 if not compilation_failed:
-                    make = os.getenv('MAKE', 'make' if platform.system() != "Windows" else "mingw32-make")
+                    make = os.getenv(
+                        'MAKE',
+                        'make'
+                        if platform.system() != "Windows"
+                        else "mingw32-make",
+                    )
                     cmd = [make, 'O={}'.format(opt_lvl), exe_file]
                     self._logger.info('compiling c++')
                     try:
@@ -211,10 +216,10 @@ class Model(object):
                     new_exec_name = (
                         os.path.basename(os.path.splitext(self._stan_file)[0])
                         + EXTENSION
-                        )
+                    )
                     self._exe_file = os.path.join(
                         original_target_dir, new_exec_name
-                        )
+                    )
                     shutil.copy(exe_file, self._exe_file)
                 else:
                     self._exe_file = exe_file
@@ -813,7 +818,10 @@ class Model(object):
         self._logger.info('start chain %u', idx + 1)
         self._logger.debug('sampling: %s', cmd)
         proc = subprocess.Popen(
-            cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ,
+            cmd.split(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ,
         )
         if pbar:
             stdout_pbar = self._read_progress(proc, pbar, idx)

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -72,7 +72,7 @@ class RunSet(object):
         repr = '{}\n cmd:\n\t{}'.format(repr, self._cmds[0])
         repr = '{}\n csv_files:\n\t{}\n console_files:\n\t{}'.format(
             repr, '\n\t'.join(self._csv_files), '\n\t'.join(self._console_files)
-            )
+        )
         return repr
 
     @property

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -340,9 +340,7 @@ def jsondump(path: str, data: Dict) -> None:
         if isinstance(val, Sequence) and not val:
             raise ValueError(
                 'variable: {}, error: '
-                'empty array not allowed with JSON interface'.format(
-                    val
-                )
+                'empty array not allowed with JSON interface'.format(val)
             )
     with open(path, 'w') as fd:
         json.dump(data, fd)
@@ -708,7 +706,11 @@ def do_command(cmd: str, cwd: str = None, logger: logging.Logger = None) -> str:
     if logger:
         logger.debug('cmd: %s', cmd)
     proc = subprocess.Popen(
-        cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ,
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ,
     )
     stdout, stderr = proc.communicate()
     if proc.returncode:
@@ -799,7 +801,9 @@ def install_cmdstan(version: str = None, dir: str = None) -> bool:
         cmd.extend(['--version', version])
     if dir is not None:
         cmd.extend(['--dir', dir])
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ
+    )
     while proc.poll() is None:
         output = proc.stdout.readline().decode('utf-8').strip()
         if output:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -708,7 +708,7 @@ def do_command(cmd: str, cwd: str = None, logger: logging.Logger = None) -> str:
     if logger:
         logger.debug('cmd: %s', cmd)
     proc = subprocess.Popen(
-        cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ,
     )
     stdout, stderr = proc.communicate()
     if proc.returncode:

--- a/scripts/clean_examples.py
+++ b/scripts/clean_examples.py
@@ -4,7 +4,7 @@ from cmdstanpy import cmdstan_path
 
 def clean_examples():
     cmdstan_examples = s.path.join(cmdstan_path(), "examples")
-    for root, _, files in os.walk(cmdstan_examples)
+    for root, _, files in os.walk(cmdstan_examples):
         for filename in files:
             _, ext = os.path.splitext(filename)
             if ext.lower() in (".o", ".hpp", ".exe", ""):

--- a/scripts/clean_examples.py
+++ b/scripts/clean_examples.py
@@ -11,4 +11,4 @@ def clean_examples():
                 os.remove(os.path.join(root, filename))
 
 if __name__ == "__main__":
-    cmdstan_examples()
+    clean_examples()

--- a/scripts/clean_examples.py
+++ b/scripts/clean_examples.py
@@ -1,0 +1,14 @@
+import glob
+import os
+from cmdstanpy import cmdstan_path
+
+def clean_examples():
+    cmdstan_examples = s.path.join(cmdstan_path(), "examples")
+    for root, _, files in os.walk(cmdstan_examples)
+        for filename in files:
+            _, ext = os.path.splitext(filename)
+            if ext.lower() in (".o", ".hpp", ".exe", ""):
+                os.remove(os.path.join(root, filename))
+
+if __name__ == "__main__":
+    cmdstan_examples()

--- a/scripts/clean_examples.py
+++ b/scripts/clean_examples.py
@@ -2,15 +2,19 @@ import glob
 import os
 from cmdstanpy import cmdstan_path
 
+
 def clean_examples():
     cmdstan_examples = os.path.join(cmdstan_path(), "examples")
     for root, _, files in os.walk(cmdstan_examples):
         for filename in files:
             _, ext = os.path.splitext(filename)
-            if ext.lower() in (".o", ".hpp", ".exe", ""):
+            if ext.lower() in (".o", ".hpp", ".exe", "") and (
+                filename != ".gitignore"
+            ):
                 filepath = os.path.join(root, filename)
                 os.remove(filepath)
                 print("Deleted {}".format(filepath))
+
 
 if __name__ == "__main__":
     clean_examples()

--- a/scripts/clean_examples.py
+++ b/scripts/clean_examples.py
@@ -8,7 +8,9 @@ def clean_examples():
         for filename in files:
             _, ext = os.path.splitext(filename)
             if ext.lower() in (".o", ".hpp", ".exe", ""):
-                os.remove(os.path.join(root, filename))
+                filepath = os.path.join(root, filename)
+                os.remove(filepath)
+                print("Deleted {}".format(filepath))
 
 if __name__ == "__main__":
     clean_examples()

--- a/scripts/clean_examples.py
+++ b/scripts/clean_examples.py
@@ -3,7 +3,7 @@ import os
 from cmdstanpy import cmdstan_path
 
 def clean_examples():
-    cmdstan_examples = s.path.join(cmdstan_path(), "examples")
+    cmdstan_examples = os.path.join(cmdstan_path(), "examples")
     for root, _, files in os.walk(cmdstan_examples):
         for filename in files:
             _, ext = os.path.splitext(filename)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add libTBB to $PATH on Windows and fix the env variable handling for subprocess.
Changes the default `make` to `mingw32-make` on Windows.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

