### PR TITLE
Feature/153 compile model on instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ The CmdStanPy, CmdStan, and the core Stan C++ code are licensed under new BSD.
     # specify Stan file, create, compile CmdStanModel object
     bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
-    bernoulli_model.compile()
 
 
     # specify data, fit the model

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -43,7 +43,7 @@ def install_version(cmdstan_version):
     with pushd(cmdstan_version):
         print('Building {} binaries'.format(cmdstan_version))
         make = os.getenv(
-            'MAKE', 'make' if platform.system() != "Windows" else "mingw32-make"
+            'MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make'
         )
         cmd = [make, 'build']
         proc = subprocess.Popen(

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -83,6 +83,15 @@ class CmdStanModel(object):
                 )
             self._name, _ = os.path.splitext(filename)
             self._exe_file = None
+            # if program has #includes, search program dir
+            with open(stan_file, 'r') as fp:
+                program = fp.read()
+            if '#include' in program:
+                path, _ = os.path.split(stan_file)
+                if include_paths is None:
+                    include_paths = []
+                if path not in include_paths:
+                    include_paths.append(path)
 
         if exe_file is not None:
             if not os.path.exists(exe_file):
@@ -106,15 +115,7 @@ class CmdStanModel(object):
                     'invalid include paths: {}'.format(', '.join(bad_paths))
                 )
             self._include_paths = include_paths
-        elif stan_file is not None:
-            # if program has #includes, search program dir
-            with open(stan_file, 'r') as fp:
-                program = fp.read()
-            if '#include' in program:
-                self._include_paths = []
-                path, _ = os.path.split(stan_file)
-                self._include_paths.append(path)
-        
+
         if platform.system() == 'Windows':
             # Add tbb to the $PATH on Windows
             libtbb = os.getenv('STAN_TBB')

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -42,13 +42,13 @@ class CmdStanModel(object):
     Stan model.
 
     + Stores pathnames to Stan program, compiled executable, and list of
-    paths for directories which contain included Stan programs.
+        paths for directories which contain included Stan programs.
 
     + Provides functions to compile the model and perform inference on the
-    model given data.
+        model given data.
 
     + By default, compiles model on instantiation - override with argument
-    ``compile=False``
+        ``compile=False``
     """
 
     def __init__(

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -71,8 +71,6 @@ class CmdStanModel(object):
                 raise ValueError(
                     'must specify Stan source or executable program file'
                 )
-            else:
-                self._stan_file = None
         else:
             if not os.path.exists(stan_file):
                 raise ValueError('no such file {}'.format(self._stan_file))

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -97,31 +97,28 @@ class CmdStanModel(object):
                     )
             self._exe_file = exe_file
         if include_paths is not None:
-            bad_paths = [
-                d for d in include_paths if not os.path.exists(d)
-            ]
+            bad_paths = [d for d in include_paths if not os.path.exists(d)]
             if any(bad_paths):
                 raise ValueError(
-                    'invalid include paths: {}'.format(
-                        ', '.join(bad_paths)
-                        )
+                    'invalid include paths: {}'.format(', '.join(bad_paths))
                 )
             self._include_paths = include_paths
-        if platform.system() == "Windows":
+        if platform.system() == 'Windows':
             # Add tbb to the $PATH on Windows
-            libtbb = os.getenv("STAN_TBB")
+            libtbb = os.getenv('STAN_TBB')
             if libtbb is None:
                 libtbb = os.path.join(
-                    cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb"
+                    cmdstan_path(), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
                 )
-            os.environ["PATH"] = "{};{}".format(libtbb, os.getenv("PATH"))
+            os.environ['PATH'] = '{};{}'.format(libtbb, os.getenv('PATH'))
         if compile and self._exe_file is None:
             self.compile()
             if self._exe_file is None:
                 raise ValueError(
-                    'unable to compile Stan model file: {}'.format(self._stan_file)
+                    'unable to compile Stan model file: {}'.format(
+                        self._stan_file
+                    )
                 )
-            
 
     def __repr__(self) -> str:
         return 'CmdStanModel(name={},  stan_file="{}", exe_file="{}")'.format(
@@ -159,9 +156,7 @@ class CmdStanModel(object):
     def include_paths(self) -> List[str]:
         return self._include_paths
 
-    def compile(
-        self, opt_lvl: int = 3, force: bool = False
-    ) -> None:
+    def compile(self, opt_lvl: int = 3, force: bool = False) -> None:
         """
         Compile the given Stan program file.  Translates the Stan code to
         C++, then calls the C++ compiler.
@@ -214,7 +209,9 @@ class CmdStanModel(object):
                     ]
                     if self._include_paths is not None:
                         bad_paths = [
-                            d for d in self._include_paths if not os.path.exists(d)
+                            d
+                            for d in self._include_paths
+                            if not os.path.exists(d)
                         ]
                         if any(bad_paths):
                             raise ValueError(
@@ -225,7 +222,10 @@ class CmdStanModel(object):
                         cmd.append(
                             '--include_paths='
                             + ','.join(
-                                (Path(p).as_posix() for p in self._include_paths)
+                                (
+                                    Path(p).as_posix()
+                                    for p in self._include_paths
+                                )
                             )
                         )
                     try:
@@ -238,8 +238,8 @@ class CmdStanModel(object):
                     make = os.getenv(
                         'MAKE',
                         'make'
-                        if platform.system() != "Windows"
-                        else "mingw32-make",
+                        if platform.system() != 'Windows'
+                        else 'mingw32-make',
                     )
                     cmd = [make, 'O={}'.format(opt_lvl), exe_file]
                     self._logger.info('compiling c++')

--- a/cmdstanpy_tutorial.ipynb
+++ b/cmdstanpy_tutorial.ipynb
@@ -137,7 +137,6 @@
    "outputs": [],
    "source": [
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
-    "bernoulli_model.compile()\n",
     "print(bernoulli_model)"
    ]
   },

--- a/docs/generate_quantities.rst
+++ b/docs/generate_quantities.rst
@@ -91,9 +91,8 @@ The first step is to fit model ``bernoulli`` to the data:
     bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')
     bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')
 
-    # instantiate bernoulli model, compile Stan program
+    # instantiate, compile bernoulli model
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
-    bernoulli_model.compile()
 
     # fit the model to the data
     bern_fit = bernoulli_model.sample(data=bernoulli_data)

--- a/docs/hello_world.rst
+++ b/docs/hello_world.rst
@@ -16,7 +16,7 @@ Specify a Stan model
 ^^^^^^^^^^^^^^^^^^^^
 
 The ``CmdStanModel`` class specifies the Stan program and its corresponding compiled executable.
-The method ``compile`` is used to compile or or recompile a Stan program.
+By default, the Stan program is compiled on instantiation.
 
 .. code-block:: python
 
@@ -25,16 +25,16 @@ The method ``compile`` is used to compile or or recompile a Stan program.
 
     bernoulli_stan = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_stan)
-    bernoulli_model.compile()
 
-If you already have a compiled executable, you can construct a ``CmdStanModel`` object directly:
+The ``CmdStanModel`` class provides properties and functions to inspect the model code and filepaths.
 
 .. code-block:: python
 
-    bernoulli_model = CmdStanModel(
-            stan_file=os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan'),
-            exe_file=os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli')
-            )
+    bernoulli_model.name
+    bernoulli_model.stan_file
+    bernoulli_model.exe_file
+    bernoulli_model.code()
+
 
             
 Run the HMC-NUTS sampler

--- a/docs/notebooks/MCMC Sampling.ipynb
+++ b/docs/notebooks/MCMC Sampling.ipynb
@@ -54,7 +54,6 @@
     "\n",
     "# instantiate bernoulli model, compile Stan program\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
-    "bernoulli_model.compile()\n",
     "\n",
     "# run CmdStan's sample method, returns object `CmdStanMCMC`\n",
     "bern_fit = bernoulli_model.sample(data=bernoulli_data)\n",
@@ -80,7 +79,6 @@
    "outputs": [],
    "source": [
     "datagen_model = CmdStanModel(stan_file='bernoulli_datagen.stan')\n",
-    "datagen_model.compile()\n",
     "\n",
     "sim_data = datagen_model.sample(fixed_param=True)\n",
     "sim_data.summary()"

--- a/docs/notebooks/MCMC Sampling.ipynb
+++ b/docs/notebooks/MCMC Sampling.ipynb
@@ -52,7 +52,7 @@
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
     "\n",
-    "# instantiate compile bernoulli model\n",
+    "# instantiate, compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "\n",
     "# run CmdStan's sample method, returns object `CmdStanMCMC`\n",

--- a/docs/notebooks/MCMC Sampling.ipynb
+++ b/docs/notebooks/MCMC Sampling.ipynb
@@ -52,7 +52,7 @@
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
     "\n",
-    "# instantiate bernoulli model, compile Stan program\n",
+    "# instantiate compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "\n",
     "# run CmdStan's sample method, returns object `CmdStanMCMC`\n",

--- a/docs/notebooks/Maximum Likelihood Estimation.ipynb
+++ b/docs/notebooks/Maximum Likelihood Estimation.ipynb
@@ -47,7 +47,7 @@
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
     "\n",
-    "# instantiate compile bernoulli model\n",
+    "# instantiate, compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "\n",
     "# run CmdStan's otpimize method, returns object `CmdStanMLE`\n",

--- a/docs/notebooks/Maximum Likelihood Estimation.ipynb
+++ b/docs/notebooks/Maximum Likelihood Estimation.ipynb
@@ -49,7 +49,6 @@
     "\n",
     "# instantiate bernoulli model, compile Stan program\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
-    "bernoulli_model.compile()\n",
     "\n",
     "# run CmdStan's otpimize method, returns object `CmdStanMLE`\n",
     "mle = bernoulli_model.optimize(data=bernoulli_data)\n",

--- a/docs/notebooks/Maximum Likelihood Estimation.ipynb
+++ b/docs/notebooks/Maximum Likelihood Estimation.ipynb
@@ -47,7 +47,7 @@
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
     "\n",
-    "# instantiate bernoulli model, compile Stan program\n",
+    "# instantiate compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "\n",
     "# run CmdStan's otpimize method, returns object `CmdStanMLE`\n",

--- a/docs/notebooks/Run Generated Quantities.ipynb
+++ b/docs/notebooks/Run Generated Quantities.ipynb
@@ -80,7 +80,6 @@
     "\n",
     "# instantiate bernoulli model, compile Stan program\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
-    "bernoulli_model.compile()\n",
     "print(bernoulli_model.code())"
    ]
   },
@@ -154,7 +153,6 @@
    "outputs": [],
    "source": [
     "bernoulli_ppc_model = CmdStanModel(stan_file='bernoulli_ppc.stan')\n",
-    "bernoulli_ppc_model.compile()\n",
     "print(bernoulli_ppc_model.code())"
    ]
   },

--- a/docs/notebooks/Run Generated Quantities.ipynb
+++ b/docs/notebooks/Run Generated Quantities.ipynb
@@ -78,7 +78,7 @@
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
     "\n",
-    "# instantiate bernoulli model, compile Stan program\n",
+    "# instantiate compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "print(bernoulli_model.code())"
    ]

--- a/docs/notebooks/Run Generated Quantities.ipynb
+++ b/docs/notebooks/Run Generated Quantities.ipynb
@@ -78,7 +78,7 @@
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
     "\n",
-    "# instantiate compile bernoulli model\n",
+    "# instantiate, compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "print(bernoulli_model.code())"
    ]

--- a/docs/notebooks/Variational Inference.ipynb
+++ b/docs/notebooks/Variational Inference.ipynb
@@ -50,7 +50,7 @@
     "bernoulli_dir = os.path.join(cmdstan_path(), 'examples', 'bernoulli')\n",
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
-    "# instantiate compile bernoulli model\n",
+    "# instantiate, compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "# run CmdStan's variational inference method, returns object `CmdStanVB`\n",
     "vi = bernoulli_model.variational(data=bernoulli_data)"

--- a/docs/notebooks/Variational Inference.ipynb
+++ b/docs/notebooks/Variational Inference.ipynb
@@ -50,7 +50,7 @@
     "bernoulli_dir = os.path.join(cmdstan_path(), 'examples', 'bernoulli')\n",
     "bernoulli_path = os.path.join(bernoulli_dir, 'bernoulli.stan')\n",
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
-    "# instantiate bernoulli model, compile Stan program\n",
+    "# instantiate compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "# run CmdStan's variational inference method, returns object `CmdStanVB`\n",
     "vi = bernoulli_model.variational(data=bernoulli_data)"

--- a/docs/notebooks/Variational Inference.ipynb
+++ b/docs/notebooks/Variational Inference.ipynb
@@ -52,7 +52,6 @@
     "bernoulli_data = os.path.join(bernoulli_dir, 'bernoulli.data.json')\n",
     "# instantiate bernoulli model, compile Stan program\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
-    "bernoulli_model.compile()\n",
     "# run CmdStan's variational inference method, returns object `CmdStanVB`\n",
     "vi = bernoulli_model.variational(data=bernoulli_data)"
    ]
@@ -115,7 +114,6 @@
    "source": [
     "fail_stan = os.path.join(datafiles_path, 'variational', 'eta_should_fail.stan')\n",
     "fail_model = CmdStanModel(stan_file=fail_stan)\n",
-    "model.compile()\n",
     "vi = model.variational()"
    ]
   },

--- a/docs/optimize.rst
+++ b/docs/optimize.rst
@@ -47,7 +47,7 @@ In the following example, we instantiate a model and do optimization using the d
     from cmdstanpy.model import CmdStanModel
     from cmdstanpy.utils import cmdstan_path
 
-    # instantiate bernoulli model, compile Stan program
+    # instantiate compile bernoulli model
     bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
 

--- a/docs/optimize.rst
+++ b/docs/optimize.rst
@@ -50,7 +50,6 @@ In the following example, we instantiate a model and do optimization using the d
     # instantiate bernoulli model, compile Stan program
     bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
-    bernoulli_model.compile()
 
     # run CmdStan's optimize method, returns object `CmdStanMLE`
     bern_data = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.data.json')

--- a/docs/optimize.rst
+++ b/docs/optimize.rst
@@ -47,7 +47,7 @@ In the following example, we instantiate a model and do optimization using the d
     from cmdstanpy.model import CmdStanModel
     from cmdstanpy.utils import cmdstan_path
 
-    # instantiate compile bernoulli model
+    # instantiate, compile bernoulli model
     bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
 

--- a/docs/sample.rst
+++ b/docs/sample.rst
@@ -87,7 +87,7 @@ It will use 2 less than that number of cores available, as determined by Python'
     from cmdstanpy import cmdstan_path, CmdStanModel
     bernoulli_stan = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
 
-    # instantiate compile bernoulli model
+    # instantiate, compile bernoulli model
     bernoulli_model = CmdStanModel(stan_file=bernoulli_stan)
 
     # run CmdStan's sample method, returns object `CmdStanMCMC`
@@ -137,7 +137,6 @@ produced by RNG functions may change.
 
     datagen_stan = os.path.join('..', '..', 'test', 'data', 'bernoulli_datagen.stan')
     datagen_model = CmdStanModel(stan_file=datagen_stan)
-    datagen_model.compile()
 
     sim_data = datagen_model.sample(fixed_param=True)
     sim_data.summary()

--- a/docs/sample.rst
+++ b/docs/sample.rst
@@ -89,7 +89,6 @@ It will use 2 less than that number of cores available, as determined by Python'
 
     # instantiate bernoulli model, compile Stan program
     bernoulli_model = CmdStanModel(stan_file=bernoulli_stan)
-    bernoulli_model.compile()
 
     # run CmdStan's sample method, returns object `CmdStanMCMC`
     bernoulli_data = { "N" : 10, "y" : [0,1,0,0,0,0,0,0,0,1] }

--- a/docs/sample.rst
+++ b/docs/sample.rst
@@ -87,7 +87,7 @@ It will use 2 less than that number of cores available, as determined by Python'
     from cmdstanpy import cmdstan_path, CmdStanModel
     bernoulli_stan = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
 
-    # instantiate bernoulli model, compile Stan program
+    # instantiate compile bernoulli model
     bernoulli_model = CmdStanModel(stan_file=bernoulli_stan)
 
     # run CmdStan's sample method, returns object `CmdStanMCMC`

--- a/docs/variational_bayes.rst
+++ b/docs/variational_bayes.rst
@@ -78,7 +78,7 @@ In the following example, we instantiate a model and run variational inference u
     from cmdstanpy.model import CmdStanModel
     from cmdstanpy.utils import cmdstan_path
 
-    # instantiate bernoulli model, compile Stan program
+    # instantiate compile bernoulli model
     bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
 

--- a/docs/variational_bayes.rst
+++ b/docs/variational_bayes.rst
@@ -81,7 +81,6 @@ In the following example, we instantiate a model and run variational inference u
     # instantiate bernoulli model, compile Stan program
     bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
-    bernoulli_model.compile()
 
     # run CmdStan's variational inference method, returns object `CmdStanVB`
     bern_data = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.data.json')

--- a/docs/variational_bayes.rst
+++ b/docs/variational_bayes.rst
@@ -78,7 +78,7 @@ In the following example, we instantiate a model and run variational inference u
     from cmdstanpy.model import CmdStanModel
     from cmdstanpy.utils import cmdstan_path
 
-    # instantiate compile bernoulli model
+    # instantiate, compile bernoulli model
     bernoulli_path = os.path.join(cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan')
     bernoulli_model = CmdStanModel(stan_file=bernoulli_path)
 

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -20,7 +20,6 @@ class GenerateQuantitiesTest(unittest.TestCase):
     def test_gen_quantities_csv_files(self):
         stan = os.path.join(datafiles_path, 'bernoulli_ppc.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
 
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
 
@@ -68,7 +67,6 @@ class GenerateQuantitiesTest(unittest.TestCase):
     def test_gen_quantities_csv_files_bad(self):
         stan = os.path.join(datafiles_path, 'bernoulli_ppc.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
 
         # synthesize list of filenames
@@ -87,7 +85,6 @@ class GenerateQuantitiesTest(unittest.TestCase):
     def test_gen_quanties_mcmc_sample(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         bern_model = CmdStanModel(stan_file=stan)
-        bern_model.compile()
 
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         bern_fit = bern_model.sample(
@@ -96,7 +93,6 @@ class GenerateQuantitiesTest(unittest.TestCase):
 
         stan = os.path.join(datafiles_path, 'bernoulli_ppc.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
 
         bern_gqs = model.generate_quantities(
             data=jdata,
@@ -135,7 +131,7 @@ class GenerateQuantitiesTest(unittest.TestCase):
     def test_sample_plus_quantities_dedup(self):
         stan = os.path.join(datafiles_path, 'bernoulli_ppc.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
+
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         bern_fit = model.sample(
             data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -125,17 +125,18 @@ class CmdStanModelTest(unittest.TestCase):
         datafiles_abspath = os.path.join(here, 'data')
         include_paths = [datafiles_abspath]
 
-        model = CmdStanModel(stan_file=stan)
-        model.compile(include_paths=include_paths)
-
+        # test compile with explicit include paths
+        model = CmdStanModel(stan_file=stan, include_paths=include_paths)
         self.assertEqual(stan, model.stan_file)
         self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
 
+        # test compile - implicit include path is current dir
         os.remove(os.path.join(datafiles_path, 'bernoulli_include' + '.hpp'))
         os.remove(exe)
         model2 = CmdStanModel(stan_file=stan)
         self.assertEqual(model2.include_paths, include_paths)
 
+        # already compiled
         model3 = CmdStanModel(stan_file=stan)
         self.assertTrue(model3.exe_file.endswith(exe.replace('\\', '/')))
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -36,18 +36,17 @@ class CmdStanModelTest(unittest.TestCase):
     def test_model_good(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
-
+        
         # compile on instantiation
         model = CmdStanModel(stan_file=stan)
         self.assertEqual(stan, model.stan_file)
         self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
 
-
         # instantiate with existing exe
         model = CmdStanModel(stan_file=stan, exe_file=exe)
         self.assertEqual(stan, model.stan_file)
-        self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
-        
+        self.assertTrue(model.exe_file.endswith(exe))
+
         # instantiate, don't compile
         os.remove(exe)
         model = CmdStanModel(stan_file=stan, compile=False)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -40,12 +40,13 @@ class CmdStanModelTest(unittest.TestCase):
         # compile on instantiation
         model = CmdStanModel(stan_file=stan)
         self.assertEqual(stan, model.stan_file)
-        self.assertEqual(exe, model.exe_file.replace('\\', '/'))
+        self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
+
 
         # instantiate with existing exe
         model = CmdStanModel(stan_file=stan, exe_file=exe)
         self.assertEqual(stan, model.stan_file)
-        self.assertEqual(exe, model.exe_file.replace('\\', '/'))
+        self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
         
         # instantiate, don't compile
         os.remove(exe)
@@ -130,7 +131,10 @@ class CmdStanModelTest(unittest.TestCase):
         os.remove(os.path.join(datafiles_path, 'bernoulli_include' + '.hpp'))
         os.remove(exe)
         with self.assertRaises(ValueError):
-            model2 = CmdStanModel(stan_file=stan)
+            model2 = CmdStanModel(stan_file=stan, include_paths=[])
+
+        model3 = CmdStanModel(stan_file=stan)
+        self.assertTrue(model3.exe_file.endswith(exe.replace('\\', '/')))
 
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -40,12 +40,12 @@ class CmdStanModelTest(unittest.TestCase):
         # compile on instantiation
         model = CmdStanModel(stan_file=stan)
         self.assertEqual(stan, model.stan_file)
-        self.assertEqual(exe, model.exe_file)
+        self.assertEqual(exe, model.exe_file.replace('\\', '/'))
 
         # instantiate with existing exe
         model = CmdStanModel(stan_file=stan, exe_file=exe)
         self.assertEqual(stan, model.stan_file)
-        self.assertEqual(exe, model.exe_file)
+        self.assertEqual(exe, model.exe_file.replace('\\', '/'))
         
         # instantiate, don't compile
         os.remove(exe)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -130,8 +130,8 @@ class CmdStanModelTest(unittest.TestCase):
 
         os.remove(os.path.join(datafiles_path, 'bernoulli_include' + '.hpp'))
         os.remove(exe)
-        with self.assertRaises(ValueError):
-            model2 = CmdStanModel(stan_file=stan, include_paths=[])
+        model2 = CmdStanModel(stan_file=stan)
+        self.assertEqual(model2.include_paths, include_paths)
 
         model3 = CmdStanModel(stan_file=stan)
         self.assertTrue(model3.exe_file.endswith(exe.replace('\\', '/')))

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -21,7 +21,6 @@ class CmdStanMLETest(unittest.TestCase):
     def test_set_mle_attrs(self):
         stan = os.path.join(datafiles_path, 'optimize', 'rosenbrock.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
         no_data = {}
         args = OptimizeArgs(algorithm='Newton')
         cmdstan_args = CmdStanArgs(
@@ -51,7 +50,6 @@ class OptimizeTest(unittest.TestCase):
     def test_optimize_good(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         jinit = os.path.join(datafiles_path, 'bernoulli.init.json')
         mle = model.optimize(
@@ -107,7 +105,6 @@ class OptimizeTest(unittest.TestCase):
     def test_optimize_rosenbrock(self):
         stan = os.path.join(datafiles_path, 'optimize', 'rosenbrock.stan')
         rose_model = CmdStanModel(stan_file=stan)
-        rose_model.compile()
         no_data = {}
         mle = rose_model.optimize(
             data=no_data,
@@ -123,7 +120,6 @@ class OptimizeTest(unittest.TestCase):
     def test_optimize_bad(self):
         stan = os.path.join(datafiles_path, 'optimize', 'exponential_boundary.stan')
         exp_bound_model = CmdStanModel(stan_file=stan)
-        exp_bound_model.compile()
         no_data = {}
         with self.assertRaisesRegex(Exception, 'Error during optimizing, error code 70'):
             exp_bound_model.optimize(

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -19,7 +19,6 @@ class SampleTest(unittest.TestCase):
     def test_bernoulli_good(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         bern_model = CmdStanModel(stan_file=stan)
-        bern_model.compile()
 
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         bern_fit = bern_model.sample(
@@ -93,7 +92,6 @@ class SampleTest(unittest.TestCase):
     def test_bernoulli_bad(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         bern_model = CmdStanModel(stan_file=stan)
-        bern_model.compile()
 
         with self.assertRaisesRegex(Exception, 'Error during sampling'):
             bern_fit = bern_model.sample(
@@ -103,7 +101,6 @@ class SampleTest(unittest.TestCase):
     def test_multi_proc(self):
         logistic_stan = os.path.join(datafiles_path, 'logistic.stan')
         logistic_model = CmdStanModel(stan_file=logistic_stan)
-        logistic_model.compile()
         logistic_data = os.path.join(datafiles_path, 'logistic.data.R')
 
         with LogCapture() as log:
@@ -136,7 +133,6 @@ class SampleTest(unittest.TestCase):
     def test_fixed_param_good(self):
         stan = os.path.join(datafiles_path, 'datagen_poisson_glm.stan')
         datagen_model = CmdStanModel(stan_file=stan)
-        datagen_model.compile()
         no_data = {}
         datagen_fit = datagen_model.sample(
             data=no_data, seed=12345, sampling_iters=100, fixed_param=True
@@ -349,7 +345,6 @@ class CmdStanMCMCTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         bern_model = CmdStanModel(stan_file=stan)
-        bern_model.compile()
         bern_fit = bern_model.sample(
             data=jdata, chains=4, cores=2, seed=12345, sampling_iters=200
         )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -168,8 +168,6 @@ class ReadStanCsvTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
         bern_model = CmdStanModel(stan_file=stan, exe_file=exe)
-        bern_model.compile()
-
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
         bern_fit = bern_model.sample(
             data=jdata,

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -21,7 +21,6 @@ class CmdStanVBTest(unittest.TestCase):
     def test_set_variational_attrs(self):
         stan = os.path.join(datafiles_path, 'variational', 'eta_should_be_big.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
         no_data = {}
         args = VariationalArgs(algorithm='meanfield')
         cmdstan_args = CmdStanArgs(
@@ -54,7 +53,6 @@ class VariationalTest(unittest.TestCase):
     def test_variational_good(self):
         stan = os.path.join(datafiles_path, 'variational', 'eta_should_be_big.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
         vi = model.variational(algorithm='meanfield', seed=12345)
         self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1', 'mu.2'))
 
@@ -83,7 +81,6 @@ class VariationalTest(unittest.TestCase):
     def test_variational_eta_small(self):
         stan = os.path.join(datafiles_path, 'variational', 'eta_should_be_small.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
         vi = model.variational(algorithm='meanfield', seed=12345)
         self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1', 'mu.2'))
         self.assertAlmostEqual(fabs(vi.variational_params_dict['mu.1']), 0.08, places=1)
@@ -94,7 +91,6 @@ class VariationalTest(unittest.TestCase):
     def test_variational_eta_fail(self):
         stan = os.path.join(datafiles_path, 'variational', 'eta_should_fail.stan')
         model = CmdStanModel(stan_file=stan)
-        model.compile()
         with self.assertRaisesRegex(RuntimeError, 'algorithm may not have converged'):
             vi = model.variational(algorithm='meanfield', seed=12345)
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Changes to `CmdStanModel` class, unit test, and docs.

- Stan programs allow `#include` directive - the stanc compiler takes a list of directories to search for the include files, therefore `include_paths` is specified as part of constructor and stored as attribute - previously, `include_paths` were supplied as arg to `compile` method.

- Added option `force` to `compile` method so that it will redo the compile step, even if the exe file is newer than the Stan program file - allows user to recompile model when changes are made to one of the include file.

- Remove calls to compile method from unit tests, docs, and notebooks.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

