### PR TITLE
cleanup utils logic, add unit tests

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -466,7 +466,7 @@ class CmdStanArgs(object):
         ],
         data: Union[str, dict] = None,
         seed: Union[int, List[int]] = None,
-        inits: Union[float, str, List[str]] = None,
+        inits: Union[int, float, str, List[str]] = None,
         output_basename: str = None,
         refresh: str = None,
     ) -> None:
@@ -577,7 +577,7 @@ class CmdStanArgs(object):
             raise ValueError('data must be string or dict')
 
         if self.inits is not None:
-            if isinstance(self.inits, Real):
+            if isinstance(self.inits, (Integral, Real)):
                 if self.inits < 0:
                     raise ValueError(
                         'inits must be > 0, found {}'.format(self.inits)

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -122,8 +122,8 @@ class CmdStanModel(object):
                 libtbb = os.path.join(
                     cmdstan_path(), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
                 )
-            os.environ["PATH"] = ";".join(list(OrderedDict.fromkeys(
-                [libtbb, ] + os.getenv("PATH", "").split(";")
+            os.environ['PATH'] = ';'.join(list(OrderedDict.fromkeys(
+                [libtbb, ] + os.getenv('PATH', '').split(';')
             )))
 
         if compile and self._exe_file is None:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -81,6 +81,8 @@ class MaybeDictToFilePath(object):
                 self._paths[i] = o
             elif o is None:
                 self._paths[i] = None
+            elif i == 1 and isinstance(o, (Integral, Real)):
+                self._paths[i] = o
             else:
                 raise ValueError('data must be string or dict')
             i += 1

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -89,6 +89,38 @@ class SampleTest(unittest.TestCase):
         bern_sample = bern_fit.sample
         self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
 
+    def test_init_types(self):
+        stan = os.path.join(datafiles_path, 'bernoulli.stan')
+        bern_model = CmdStanModel(stan_file=stan)
+        jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
+
+        bern_fit = bern_model.sample(
+            data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100,
+            inits=1.1
+        )
+        self.assertIn('init=1.1', bern_fit.runset.__repr__())
+
+        bern_fit = bern_model.sample(
+            data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100,
+            inits=1
+        )
+        self.assertIn('init=1', bern_fit.runset.__repr__())
+
+        with self.assertRaises(ValueError):
+            bern_fit = bern_model.sample(
+                data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100,
+                inits=(1,2)
+            )
+
+        with self.assertRaises(ValueError):
+            bern_fit = bern_model.sample(
+                data=jdata, chains=4, cores=2, seed=12345, sampling_iters=100,
+                inits=-1
+            )
+
+
+
+
     def test_bernoulli_bad(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         bern_model = CmdStanModel(stan_file=stan)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Bugfix - sampler arg `inits` should allow scalar int or float, but this was overlooked when implementing util methods to deal with the case where it is a pathname.  Cleaned up the logic, added unit tests.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

