### PR TITLE
Compile with make instead of bin/stanc

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -209,16 +209,16 @@ class CmdStanModel(object):
                     self._logger.info('found newer exe file, not recompiling')
 
             if do_compile:
+                make = os.getenv(
+                    'MAKE',
+                    'make'
+                    if platform.system() != 'Windows'
+                    else 'mingw32-make',
+                )
                 hpp_file = os.path.splitext(stan_file)[0] + '.hpp'
                 hpp_file = Path(hpp_file).as_posix()
                 if not os.path.exists(hpp_file):
                     self._logger.info('stan to c++ (%s)', hpp_file)
-                    make = os.getenv(
-                        'MAKE',
-                        'make'
-                        if platform.system() != 'Windows'
-                        else 'mingw32-make',
-                    )
                     cmd = [
                         make,
                         Path(exe_file).as_posix(),
@@ -251,12 +251,6 @@ class CmdStanModel(object):
                         compilation_failed = True
 
                 if not compilation_failed:
-                    make = os.getenv(
-                        'MAKE',
-                        'make'
-                        if platform.system() != 'Windows'
-                        else 'mingw32-make',
-                    )
                     cmd = [make, 'O={}'.format(opt_lvl), exe_file]
                     self._logger.info('compiling c++')
                     try:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -236,7 +236,8 @@ class CmdStanModel(object):
                                     ', '.join(bad_paths)
                                 )
                             )
-                        cmd.append('STANCFLAGS+=--include_paths=' + 
+                        cmd.append(
+                            'STANCFLAGS+=--include_paths=' +
                             ','.join(
                                 (
                                     Path(p).as_posix()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -132,6 +132,7 @@ class CmdStanModelTest(unittest.TestCase):
 
         # test compile - implicit include path is current dir
         os.remove(os.path.join(datafiles_path, 'bernoulli_include' + '.hpp'))
+        os.remove(os.path.join(datafiles_path, 'bernoulli_include' + '.o'))
         os.remove(exe)
         model2 = CmdStanModel(stan_file=stan)
         self.assertEqual(model2.include_paths, include_paths)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Replace usage of `bin/stanc` with `make`. Fixes #169.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): American Express



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

