### PR TITLE
Feature/prevent path duplicate

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -314,8 +314,12 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
             'run command line script "install_cxx_toolchain"'
         )
     logger.info('Adds C++ toolchain to $PATH: %s', toolchain_root)
-    os.environ['PATH'] = '{};{};{}'.format(
-        compiler_path, tool_path, os.environ['PATH']
+    os.environ['PATH'] = ';'.join(
+        list(
+            dict.fromkeys(
+                [compiler_path, tool_path] + os.environ['PATH'].split(';')
+            )
+        )
     )
     return compiler_path, tool_path
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -225,7 +225,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
                     'Found invalid installion for RTools35 on %', toolchain_root
                 )
                 toolchain_root = ''
-        elif os.path.exist(os.path.join(toolchain_root, 'mingw64')):
+        elif os.path.exists(os.path.join(toolchain_root, 'mingw64')):
             compiler_path = os.path.join(
                 toolchain_root,
                 'mingw64' if (sys.maxsize > 2 ** 32) else 'mingw32',


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [ ] Declare copyright holder and open-source license: see below

#### Summary

The `utilscxx_toolchain_path` appends toolchain dirs to PATH even if they're already there.

This keeps the prepended non-duplicated entries only, which is relevant in the case of `find.exe` from `tool_path` having precedence over `C:\Windows\System32\find.exe`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

