### PR TITLE
Implement cmd as List

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -194,47 +194,48 @@ class SamplerArgs(object):
                 ' or any adaptation parameters.'
             )
 
-    def compose(self, idx: int, cmd: str) -> str:
+    def compose(self, idx: int, cmd: List = []) -> str:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
-        cmd = cmd + ' method=sample'
+        cmd.append('method=sample')
         if self.sampling_iters is not None:
-            cmd = '{} num_samples={}'.format(cmd, self.sampling_iters)
+            cmd.append('num_samples={}'.format(self.sampling_iters))
         if self.warmup_iters is not None:
-            cmd = '{} num_warmup={}'.format(cmd, self.warmup_iters)
+            cmd.append('num_warmup={}'.format(self.warmup_iters))
         if self.save_warmup:
-            cmd = cmd + ' save_warmup=1'
+            cmd.append('save_warmup=1')
         if self.thin is not None:
-            cmd = '{} thin={}'.format(cmd, self.thin)
+            cmd.append('thin={}'.format(self.thin))
         if self.fixed_param:
-            cmd = cmd + ' algorithm=fixed_param'
+            cmd.append('algorithm=fixed_param')
             return cmd
         else:
-            cmd = cmd + ' algorithm=hmc'
+            cmd.append('algorithm=hmc')
         if self.max_treedepth is not None:
-            cmd = '{} engine=nuts max_depth={}'.format(cmd, self.max_treedepth)
+            cmd.append('engine=nuts')
+            cmd.append('max_depth={}'.format(self.max_treedepth))
         if self.step_size is not None:
             if not isinstance(self.step_size, list):
-                cmd = '{} stepsize={}'.format(cmd, self.step_size)
+                cmd.append('stepsize={}'.format(self.step_size))
             else:
-                cmd = '{} stepsize={}'.format(cmd, self.step_size[idx])
+                cmd.append('stepsize={}'.format(self.step_size[idx]))
         if self.metric is not None:
-            cmd = '{} metric={}'.format(cmd, self.metric)
+            cmd.append('metric={}'.format(self.metric))
         if self.metric_file is not None:
             if not isinstance(self.metric_file, list):
-                cmd = '{} metric_file="{}"'.format(cmd, self.metric_file)
+                cmd.append('metric_file="{}"'.format(self.metric_file))
             else:
-                cmd = '{} metric_file="{}"'.format(cmd, self.metric_file[idx])
+                cmd.append('metric_file="{}"'.format(self.metric_file[idx]))
         if self.adapt_engaged is not None or self.adapt_delta is not None:
-            cmd = cmd + ' adapt'
+            cmd.append('adapt')
         if self.adapt_engaged is not None:
             if self.adapt_engaged:
-                cmd = cmd + ' engaged=1'
+                cmd.append('engaged=1')
             else:
-                cmd = cmd + ' engaged=0'
+                cmd.append('engaged=0')
         if self.adapt_delta is not None:
-            cmd = '{} delta={}'.format(cmd, self.adapt_delta)
+            cmd.append('delta={}'.format(self.adapt_delta))
         return cmd
 
 
@@ -283,16 +284,16 @@ class OptimizeArgs(object):
             else:
                 raise ValueError('iter must be type of int')
 
-    def compose(self, idx: int, cmd: str) -> str:
+    def compose(self, idx: int, cmd: List = []) -> str:
         """compose command string for CmdStan for non-default arg values.
         """
-        cmd = cmd + ' method=optimize'
+        cmd.append('method=optimize')
         if self.algorithm:
-            cmd += ' algorithm={}'.format(self.algorithm.lower())
+            cmd.append('algorithm={}'.format(self.algorithm.lower()))
         if self.init_alpha is not None:
-            cmd += ' init_alpha={}'.format(self.init_alpha)
+            cmd.append('init_alpha={}'.format(self.init_alpha))
         if self.iter is not None:
-            cmd += ' iter={}'.format(self.iter)
+            cmd.append('iter={}'.format(self.iter))
         return cmd
 
 
@@ -315,12 +316,12 @@ class GenerateQuantitiesArgs(object):
                     'Invalid path for sample csv file: {}'.format(csv)
                 )
 
-    def compose(self, idx: int, cmd: str) -> str:
+    def compose(self, idx: int, cmd: List = []) -> str:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
-        cmd = cmd + ' method=generate_quantities'
-        cmd = '{} fitted_params={}'.format(cmd, self.sample_csv_files[idx - 1])
+        cmd.append('method=generate_quantities')
+        cmd.append('fitted_params={}'.format(self.sample_csv_files[idx - 1]))
         return cmd
 
 
@@ -421,29 +422,30 @@ class VariationalArgs(object):
                     ' found {}'.format(self.output_samples)
                 )
 
-    def compose(self, idx: int, cmd: str) -> str:
+    def compose(self, idx: int, cmd: List = []) -> str:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
-        cmd = cmd + ' method=variational'
+        cmd.append('method=variational')
         if self.algorithm is not None:
-            cmd = '{} algorithm={}'.format(cmd, self.algorithm)
+            cmd.append('algorithm={}'.format(self.algorithm))
         if self.iter is not None:
-            cmd = '{} iter={}'.format(cmd, self.iter)
+            cmd.append('iter={}'.format(self.iter))
         if self.grad_samples is not None:
-            cmd = '{} grad_samples={}'.format(cmd, self.grad_samples)
+            cmd.append('grad_samples={}'.format(self.grad_samples))
         if self.elbo_samples is not None:
-            cmd = '{} elbo_samples={}'.format(cmd, self.elbo_samples)
+            cmd.append('elbo_samples={}'.format(self.elbo_samples))
         if self.eta is not None:
-            cmd = '{} eta={}'.format(cmd, self.eta)
+            cmd.append('eta={}'.format(self.eta))
         if self.adapt_iter is not None:
-            cmd = '{} adapt iter={}'.format(cmd, self.adapt_iter)
+            cmd.append('adapt')
+            cmd.append('iter={}'.format(self.adapt_iter))
         if self.tol_rel_obj is not None:
-            cmd = '{} tol_rel_obj={}'.format(cmd, self.tol_rel_obj)
+            cmd.append('tol_rel_obj={}'.format(self.tol_rel_obj))
         if self.eval_elbo is not None:
-            cmd = '{} eval_elbo={}'.format(cmd, self.eval_elbo)
+            cmd.append('eval_elbo={}'.format(self.eval_elbo))
         if self.output_samples is not None:
-            cmd = '{} output_samples={}'.format(cmd, self.output_samples)
+            cmd.append('output_samples={}'.format(self.output_samples))
         return cmd
 
 
@@ -612,6 +614,7 @@ class CmdStanArgs(object):
         """
         Compose CmdStan command for non-default arguments.
         """
+        cmd = []
         if idx is not None and self.chain_ids is not None:
             if idx < 0 or idx > len(self.chain_ids) - 1:
                 raise ValueError(
@@ -619,24 +622,29 @@ class CmdStanArgs(object):
                         idx, len(self.chain_ids)
                     )
                 )
-            cmd = '{} id={}'.format(self.model_exe, self.chain_ids[idx])
+            cmd.append(self.model_exe)
+            cmd.append('id={}'.format(self.chain_ids[idx]))
         else:
-            cmd = self.model_exe
+            cmd.append(self.model_exe)
 
         if self.seed is not None:
             if not isinstance(self.seed, list):
-                cmd = '{} random seed={}'.format(cmd, self.seed)
+                cmd.append('random')
+                cmd.append('seed={}'.format(self.seed))
             else:
-                cmd = '{} random seed={}'.format(cmd, self.seed[idx])
+                cmd.append('random')
+                cmd.append('seed={}'.format(self.seed[idx]))
         if self.data is not None:
-            cmd = '{} data file={}'.format(cmd, self.data)
+            cmd.append('data')
+            cmd.append('file={}'.format(self.data))
         if self.inits is not None:
             if not isinstance(self.inits, list):
-                cmd = '{} init={}'.format(cmd, self.inits)
+                cmd.append('init={}'.format(self.inits))
             else:
-                cmd = '{} init={}'.format(cmd, self.inits[idx])
-        cmd = '{} output file={}'.format(cmd, csv_file)
+                cmd.append('init={}'.format(self.inits[idx]))
+        cmd.append('output')
+        cmd.append('file={}'.format(csv_file))
         if self.refresh is not None:
-            cmd = '{} refresh={}'.format(cmd, self.refresh)
+            cmd.append('refresh={}'.format(self.refresh))
         cmd = self.method_args.compose(idx, cmd)
         return cmd

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -194,7 +194,7 @@ class SamplerArgs(object):
                 ' or any adaptation parameters.'
             )
 
-    def compose(self, idx: int, cmd: List = []) -> str:
+    def compose(self, idx: int, cmd: List) -> str:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -284,7 +284,7 @@ class OptimizeArgs(object):
             else:
                 raise ValueError('iter must be type of int')
 
-    def compose(self, idx: int, cmd: List = []) -> str:
+    def compose(self, idx: int, cmd: List) -> str:
         """compose command string for CmdStan for non-default arg values.
         """
         cmd.append('method=optimize')
@@ -316,7 +316,7 @@ class GenerateQuantitiesArgs(object):
                     'Invalid path for sample csv file: {}'.format(csv)
                 )
 
-    def compose(self, idx: int, cmd: List = []) -> str:
+    def compose(self, idx: int, cmd: List) -> str:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -422,7 +422,7 @@ class VariationalArgs(object):
                     ' found {}'.format(self.output_samples)
                 )
 
-    def compose(self, idx: int, cmd: List = []) -> str:
+    def compose(self, idx: int, cmd: List) -> str:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -212,7 +212,9 @@ class CmdStanModel(object):
 
             if not compilation_failed:
                 if is_copied:
-                    original_target_dir = os.path.dirname(os.path.abspath(self._stan_file))
+                    original_target_dir = os.path.dirname(
+                        os.path.abspath(self._stan_file)
+                    )
                     new_exec_name = (
                         os.path.basename(os.path.splitext(self._stan_file)[0])
                         + EXTENSION

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -148,7 +148,7 @@ class CmdStanModel(object):
         compilation_failed = False
 
         with TemporaryCopiedFile(self._stan_file) as (stan_file, is_copied):
-            exe_file, _ = os.path.splitext(stan_file)
+            exe_file, _ = os.path.splitext(os.path.abspath(stan_file))
             exe_file = Path(exe_file).as_posix()
             exe_file += EXTENSION
             do_compile = True

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -148,7 +148,7 @@ class CmdStanModel(object):
         compilation_failed = False
 
         with TemporaryCopiedFile(self._stan_file) as (stan_file, is_copied):
-            exe_file, _ = os.path.splitext(os.path.abspath(stan_file))
+            exe_file, _ = os.path.splitext(stan_file)
             exe_file = Path(exe_file).as_posix()
             exe_file += EXTENSION
             do_compile = True
@@ -212,7 +212,7 @@ class CmdStanModel(object):
 
             if not compilation_failed:
                 if is_copied:
-                    original_target_dir = os.path.dirname(self._stan_file)
+                    original_target_dir = os.path.dirname(os.path.abspath(self._stan_file))
                     new_exec_name = (
                         os.path.basename(os.path.splitext(self._stan_file)[0])
                         + EXTENSION
@@ -863,7 +863,7 @@ class CmdStanModel(object):
         self._logger.info('start chain %u', idx + 1)
         self._logger.debug('sampling: %s', cmd)
         proc = subprocess.Popen(
-            cmd.split(),
+            cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=os.environ,

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -208,7 +208,7 @@ class CmdStanMCMC(object):
         repr = 'CmdStanMCMC: model={} chains={}{}'.format(
             self.runset.model,
             self.runset.chains,
-            self.runset._args.method_args.compose(0),
+            self.runset._args.method_args.compose(0, cmd=[]),
         )
         repr = '{}\n csv_files:\n\t{}\n console_files\n\t{}'.format(
             repr,
@@ -478,7 +478,7 @@ class CmdStanMLE(object):
 
     def __repr__(self) -> str:
         repr = 'CmdStanMLE: model={}{}'.format(
-            self.runset.model, self.runset._args.method_args.compose(0)
+            self.runset.model, self.runset._args.method_args.compose(0, cmd=[])
         )
         repr = '{}\n csv_file:\n\t{}\n console_file\n\t{}'.format(
             repr,
@@ -553,7 +553,7 @@ class CmdStanGQ(object):
         repr = 'CmdStanGQ: model={} chains={}{}'.format(
             self.runset.model,
             self.runset.chains,
-            self.runset._args.method_args.compose(0),
+            self.runset._args.method_args.compose(0, cmd=[]),
         )
         repr = '{}\n csv_files:\n\t{}\n console_files\n\t{}'.format(
             repr,
@@ -683,7 +683,7 @@ class CmdStanVB(object):
 
     def __repr__(self) -> str:
         repr = 'CmdStanVB: model={}{}'.format(
-            self.runset.model, self.runset._args.method_args.compose(0)
+            self.runset.model, self.runset._args.method_args.compose(0, cmd=[])
         )
         repr = '{}\n csv_file:\n\t{}\n console_file\n\t{}'.format(
             repr,

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -208,7 +208,7 @@ class CmdStanMCMC(object):
         repr = 'CmdStanMCMC: model={} chains={}{}'.format(
             self.runset.model,
             self.runset.chains,
-            self.runset._args.method_args.compose(0, ''),
+            self.runset._args.method_args.compose(0),
         )
         repr = '{}\n csv_files:\n\t{}\n console_files\n\t{}'.format(
             repr,
@@ -478,7 +478,7 @@ class CmdStanMLE(object):
 
     def __repr__(self) -> str:
         repr = 'CmdStanMLE: model={}{}'.format(
-            self.runset.model, self.runset._args.method_args.compose(0, '')
+            self.runset.model, self.runset._args.method_args.compose(0)
         )
         repr = '{}\n csv_file:\n\t{}\n console_file\n\t{}'.format(
             repr,
@@ -553,7 +553,7 @@ class CmdStanGQ(object):
         repr = 'CmdStanGQ: model={} chains={}{}'.format(
             self.runset.model,
             self.runset.chains,
-            self.runset._args.method_args.compose(0, ''),
+            self.runset._args.method_args.compose(0),
         )
         repr = '{}\n csv_files:\n\t{}\n console_files\n\t{}'.format(
             repr,
@@ -683,7 +683,7 @@ class CmdStanVB(object):
 
     def __repr__(self) -> str:
         repr = 'CmdStanVB: model={}{}'.format(
-            self.runset.model, self.runset._args.method_args.compose(0, '')
+            self.runset.model, self.runset._args.method_args.compose(0)
         )
         repr = '{}\n csv_file:\n\t{}\n console_file\n\t{}'.format(
             repr,

--- a/test/data/bernoulli with space in name.stan
+++ b/test/data/bernoulli with space in name.stan
@@ -1,0 +1,12 @@
+data {
+  int<lower=0> N;
+  int<lower=0,upper=1> y[N];
+}
+parameters {
+  real<lower=0,upper=1> theta;
+}
+model {
+  theta ~ beta(1,1);
+  for (n in 1:N)
+    y[n] ~ bernoulli(theta);
+}

--- a/test/data/path with space/bernoulli_path_with_space.stan
+++ b/test/data/path with space/bernoulli_path_with_space.stan
@@ -1,0 +1,12 @@
+data {
+  int<lower=0> N;
+  int<lower=0,upper=1> y[N];
+}
+parameters {
+  real<lower=0,upper=1> theta;
+}
+model {
+  theta ~ beta(1,1);
+  for (n in 1:N)
+    y[n] ~ bernoulli(theta);
+}

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -22,13 +22,13 @@ class OptimizeArgsTest(unittest.TestCase):
         self.assertRaises(ValueError, lambda: args.validate())
         args = OptimizeArgs(algorithm='Newton')
         args.validate()
-        cmd = args.compose(None, ['output'])
+        cmd = args.compose(None, cmd=['output'])
         self.assertIn('algorithm=newton', ' '.join(cmd))
 
     def test_args_algorithm_init_alpha(self):
         args = OptimizeArgs(init_alpha=2e-4)
         args.validate()
-        cmd = args.compose(None, ['output'])
+        cmd = args.compose(None, cmd=['output'])
 
 
         self.assertIn('init_alpha=0.0002', ' '.join(cmd))
@@ -40,7 +40,7 @@ class OptimizeArgsTest(unittest.TestCase):
     def test_args_algorithm_iter(self):
         args = OptimizeArgs(iter=400)
         args.validate()
-        cmd = args.compose(None, ['output'])
+        cmd = args.compose(None, cmd=['output'])
         self.assertIn('iter=400', ' '.join(cmd))
         args = OptimizeArgs(iter=-1)
         self.assertRaises(ValueError, lambda: args.validate())
@@ -50,7 +50,7 @@ class SamplerArgsTest(unittest.TestCase):
     def test_args_min(self):
         args = SamplerArgs()
         args.validate(chains=4)
-        cmd = args.compose(idx=1)
+        cmd = args.compose(idx=1, cmd=[])
         self.assertIn('method=sample algorithm=hmc', ' '.join(cmd))
 
     def test_args_chains(self):
@@ -68,7 +68,7 @@ class SamplerArgsTest(unittest.TestCase):
             adapt_delta=0.99,
         )
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample', ' '.join(cmd))
         self.assertIn('num_warmup=10', ' '.join(cmd))
         self.assertIn('num_samples=20', ' '.join(cmd))
@@ -79,7 +79,7 @@ class SamplerArgsTest(unittest.TestCase):
 
         args = SamplerArgs(warmup_iters=10)
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample', ' '.join(cmd))
         self.assertIn('num_warmup=10', ' '.join(cmd))
         self.assertNotIn('num_samples=', ' '.join(cmd))
@@ -154,50 +154,50 @@ class SamplerArgsTest(unittest.TestCase):
     def test_adapt(self):
         args = SamplerArgs(adapt_engaged=False)
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample algorithm=hmc adapt engaged=0', ' '.join(cmd))
 
         args = SamplerArgs(adapt_engaged=True)
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample algorithm=hmc adapt engaged=1', ' '.join(cmd))
 
         args = SamplerArgs()
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertNotIn('engine=nuts', ' '.join(cmd))
         self.assertNotIn('engaged=1', ' '.join(cmd))
 
     def test_metric(self):
         args = SamplerArgs(metric='dense_e')
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample algorithm=hmc metric=dense_e', ' '.join(cmd))
 
         args = SamplerArgs(metric='dense')
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample algorithm=hmc metric=dense_e', ' '.join(cmd))
 
         args = SamplerArgs(metric='diag_e')
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample algorithm=hmc metric=diag_e', ' '.join(cmd))
 
         args = SamplerArgs(metric='diag')
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('method=sample algorithm=hmc metric=diag_e', ' '.join(cmd))
 
         args = SamplerArgs()
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertNotIn('metric=', ' '.join(cmd))
 
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
         args = SamplerArgs(metric=jmetric)
         args.validate(chains=4)
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('metric=diag_e', ' '.join(cmd))
         self.assertIn('metric_file=', ' '.join(cmd))
         self.assertIn('bernoulli.metric.json', ' '.join(cmd))
@@ -205,9 +205,9 @@ class SamplerArgsTest(unittest.TestCase):
         jmetric2 = os.path.join(datafiles_path, 'bernoulli.metric-2.json')
         args = SamplerArgs(metric=[jmetric, jmetric2])
         args.validate(chains=2)
-        cmd = args.compose(0)
+        cmd = args.compose(0, cmd=[])
         self.assertIn('bernoulli.metric.json', ' '.join(cmd))
-        cmd = args.compose(1)
+        cmd = args.compose(1, cmd=[])
         self.assertIn('bernoulli.metric-2.json', ' '.join(cmd))
 
         args = SamplerArgs(metric=[jmetric, jmetric])
@@ -225,7 +225,7 @@ class SamplerArgsTest(unittest.TestCase):
     def test_fixed_param(self):
         args = SamplerArgs(fixed_param=True)
         args.validate(chains=1)
-        cmd = args.compose(0)
+        cmd = args.compose(0, cmd=[])
         self.assertIn('method=sample algorithm=fixed_param', ' '.join(cmd))
 
 
@@ -507,7 +507,7 @@ class GenerateQuantitesTest(unittest.TestCase):
         ]
         args = GenerateQuantitiesArgs(csv_files=csv_files)
         args.validate(chains=4)
-        cmd = args.compose(idx=1)
+        cmd = args.compose(idx=1, cmd=[])
         self.assertIn('method=generate_quantities', ' '.join(cmd))
         self.assertIn('fitted_params={}'.format(csv_files[0]), ' '.join(cmd))
 
@@ -518,13 +518,13 @@ class VariationalTest(unittest.TestCase):
 
         args = VariationalArgs(output_samples=1)
         args.validate(chains=1)
-        cmd = args.compose(idx=0)
+        cmd = args.compose(idx=0, cmd=[])
         self.assertIn('method=variational', ' '.join(cmd))
         self.assertIn('output_samples=1', ' '.join(cmd))
 
         args = VariationalArgs(tol_rel_obj=1)
         args.validate(chains=1)
-        cmd = args.compose(idx=0)
+        cmd = args.compose(idx=0, cmd=[])
         self.assertIn('method=variational', ' '.join(cmd))
         self.assertIn('tol_rel_obj=1', ' '.join(cmd))
 

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -22,14 +22,16 @@ class OptimizeArgsTest(unittest.TestCase):
         self.assertRaises(ValueError, lambda: args.validate())
         args = OptimizeArgs(algorithm='Newton')
         args.validate()
-        cmd = args.compose(None, 'output')
-        self.assertIn('algorithm=newton', cmd)
+        cmd = args.compose(None, ['output'])
+        self.assertIn('algorithm=newton', ' '.join(cmd))
 
     def test_args_algorithm_init_alpha(self):
         args = OptimizeArgs(init_alpha=2e-4)
         args.validate()
-        cmd = args.compose(None, 'output')
-        self.assertIn('init_alpha=0.0002', cmd)
+        cmd = args.compose(None, ['output'])
+
+
+        self.assertIn('init_alpha=0.0002', ' '.join(cmd))
         args = OptimizeArgs(init_alpha=-1.0)
         self.assertRaises(ValueError, lambda: args.validate())
         args = OptimizeArgs(init_alpha=1.0, algorithm='Newton')
@@ -38,8 +40,8 @@ class OptimizeArgsTest(unittest.TestCase):
     def test_args_algorithm_iter(self):
         args = OptimizeArgs(iter=400)
         args.validate()
-        cmd = args.compose(None, 'output')
-        self.assertIn('iter=400', cmd)
+        cmd = args.compose(None, ['output'])
+        self.assertIn('iter=400', ' '.join(cmd))
         args = OptimizeArgs(iter=-1)
         self.assertRaises(ValueError, lambda: args.validate())
 
@@ -48,8 +50,8 @@ class SamplerArgsTest(unittest.TestCase):
     def test_args_min(self):
         args = SamplerArgs()
         args.validate(chains=4)
-        cmd = args.compose(idx=1, cmd='')
-        self.assertIn('method=sample algorithm=hmc', cmd)
+        cmd = args.compose(idx=1)
+        self.assertIn('method=sample algorithm=hmc', ' '.join(cmd))
 
     def test_args_chains(self):
         args = SamplerArgs()
@@ -66,23 +68,23 @@ class SamplerArgsTest(unittest.TestCase):
             adapt_delta=0.99,
         )
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample', cmd)
-        self.assertIn('num_warmup=10', cmd)
-        self.assertIn('num_samples=20', cmd)
-        self.assertIn('save_warmup=1', cmd)
-        self.assertIn('thin=7', cmd)
-        self.assertIn('algorithm=hmc engine=nuts', cmd)
-        self.assertIn('max_depth=15 adapt delta=0.99', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample', ' '.join(cmd))
+        self.assertIn('num_warmup=10', ' '.join(cmd))
+        self.assertIn('num_samples=20', ' '.join(cmd))
+        self.assertIn('save_warmup=1', ' '.join(cmd))
+        self.assertIn('thin=7', ' '.join(cmd))
+        self.assertIn('algorithm=hmc engine=nuts', ' '.join(cmd))
+        self.assertIn('max_depth=15 adapt delta=0.99', ' '.join(cmd))
 
         args = SamplerArgs(warmup_iters=10)
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample', cmd)
-        self.assertIn('num_warmup=10', cmd)
-        self.assertNotIn('num_samples=', cmd)
-        self.assertNotIn('save_warmup=', cmd)
-        self.assertNotIn('algorithm=hmc engine=nuts', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample', ' '.join(cmd))
+        self.assertIn('num_warmup=10', ' '.join(cmd))
+        self.assertNotIn('num_samples=', ' '.join(cmd))
+        self.assertNotIn('save_warmup=', ' '.join(cmd))
+        self.assertNotIn('algorithm=hmc engine=nuts', ' '.join(cmd))
 
     def test_bad(self):
         args = SamplerArgs(warmup_iters=-10)
@@ -152,61 +154,61 @@ class SamplerArgsTest(unittest.TestCase):
     def test_adapt(self):
         args = SamplerArgs(adapt_engaged=False)
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample algorithm=hmc adapt engaged=0', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample algorithm=hmc adapt engaged=0', ' '.join(cmd))
 
         args = SamplerArgs(adapt_engaged=True)
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample algorithm=hmc adapt engaged=1', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample algorithm=hmc adapt engaged=1', ' '.join(cmd))
 
         args = SamplerArgs()
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertNotIn('engine=nuts', cmd)
-        self.assertNotIn('engaged=1', cmd)
+        cmd = args.compose(1)
+        self.assertNotIn('engine=nuts', ' '.join(cmd))
+        self.assertNotIn('engaged=1', ' '.join(cmd))
 
     def test_metric(self):
         args = SamplerArgs(metric='dense_e')
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample algorithm=hmc metric=dense_e', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample algorithm=hmc metric=dense_e', ' '.join(cmd))
 
         args = SamplerArgs(metric='dense')
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample algorithm=hmc metric=dense_e', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample algorithm=hmc metric=dense_e', ' '.join(cmd))
 
         args = SamplerArgs(metric='diag_e')
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample algorithm=hmc metric=diag_e', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample algorithm=hmc metric=diag_e', ' '.join(cmd))
 
         args = SamplerArgs(metric='diag')
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('method=sample algorithm=hmc metric=diag_e', cmd)
+        cmd = args.compose(1)
+        self.assertIn('method=sample algorithm=hmc metric=diag_e', ' '.join(cmd))
 
         args = SamplerArgs()
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertNotIn('metric=', cmd)
+        cmd = args.compose(1)
+        self.assertNotIn('metric=', ' '.join(cmd))
 
         jmetric = os.path.join(datafiles_path, 'bernoulli.metric.json')
         args = SamplerArgs(metric=jmetric)
         args.validate(chains=4)
-        cmd = args.compose(1, '')
-        self.assertIn('metric=diag_e', cmd)
-        self.assertIn('metric_file=', cmd)
-        self.assertIn('bernoulli.metric.json', cmd)
+        cmd = args.compose(1)
+        self.assertIn('metric=diag_e', ' '.join(cmd))
+        self.assertIn('metric_file=', ' '.join(cmd))
+        self.assertIn('bernoulli.metric.json', ' '.join(cmd))
 
         jmetric2 = os.path.join(datafiles_path, 'bernoulli.metric-2.json')
         args = SamplerArgs(metric=[jmetric, jmetric2])
         args.validate(chains=2)
-        cmd = args.compose(0, '')
-        self.assertIn('bernoulli.metric.json', cmd)
-        cmd = args.compose(1, '')
-        self.assertIn('bernoulli.metric-2.json', cmd)
+        cmd = args.compose(0)
+        self.assertIn('bernoulli.metric.json', ' '.join(cmd))
+        cmd = args.compose(1)
+        self.assertIn('bernoulli.metric-2.json', ' '.join(cmd))
 
         args = SamplerArgs(metric=[jmetric, jmetric])
         with self.assertRaises(ValueError):
@@ -223,8 +225,8 @@ class SamplerArgsTest(unittest.TestCase):
     def test_fixed_param(self):
         args = SamplerArgs(fixed_param=True)
         args.validate(chains=1)
-        cmd = args.compose(0, '')
-        self.assertIn('method=sample algorithm=fixed_param', cmd)
+        cmd = args.compose(0)
+        self.assertIn('method=sample algorithm=fixed_param', ' '.join(cmd))
 
 
 class CmdStanArgsTest(unittest.TestCase):
@@ -283,10 +285,10 @@ class CmdStanArgsTest(unittest.TestCase):
         )
         self.assertEqual(cmdstan_args.method, Method.SAMPLE)
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
-        self.assertIn('id=1 random seed=', cmd)
-        self.assertIn('data file=', cmd)
-        self.assertIn('output file=', cmd)
-        self.assertIn('method=sample algorithm=hmc', cmd)
+        self.assertIn('id=1 random seed=', ' '.join(cmd))
+        self.assertIn('data file=', ' '.join(cmd))
+        self.assertIn('output file=', ' '.join(cmd))
+        self.assertIn('method=sample algorithm=hmc', ' '.join(cmd))
 
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -296,7 +298,7 @@ class CmdStanArgsTest(unittest.TestCase):
             method_args=sampler_args,
         )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
-        self.assertIn('id=7 random seed=', cmd)
+        self.assertIn('id=7 random seed=', ' '.join(cmd))
 
     def test_args_inits(self):
         exe = os.path.join(datafiles_path, 'bernoulli')
@@ -316,7 +318,7 @@ class CmdStanArgsTest(unittest.TestCase):
             method_args=sampler_args,
         )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
-        self.assertIn('init=', cmd)
+        self.assertIn('init=', ' '.join(cmd))
 
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -327,9 +329,9 @@ class CmdStanArgsTest(unittest.TestCase):
             method_args=sampler_args,
         )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
-        self.assertIn('bernoulli.init_1.json', cmd)
+        self.assertIn('bernoulli.init_1.json', ' '.join(cmd))
         cmd = cmdstan_args.compose_command(idx=1, csv_file='bern-output-1.csv')
-        self.assertIn('bernoulli.init_2.json', cmd)
+        self.assertIn('bernoulli.init_2.json', ' '.join(cmd))
 
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -340,7 +342,7 @@ class CmdStanArgsTest(unittest.TestCase):
             method_args=sampler_args,
         )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
-        self.assertIn('init=0', cmd)
+        self.assertIn('init=0', ' '.join(cmd))
 
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -351,7 +353,7 @@ class CmdStanArgsTest(unittest.TestCase):
             method_args=sampler_args,
         )
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
-        self.assertIn('init=3.33', cmd)
+        self.assertIn('init=3.33', ' '.join(cmd))
 
     def test_args_bad(self):
         sampler_args = SamplerArgs()
@@ -505,9 +507,9 @@ class GenerateQuantitesTest(unittest.TestCase):
         ]
         args = GenerateQuantitiesArgs(csv_files=csv_files)
         args.validate(chains=4)
-        cmd = args.compose(idx=1, cmd='')
-        self.assertIn('method=generate_quantities', cmd)
-        self.assertIn('fitted_params={}'.format(csv_files[0]), cmd)
+        cmd = args.compose(idx=1)
+        self.assertIn('method=generate_quantities', ' '.join(cmd))
+        self.assertIn('fitted_params={}'.format(csv_files[0]), ' '.join(cmd))
 
 class VariationalTest(unittest.TestCase):
     def test_args_variational(self):
@@ -516,15 +518,15 @@ class VariationalTest(unittest.TestCase):
 
         args = VariationalArgs(output_samples=1)
         args.validate(chains=1)
-        cmd = args.compose(idx=0, cmd='')
-        self.assertIn('method=variational', cmd)
-        self.assertIn('output_samples=1', cmd)
+        cmd = args.compose(idx=0)
+        self.assertIn('method=variational', ' '.join(cmd))
+        self.assertIn('output_samples=1', ' '.join(cmd))
 
         args = VariationalArgs(tol_rel_obj=1)
         args.validate(chains=1)
-        cmd = args.compose(idx=0, cmd='')
-        self.assertIn('method=variational', cmd)
-        self.assertIn('tol_rel_obj=1', cmd)
+        cmd = args.compose(idx=0)
+        self.assertIn('method=variational', ' '.join(cmd))
+        self.assertIn('tol_rel_obj=1', ' '.join(cmd))
 
     def test_args_bad(self):
         args = VariationalArgs(algorithm='no_such_algo')

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -2,7 +2,6 @@ import os
 import unittest
 
 import logging
-import pytest
 from testfixtures import LogCapture
 from multiprocessing import cpu_count
 
@@ -17,11 +16,6 @@ goodfiles_path = os.path.join(datafiles_path, 'runset-good')
 badfiles_path = os.path.join(datafiles_path, 'runset-bad')
 
 class SampleTest(unittest.TestCase):
-    @pytest.mark.parametrize('stanfile', [
-        'bernoulli.stan', 
-        'bernoulli with space in name.stan',
-        'path with space/bernoulli_path_with_space.stan'
-    ])
     def test_bernoulli_good(self, stanfile='bernoulli.stan'):
         stan = os.path.join(datafiles_path, stanfile)
         bern_model = CmdStanModel(stan_file=stan)
@@ -250,6 +244,12 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(datagen_fit.metric, None)
         self.assertEqual(datagen_fit.metric_type, None)
         self.assertEqual(datagen_fit.stepsize, None)
+
+    def test_bernoulli_file_with_space(self):
+        self.test_bernoulli_good('bernoulli with space in name.stan')
+
+    def test_bernoulli_path_with_space(self):
+        self.test_bernoulli_good('path with space/bernoulli_path_with_space.stan')
 
 class CmdStanMCMCTest(unittest.TestCase):
     def test_validate_good_run(self):

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -16,8 +16,8 @@ goodfiles_path = os.path.join(datafiles_path, 'runset-good')
 badfiles_path = os.path.join(datafiles_path, 'runset-bad')
 
 class SampleTest(unittest.TestCase):
-    def test_bernoulli_good(self):
-        stan = os.path.join(datafiles_path, 'bernoulli.stan')
+    def test_bernoulli_good(self, stanfile='bernoulli.stan'):
+        stan = os.path.join(datafiles_path, stanfile)
         bern_model = CmdStanModel(stan_file=stan)
         bern_model.compile()
 
@@ -246,79 +246,10 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(datagen_fit.stepsize, None)
 
     def test_bernoulli_file_with_space(self):
-        stan = os.path.join(datafiles_path, 'bernoulli with space in name.stan')
-        bern_model = CmdStanModel(stan_file=stan)
-        bern_model.compile()
+        self.test_bernoulli_good('bernoulli with space in name.stan')
 
-        jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
-        bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100
-        )
-        self.assertIn('CmdStanMCMC: model=bernoulli', bern_fit.__repr__())
-        self.assertIn('method=sample', bern_fit.__repr__())
-
-        self.assertEqual(bern_fit.runset._args.method, Method.SAMPLE)
-
-        for i in range(bern_fit.runset.chains):
-            csv_file = bern_fit.runset.csv_files[i]
-            txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
-            self.assertTrue(os.path.exists(csv_file))
-            self.assertTrue(os.path.exists(txt_file))
-
-        self.assertEqual(bern_fit.runset.chains, 4)
-        self.assertEqual(bern_fit.draws, 100)
-        column_names = [
-            'lp__',
-            'accept_stat__',
-            'stepsize__',
-            'treedepth__',
-            'n_leapfrog__',
-            'divergent__',
-            'energy__',
-            'theta',
-        ]
-        self.assertEqual(bern_fit.column_names, tuple(column_names))
-
-        bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
-        self.assertEqual(bern_fit.metric_type, 'diag_e')
-        self.assertEqual(bern_fit.stepsize.shape, (4,))
-        self.assertEqual(bern_fit.metric.shape, (4, 1))
-
-        output = os.path.join(datafiles_path, 'test1-bernoulli-output')
-        bern_fit = bern_model.sample(
-            data=jdata,
-            chains=4,
-            cores=2,
-            seed=12345,
-            sampling_iters=100,
-            csv_basename=output,
-        )
-        for i in range(bern_fit.runset.chains):
-            csv_file = bern_fit.runset.csv_files[i]
-            txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
-            self.assertTrue(os.path.exists(csv_file))
-            self.assertTrue(os.path.exists(txt_file))
-        bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
-        for i in range(bern_fit.runset.chains):  # cleanup datafile_path dir
-            os.remove(bern_fit.runset.csv_files[i])
-            os.remove(bern_fit.runset.console_files[i])
-
-        rdata = os.path.join(datafiles_path, 'bernoulli.data.R')
-        bern_fit = bern_model.sample(
-            data=rdata, chains=4, cores=2, seed=12345, sampling_iters=100
-        )
-        bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
-
-        data_dict = {'N': 10, 'y': [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
-        bern_fit = bern_model.sample(
-            data=data_dict, chains=4, cores=2, seed=12345, sampling_iters=100
-        )
-        bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
-
+    def test_bernoulli_path_with_space(self):
+        self.test_bernoulli_good('path with space/bernoulli_path_with_space.stan')
 
 class CmdStanMCMCTest(unittest.TestCase):
     def test_validate_good_run(self):

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 import logging
+import pytest
 from testfixtures import LogCapture
 from multiprocessing import cpu_count
 
@@ -16,6 +17,11 @@ goodfiles_path = os.path.join(datafiles_path, 'runset-good')
 badfiles_path = os.path.join(datafiles_path, 'runset-bad')
 
 class SampleTest(unittest.TestCase):
+    @pytest.mark.parametrize('stanfile', [
+        'bernoulli.stan', 
+        'bernoulli with space in name.stan',
+        'path with space/bernoulli_path_with_space.stan'
+    ])
     def test_bernoulli_good(self, stanfile='bernoulli.stan'):
         stan = os.path.join(datafiles_path, stanfile)
         bern_model = CmdStanModel(stan_file=stan)
@@ -244,12 +250,6 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(datagen_fit.metric, None)
         self.assertEqual(datagen_fit.metric_type, None)
         self.assertEqual(datagen_fit.stepsize, None)
-
-    def test_bernoulli_file_with_space(self):
-        self.test_bernoulli_good('bernoulli with space in name.stan')
-
-    def test_bernoulli_path_with_space(self):
-        self.test_bernoulli_good('path with space/bernoulli_path_with_space.stan')
 
 class CmdStanMCMCTest(unittest.TestCase):
     def test_validate_good_run(self):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Changes command into a List. Previously it was a String and `.split()` was used. In addition an absolute path is used for the target stanfile in the scenario where it is copied from a tmpdir.

Fixes #167 and fixes #91.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): American Express



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

