### PR TITLE
Add flake8 for test dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - mkdir new_dir
   - cd new_dir
   - flake8 --extend-ignore=E127,E201,E202,E203,E231,E252,E266,E402,E999,F401,F841,W503,W605 --max-line-length=80 ../cmdstanpy
-  - flake8 --extend-ignore=E127,E201,E202,E203,E231,E252,E266,E402,E999,F401,F841,W503,W605 --max-line-length=80 ../test
+  - flake8 --extend-ignore=E127,E201,E202,E203,E231,E252,E266,E402,E999,F841,W503,W605 --max-line-length=80 ../test
   - pytest -v ../test
   - python -m pip install -r ../requirements-optional.txt
   - python ../test/example_script.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - mkdir new_dir
   - cd new_dir
   - flake8 --extend-ignore=E127,E201,E202,E203,E231,E252,E266,E402,E999,F401,F841,W503,W605 --max-line-length=80 ../cmdstanpy
+  - flake8 --extend-ignore=E127,E201,E202,E203,E231,E252,E266,E402,E999,F401,F841,W503,W605 --max-line-length=80 ../test
   - pytest -v ../test
   - python -m pip install -r ../requirements-optional.txt
   - python ../test/example_script.py

--- a/test/example_script.py
+++ b/test/example_script.py
@@ -3,9 +3,9 @@ import os
 import sys
 
 # explicit import to test if it is installed
-import tqdm
+import tqdm # noqa
 
-from cmdstanpy import CmdStanModel, cmdstan_path, set_make_env
+from cmdstanpy import CmdStanModel, cmdstan_path
 
 
 def run_bernoulli_fit():

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -1,8 +1,6 @@
 import os
 import unittest
 
-from cmdstanpy import TMPDIR
-
 from cmdstanpy.cmdstan_args import (
     Method,
     SamplerArgs,
@@ -29,7 +27,6 @@ class OptimizeArgsTest(unittest.TestCase):
         args = OptimizeArgs(init_alpha=2e-4)
         args.validate()
         cmd = args.compose(None, cmd=['output'])
-
 
         self.assertIn('init_alpha=0.0002', ' '.join(cmd))
         args = OptimizeArgs(init_alpha=-1.0)
@@ -155,12 +152,14 @@ class SamplerArgsTest(unittest.TestCase):
         args = SamplerArgs(adapt_engaged=False)
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc adapt engaged=0', ' '.join(cmd))
+        self.assertIn('method=sample algorithm=hmc adapt engaged=0',
+                      ' '.join(cmd))
 
         args = SamplerArgs(adapt_engaged=True)
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc adapt engaged=1', ' '.join(cmd))
+        self.assertIn('method=sample algorithm=hmc adapt engaged=1',
+                      ' '.join(cmd))
 
         args = SamplerArgs()
         args.validate(chains=4)
@@ -172,22 +171,26 @@ class SamplerArgsTest(unittest.TestCase):
         args = SamplerArgs(metric='dense_e')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=dense_e', ' '.join(cmd))
+        self.assertIn('method=sample algorithm=hmc metric=dense_e',
+                      ' '.join(cmd))
 
         args = SamplerArgs(metric='dense')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=dense_e', ' '.join(cmd))
+        self.assertIn('method=sample algorithm=hmc metric=dense_e',
+                      ' '.join(cmd))
 
         args = SamplerArgs(metric='diag_e')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=diag_e', ' '.join(cmd))
+        self.assertIn('method=sample algorithm=hmc metric=diag_e',
+                      ' '.join(cmd))
 
         args = SamplerArgs(metric='diag')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=diag_e', ' '.join(cmd))
+        self.assertIn('method=sample algorithm=hmc metric=diag_e',
+                      ' '.join(cmd))
 
         args = SamplerArgs()
         args.validate(chains=4)
@@ -510,6 +513,7 @@ class GenerateQuantitesTest(unittest.TestCase):
         cmd = args.compose(idx=1, cmd=[])
         self.assertIn('method=generate_quantities', ' '.join(cmd))
         self.assertIn('fitted_params={}'.format(csv_files[0]), ' '.join(cmd))
+
 
 class VariationalTest(unittest.TestCase):
     def test_args_variational(self):

--- a/test/test_cxx_installation.py
+++ b/test/test_cxx_installation.py
@@ -1,11 +1,6 @@
-import argparse
-import os
 import unittest
-from unittest import mock
 import platform
-import shutil
 
-from cmdstanpy import TMPDIR
 from cmdstanpy import install_cxx_toolchain
 
 
@@ -37,7 +32,8 @@ class install_cxx_script(unittest.TestCase):
 
         with self.assertRaisesRegex(
             NotImplementedError,
-            r'Download for the C\+\+ toolchain on the current platform has not been implemented:\s*\S+',
+            r'Download for the C\+\+ toolchain on the current platform has not '
+            'been implemented:\s*\S+',
         ):
             install_cxx_toolchain.main()
 

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -1,16 +1,8 @@
 import os
 import unittest
 
-from cmdstanpy.cmdstan_args import Method, SamplerArgs, CmdStanArgs
-from cmdstanpy.utils import EXTENSION
+from cmdstanpy.cmdstan_args import Method
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.stanfit import RunSet
-from contextlib import contextmanager
-import logging
-from multiprocessing import cpu_count
-import numpy as np
-import sys
-from testfixtures import LogCapture
 
 here = os.path.dirname(os.path.abspath(__file__))
 datafiles_path = os.path.join(here, 'data')
@@ -62,15 +54,14 @@ class GenerateQuantitiesTest(unittest.TestCase):
                              bern_gqs.mcmc_sample.shape[1] +
                              bern_gqs.generated_quantities_pd.shape[1])
 
-
-
     def test_gen_quantities_csv_files_bad(self):
         stan = os.path.join(datafiles_path, 'bernoulli_ppc.stan')
         model = CmdStanModel(stan_file=stan)
         jdata = os.path.join(datafiles_path, 'bernoulli.data.json')
 
         # synthesize list of filenames
-        goodfiles_path = os.path.join(datafiles_path, 'runset-bad', 'bad-draws-bern')
+        goodfiles_path = os.path.join(datafiles_path, 'runset-bad',
+                                      'bad-draws-bern')
         csv_files = []
         for i in range(4):
             csv_files.append('{}-{}.csv'.format(goodfiles_path, i+1))
@@ -80,7 +71,6 @@ class GenerateQuantitiesTest(unittest.TestCase):
                 data=jdata,
                 mcmc_sample=csv_files
                 )
-
 
     def test_gen_quanties_mcmc_sample(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -123,7 +113,8 @@ class GenerateQuantitiesTest(unittest.TestCase):
             'y_rep.10',
         ]
         self.assertEqual(bern_gqs.column_names, tuple(column_names))
-        self.assertEqual(bern_fit.get_drawset().shape, bern_gqs.mcmc_sample.shape)
+        self.assertEqual(bern_fit.get_drawset().shape,
+                         bern_gqs.mcmc_sample.shape)
         self.assertEqual(bern_gqs.sample_plus_quantities.shape[1],
                              bern_gqs.mcmc_sample.shape[1] +
                              bern_gqs.generated_quantities_pd.shape[1])
@@ -142,7 +133,6 @@ class GenerateQuantitiesTest(unittest.TestCase):
         )
         self.assertEqual(bern_gqs.sample_plus_quantities.shape[1],
                              bern_gqs.mcmc_sample.shape[1])
-
 
 
 if __name__ == '__main__':

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,14 +1,10 @@
 import os
 import unittest
 
-from cmdstanpy.cmdstan_args import Method, SamplerArgs, CmdStanArgs
 from cmdstanpy.utils import EXTENSION
 from cmdstanpy.model import CmdStanModel
-from contextlib import contextmanager
 
 from cmdstanpy.utils import cmdstan_path
-
-import sys
 
 here = os.path.dirname(os.path.abspath(__file__))
 datafiles_path = os.path.join(here, 'data')
@@ -36,7 +32,7 @@ class CmdStanModelTest(unittest.TestCase):
     def test_model_good(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         exe = os.path.join(datafiles_path, 'bernoulli' + EXTENSION)
-        
+
         # compile on instantiation
         model = CmdStanModel(stan_file=stan)
         self.assertEqual(stan, model.stan_file)
@@ -82,7 +78,6 @@ class CmdStanModelTest(unittest.TestCase):
         stan = os.path.join(datafiles_path, 'bad_syntax.stan')
         with self.assertRaises(Exception):
             model = CmdStanModel(stan_file=stan)
-
 
     def test_repr(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
@@ -140,7 +135,6 @@ class CmdStanModelTest(unittest.TestCase):
         # already compiled
         model3 = CmdStanModel(stan_file=stan)
         self.assertTrue(model3.exe_file.endswith(exe.replace('\\', '/')))
-
 
 
 if __name__ == '__main__':

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -2,16 +2,10 @@ import os
 import unittest
 import json
 
-from cmdstanpy.cmdstan_args import Method, OptimizeArgs, CmdStanArgs
+from cmdstanpy.cmdstan_args import OptimizeArgs, CmdStanArgs
 from cmdstanpy.utils import EXTENSION
 from cmdstanpy.model import CmdStanModel
 from cmdstanpy.stanfit import RunSet, CmdStanMLE
-from contextlib import contextmanager
-import logging
-from multiprocessing import cpu_count
-import numpy as np
-import sys
-from testfixtures import LogCapture
 
 here = os.path.dirname(os.path.abspath(__file__))
 datafiles_path = os.path.join(here, 'data')
@@ -43,7 +37,6 @@ class CmdStanMLETest(unittest.TestCase):
         self.assertEqual(mle.column_names,('lp__', 'x', 'y'))
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
-        
 
 
 class OptimizeTest(unittest.TestCase):
@@ -101,7 +94,6 @@ class OptimizeTest(unittest.TestCase):
         self.assertAlmostEqual(mle.optimized_params_np[0], -5, places=2)
         self.assertAlmostEqual(mle.optimized_params_np[1], 0.2, places=3)
 
-
     def test_optimize_rosenbrock(self):
         stan = os.path.join(datafiles_path, 'optimize', 'rosenbrock.stan')
         rose_model = CmdStanModel(stan_file=stan)
@@ -116,12 +108,13 @@ class OptimizeTest(unittest.TestCase):
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
 
-
     def test_optimize_bad(self):
-        stan = os.path.join(datafiles_path, 'optimize', 'exponential_boundary.stan')
+        stan = os.path.join(datafiles_path, 'optimize',
+                            'exponential_boundary.stan')
         exp_bound_model = CmdStanModel(stan_file=stan)
         no_data = {}
-        with self.assertRaisesRegex(Exception, 'Error during optimizing, error code 70'):
+        with self.assertRaisesRegex(Exception,
+                                    'Error during optimizing, error code 70'):
             exp_bound_model.optimize(
                 data=no_data,
                 seed=1239812093,

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -15,6 +15,7 @@ datafiles_path = os.path.join(here, 'data')
 goodfiles_path = os.path.join(datafiles_path, 'runset-good')
 badfiles_path = os.path.join(datafiles_path, 'runset-bad')
 
+
 class SampleTest(unittest.TestCase):
     def test_bernoulli_good(self, stanfile='bernoulli.stan'):
         stan = os.path.join(datafiles_path, stanfile)
@@ -118,9 +119,6 @@ class SampleTest(unittest.TestCase):
                 inits=-1
             )
 
-
-
-
     def test_bernoulli_bad(self):
         stan = os.path.join(datafiles_path, 'bernoulli.stan')
         bern_model = CmdStanModel(stan_file=stan)
@@ -178,7 +176,7 @@ class SampleTest(unittest.TestCase):
             self.assertTrue(os.path.exists(txt_file))
 
         self.assertEqual(datagen_fit.runset.chains, 1)
-                             
+
         column_names = [
             'lp__',
             'accept_stat__',
@@ -277,7 +275,9 @@ class SampleTest(unittest.TestCase):
         self.test_bernoulli_good('bernoulli with space in name.stan')
 
     def test_bernoulli_path_with_space(self):
-        self.test_bernoulli_good('path with space/bernoulli_path_with_space.stan')
+        self.test_bernoulli_good('path with space/'
+                                 'bernoulli_path_with_space.stan')
+
 
 class CmdStanMCMCTest(unittest.TestCase):
     def test_validate_good_run(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,7 +2,6 @@ import json
 import os
 import unittest
 import platform
-import tempfile
 import shutil
 import string
 import random
@@ -11,7 +10,6 @@ import numpy as np
 
 from cmdstanpy import TMPDIR
 from cmdstanpy.utils import (
-    EXTENSION,
     cmdstan_path,
     set_cmdstan_path,
     validate_cmdstan_path,
@@ -148,7 +146,6 @@ class CmdStanPathTest(unittest.TestCase):
         jsondump(file_zero_matrix, dict_zero_matrix)
         with open(file_zero_matrix) as fp:
             self.assertEqual(json.load(fp), dict_zero_matrix)
-
 
 
 class ReadStanCsvTest(unittest.TestCase):
@@ -380,7 +377,8 @@ class RloadTest(unittest.TestCase):
         os.remove(dfile_tmp)
 
     def test_parse_rdump_value(self):
-        s1 = 'structure(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),.Dim=c(2,8))'
+        s1 = 'structure(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,'
+        ' 16),.Dim=c(2,8))'
         v_s1 = parse_rdump_value(s1)
         self.assertEqual(v_s1.shape, (2, 8))
         self.assertEqual(v_s1[1, 0], 2)
@@ -390,7 +388,8 @@ class RloadTest(unittest.TestCase):
         v_s2 = parse_rdump_value(s2)
         self.assertEqual(v_s2.shape, (1, 16))
 
-        s3 = 'structure(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),.Dim = c(8, 2))'
+        s3 = 'structure(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,'
+        ' 16),.Dim = c(8, 2))'
         v_s3 = parse_rdump_value(s3)
         self.assertEqual(v_s3.shape, (8, 2))
         self.assertEqual(v_s3[1, 0], 2)

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -1,17 +1,9 @@
 import os
 import unittest
-import json
 from math import fabs
-from cmdstanpy.cmdstan_args import Method, VariationalArgs, CmdStanArgs
-from cmdstanpy.utils import EXTENSION
+from cmdstanpy.cmdstan_args import VariationalArgs, CmdStanArgs
 from cmdstanpy.model import CmdStanModel
 from cmdstanpy.stanfit import RunSet, CmdStanVB
-from contextlib import contextmanager
-import logging
-from multiprocessing import cpu_count
-import numpy as np
-import sys
-from testfixtures import LogCapture
 
 here = os.path.dirname(os.path.abspath(__file__))
 datafiles_path = os.path.join(here, 'data')
@@ -19,7 +11,8 @@ datafiles_path = os.path.join(here, 'data')
 
 class CmdStanVBTest(unittest.TestCase):
     def test_set_variational_attrs(self):
-        stan = os.path.join(datafiles_path, 'variational', 'eta_should_be_big.stan')
+        stan = os.path.join(datafiles_path, 'variational',
+                            'eta_should_be_big.stan')
         model = CmdStanModel(stan_file=stan)
         no_data = {}
         args = VariationalArgs(algorithm='meanfield')
@@ -41,26 +34,34 @@ class CmdStanVBTest(unittest.TestCase):
         self.assertEqual(vi._variational_sample,None)
 
         # process csv file, check attrs
-        output = os.path.join(datafiles_path, 'variational', 'eta_big_output.csv')
+        output = os.path.join(datafiles_path, 'variational',
+                              'eta_big_output.csv')
         vi._set_variational_attrs(output)
-        self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1', 'mu.2'))
-        self.assertAlmostEqual(vi.variational_params_dict['mu.1'], 31.0299, places=2)
-        self.assertAlmostEqual(vi.variational_params_dict['mu.2'], 28.8141, places=2)
+        self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1',
+                                          'mu.2'))
+        self.assertAlmostEqual(vi.variational_params_dict['mu.1'], 31.0299,
+                               places=2)
+        self.assertAlmostEqual(vi.variational_params_dict['mu.2'], 28.8141,
+                               places=2)
         self.assertEqual(vi.variational_sample.shape, (1000, 5))
 
 
 class VariationalTest(unittest.TestCase):
     def test_variational_good(self):
-        stan = os.path.join(datafiles_path, 'variational', 'eta_should_be_big.stan')
+        stan = os.path.join(datafiles_path, 'variational',
+                            'eta_should_be_big.stan')
         model = CmdStanModel(stan_file=stan)
         vi = model.variational(algorithm='meanfield', seed=12345)
-        self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1', 'mu.2'))
+        self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1',
+                                          'mu.2'))
 
         self.assertAlmostEqual(vi.variational_params_np[3], 31.0418, places=2)
         self.assertAlmostEqual(vi.variational_params_np[4], 27.4463, places=2)
 
-        self.assertAlmostEqual(vi.variational_params_dict['mu.1'], 31.0418, places=2)
-        self.assertAlmostEqual(vi.variational_params_dict['mu.2'], 27.4463, places=2)
+        self.assertAlmostEqual(vi.variational_params_dict['mu.1'], 31.0418,
+                               places=2)
+        self.assertAlmostEqual(vi.variational_params_dict['mu.2'], 27.4463,
+                               places=2)
 
         self.assertEqual(
             vi.variational_params_np[0], vi.variational_params_pd['lp__'][0]
@@ -77,21 +78,25 @@ class VariationalTest(unittest.TestCase):
     def test_variational_missing_args(self):
         self.assertTrue(True)
 
-
     def test_variational_eta_small(self):
-        stan = os.path.join(datafiles_path, 'variational', 'eta_should_be_small.stan')
+        stan = os.path.join(datafiles_path, 'variational',
+                            'eta_should_be_small.stan')
         model = CmdStanModel(stan_file=stan)
         vi = model.variational(algorithm='meanfield', seed=12345)
-        self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1', 'mu.2'))
-        self.assertAlmostEqual(fabs(vi.variational_params_dict['mu.1']), 0.08, places=1)
-        self.assertAlmostEqual(fabs(vi.variational_params_dict['mu.2']), 0.09, places=1)
+        self.assertEqual(vi.column_names,('lp__', 'log_p__', 'log_g__', 'mu.1',
+                                          'mu.2'))
+        self.assertAlmostEqual(fabs(vi.variational_params_dict['mu.1']), 0.08,
+                               places=1)
+        self.assertAlmostEqual(fabs(vi.variational_params_dict['mu.2']), 0.09,
+                               places=1)
         self.assertTrue(True)
 
-
     def test_variational_eta_fail(self):
-        stan = os.path.join(datafiles_path, 'variational', 'eta_should_fail.stan')
+        stan = os.path.join(datafiles_path, 'variational',
+                            'eta_should_fail.stan')
         model = CmdStanModel(stan_file=stan)
-        with self.assertRaisesRegex(RuntimeError, 'algorithm may not have converged'):
+        with self.assertRaisesRegex(RuntimeError,
+                                    'algorithm may not have converged'):
             vi = model.variational(algorithm='meanfield', seed=12345)
 
 

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -2,7 +2,6 @@ import os
 import unittest
 from math import fabs
 import pytest
-import json
 from cmdstanpy.cmdstan_args import VariationalArgs, CmdStanArgs
 from cmdstanpy.model import CmdStanModel
 from cmdstanpy.stanfit import RunSet, CmdStanVB


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds `flake8` for the test dir in Travis. Updates style in test files in order to pass `flake8`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): American Express



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

