### PR TITLE
Fix non-rendering code blocks

### DIFF
--- a/docs/generate_quantities.rst
+++ b/docs/generate_quantities.rst
@@ -82,7 +82,7 @@ which generates a new data vector ``y_rep`` using the current estimate of theta.
 
 The first step is to fit model ``bernoulli`` to the data:
 
-.. code:: ipython3
+.. code:: python
 
     import os
     from cmdstanpy import CmdStanModel, cmdstan_path
@@ -102,7 +102,7 @@ Then we compile the model ``bernoulli_ppc`` and use the fit parameter estimates
 to generate quantities of interest:
 
 
-.. code:: ipython3
+.. code:: python
 
     bernoulli_ppc_model = CmdStanModel(stan_file='bernoulli_ppc.stan')
     bernoulli_ppc_model.compile()
@@ -115,7 +115,7 @@ of the program ``bernoulli_ppc.stan``. Unlike the output from the
 probability density, sampler state, or parameters or transformed
 parameter values.
 
-.. code:: ipython3
+.. code:: python
 
     new_quantities.column_names
     new_quantities.generated_quantities.shape
@@ -126,7 +126,7 @@ parameter values.
 The method ``sample_plus_quantities`` returns a pandas DataFrame which
 combines the input drawset with the generated quantities.
 
-.. code:: ipython3
+.. code:: python
 
     sample_plus = new_quantities.sample_plus_quantities
     print(sample_plus.shape)

--- a/docs/optimize.rst
+++ b/docs/optimize.rst
@@ -41,7 +41,7 @@ penalized maximum likelihood estaimate of all model parameters:
 
 In the following example, we instantiate a model and do optimization using the default CmdStan settings:
 
-.. code:: ipython3
+.. code:: python
 
     import os
     from cmdstanpy.model import CmdStanModel

--- a/docs/sample.rst
+++ b/docs/sample.rst
@@ -111,7 +111,7 @@ For example, the Stan program
 `bernoulli.stan <https://github.com/stan-dev/cmdstanpy/blob/master/test/data/bernoulli_datagen.stan>`__
 can be used to generate a dataset of simulated data, where each row in the dataset consists of `N` draws from a Bernoulli distribution given probability `theta`:
 
-.. code-block::
+.. code::
 
     transformed data { 
       int<lower=0> N = 10;

--- a/docs/variational_bayes.rst
+++ b/docs/variational_bayes.rst
@@ -72,7 +72,7 @@ and the returned set of draws from this approximate posterior (if any):
 
 In the following example, we instantiate a model and run variational inference using the default CmdStan settings:
 
-.. code:: ipython3
+.. code:: python
 
     import os
     from cmdstanpy.model import CmdStanModel
@@ -93,7 +93,7 @@ These estimates are only valid if the algorithm has converged to a good
 approximation. When the algorithm fails to do so, the ``variational``
 method will throw a ``RuntimeError``.
 
-.. code:: ipython3
+.. code:: python
 
     fail_stan = os.path.join(datafiles_path, 'variational', 'eta_should_fail.stan')
     fail_model = CmdStanModel(stan_file=fail_stan)


### PR DESCRIPTION
Use code:: instead of code-block::
code-block:: not rendering on readthedocs

Change ipython3 blocks to python
ipython3 code blocks don't show up in Sphinx documentation, but
python blocks do

Fixes #178.

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This should fix the rendering of some code blocks on readthedocs. I'm unable to test other than locally, where it isn't a problem like it is online.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): American Express



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

