### PR TITLE
Bugfix/185 csv basename

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -531,9 +531,8 @@ class CmdStanArgs:
                 os.remove(testpath)  # cleanup
             except Exception:
                 raise ValueError(
-                    'invalid path for output files, cannot write to dir: {}'.format(
-                        self.output_dir
-                    )
+                    'invalid path for output files, '
+                    'cannot write to dir: {}'.format( self.output_dir)
                 )
 
         if self.seed is None:

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -518,6 +518,8 @@ class CmdStanArgs:
                     )
 
         if self.output_dir is not None:
+            self.output_dir = os.path.realpath(os.path.expanduser(
+                self.output_dir))
             if not os.path.exists(os.path.dirname(self.output_dir)):
                 raise ValueError(
                     'invalid path for output files, no such dir: {}'.format(

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -13,6 +13,7 @@ from cmdstanpy.utils import read_metric
 
 class Method(Enum):
     """Supported CmdStan method names."""
+
     SAMPLE = auto()
     OPTIMIZE = auto()
     GENERATE_QUANTITIES = auto()
@@ -22,7 +23,7 @@ class Method(Enum):
         return '<%s.%s>' % (self.__class__.__name__, self.name)
 
 
-class SamplerArgs():
+class SamplerArgs:
     """Arguments for the NUTS adaptive sampler."""
 
     def __init__(
@@ -241,7 +242,7 @@ class SamplerArgs():
         return cmd
 
 
-class OptimizeArgs():
+class OptimizeArgs:
     """Container for arguments for the optimizer."""
 
     OPTIMIZE_ALGOS = {'BFGS', 'LBFGS', 'Newton'}
@@ -300,7 +301,7 @@ class OptimizeArgs():
         return cmd
 
 
-class GenerateQuantitiesArgs():
+class GenerateQuantitiesArgs:
     """Arguments needed for generate_quantities method."""
 
     def __init__(self, csv_files: List[str]) -> None:
@@ -328,7 +329,7 @@ class GenerateQuantitiesArgs():
         return cmd
 
 
-class VariationalArgs():
+class VariationalArgs:
     """Arguments needed for variational method."""
 
     VARIATIONAL_ALGOS = {'meanfield', 'fullrank'}
@@ -453,7 +454,7 @@ class VariationalArgs():
         return cmd
 
 
-class CmdStanArgs():
+class CmdStanArgs:
     """
     Container for CmdStan command line arguments.
     Consists of arguments common to all methods and

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -532,7 +532,7 @@ class CmdStanArgs:
             except Exception:
                 raise ValueError(
                     'invalid path for output files, '
-                    'cannot write to dir: {}'.format( self.output_dir)
+                    'cannot write to dir: {}'.format(self.output_dir)
                 )
 
         if self.seed is None:

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -2,6 +2,7 @@
 CmdStan arguments
 """
 import os
+from time import time
 from enum import Enum, auto
 from numbers import Integral, Real
 from typing import List, Union
@@ -470,7 +471,7 @@ class CmdStanArgs():
         data: Union[str, dict] = None,
         seed: Union[int, List[int]] = None,
         inits: Union[int, float, str, List[str]] = None,
-        output_basename: str = None,
+        output_dir: str = None,
         refresh: str = None,
     ) -> None:
         """Initialize object."""
@@ -480,7 +481,7 @@ class CmdStanArgs():
         self.data = data
         self.seed = seed
         self.inits = inits
-        self.output_basename = output_basename
+        self.output_dir = output_dir
         self.refresh = refresh
         self.method_args = method_args
         if isinstance(method_args, SamplerArgs):
@@ -515,24 +516,24 @@ class CmdStanArgs():
                         'invalid chain_id {}'.format(self.chain_ids[i])
                     )
 
-        if self.output_basename is not None:
-            if not os.path.exists(os.path.dirname(self.output_basename)):
+        if self.output_dir is not None:
+            if not os.path.exists(os.path.dirname(self.output_dir)):
                 raise ValueError(
-                    'invalid path for output files: {}'.format(
-                        self.output_basename
+                    'invalid path for output files, no such dir: {}'.format(
+                        self.output_dir
                     )
                 )
             try:
-                with open(self.output_basename, 'w+') as fd:
+                testpath = os.path.join(self.output_dir, str(time()))
+                with open(testpath, 'w+') as fd:
                     pass
-                os.remove(self.output_basename)  # cleanup
+                os.remove(testpath)  # cleanup
             except Exception:
                 raise ValueError(
-                    'invalid path for output files: {}'.format(
-                        self.output_basename
+                    'invalid path for output files, cannot write to dir: {}'.format(
+                        self.output_dir
                     )
                 )
-            self.output_basename, _ = os.path.splitext(self.output_basename)
 
         if self.seed is None:
             rng = RandomState()

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -316,7 +316,7 @@ class CmdStanModel:
 
         Output filenames are composed of the model name, a timestamp
         in the form YYYYMMDDhhmm and the chain id, plus the corresponding
-        filetype suffix, either '.csv' for the CmdStan output or '.txt' for 
+        filetype suffix, either '.csv' for the CmdStan output or '.txt' for
         the console messages, e.g. `bernoulli-201912081451-1.csv`. Output files
         written to the temporary directory contain an additional 8-character
         random string, e.g. `bernoulli-201912081451-1-5nm6as7u.csv`.
@@ -420,13 +420,13 @@ class CmdStanModel:
 
         For each chain, the ``CmdStanMCMC`` object records the command,
         the return code, the sampler output file paths, and the corresponding
-        console outputs, if any. The output files are written either to a 
+        console outputs, if any. The output files are written either to a
         specified output directory or to a temporary directory which is deleted
         upon session exit.
 
         The output filenames are composed of the model name, a timestamp
         in the form YYYYMMDDhhmm and the chain id, plus the corresponding
-        filetype suffix, either '.csv' for the CmdStan output or '.txt' for 
+        filetype suffix, either '.csv' for the CmdStan output or '.txt' for
         the console messages, e.g. `bernoulli-201912081451-1.csv`. Output files
         written to the temporary directory contain an additional 8-character
         random string, e.g. `bernoulli-201912081451-1-5nm6as7u.csv`.
@@ -729,7 +729,7 @@ class CmdStanModel:
         """
         Run CmdStan's generate_quantities method which runs the generated
         quantities block of a model given an existing sample.
-        
+
         This function takes a CmdStanMCMC object and the dataset used to
         generate that sample and calls to the CmdStan ``generate_quantities``
         method to generate additional quantities of interest.
@@ -741,7 +741,7 @@ class CmdStanModel:
 
         Output filenames are composed of the model name, a timestamp
         in the form YYYYMMDDhhmm and the chain id, plus the corresponding
-        filetype suffix, either '.csv' for the CmdStan output or '.txt' for 
+        filetype suffix, either '.csv' for the CmdStan output or '.txt' for
         the console messages, e.g. `bernoulli_ppc-201912081451-1.csv`. Output
         files  written to the temporary directory contain an additional
         8-character random string, e.g.
@@ -876,7 +876,7 @@ class CmdStanModel:
 
         Output filenames are composed of the model name, a timestamp
         in the form YYYYMMDDhhmm and the chain id, plus the corresponding
-        filetype suffix, either '.csv' for the CmdStan output or '.txt' for 
+        filetype suffix, either '.csv' for the CmdStan output or '.txt' for
         the console messages, e.g. `bernoulli-201912081451-1.csv`. Output files
         written to the temporary directory contain an additional 8-character
         random string, e.g. `bernoulli-201912081451-1-5nm6as7u.csv`.

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -61,9 +61,9 @@ class CmdStanModel:
         logger: logging.Logger = None,
     ) -> None:
         """Initialize object."""
-        self._stan_file = stan_file
+        self._stan_file = None
         self._name = None
-        self._exe_file = exe_file
+        self._exe_file = None
         self._include_paths = None
         self._logger = logger or get_logger()
 
@@ -83,10 +83,10 @@ class CmdStanModel:
                 )
             self._name, _ = os.path.splitext(filename)
             # if program has #includes, search program dir
-            with open(stan_file, 'r') as fd:
+            with open(self._stan_file, 'r') as fd:
                 program = fd.read()
             if '#include' in program:
-                path, _ = os.path.split(stan_file)
+                path, _ = os.path.split(self._stan_file)
                 if include_paths is None:
                     include_paths = []
                 if path not in include_paths:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -73,7 +73,7 @@ class CmdStanModel:
                     'must specify Stan source or executable program file'
                 )
         else:
-            self._stan_file =  os.path.realpath(os.path.expanduser(stan_file))
+            self._stan_file = os.path.realpath(os.path.expanduser(stan_file))
             if not os.path.exists(self._stan_file):
                 raise ValueError('no such file {}'.format(self._stan_file))
             _, filename = os.path.split(stan_file)
@@ -641,11 +641,7 @@ class CmdStanModel:
                 method_args=sampler_args,
                 refresh=refresh,
             )
-            print(args)
-
             runset = RunSet(args=args, chains=chains)
-            print(runset)
-            
             pbar = None
             pbar_dict = {}
             with ThreadPoolExecutor(max_workers=cores) as executor:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -38,7 +38,7 @@ from cmdstanpy.utils import (
 )
 
 
-class CmdStanModel():
+class CmdStanModel:
     """
     Stan model.
 
@@ -122,9 +122,13 @@ class CmdStanModel():
                 libtbb = os.path.join(
                     cmdstan_path(), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
                 )
-            os.environ['PATH'] = ';'.join(list(OrderedDict.fromkeys(
-                [libtbb, ] + os.getenv('PATH', '').split(';')
-            )))
+            os.environ['PATH'] = ';'.join(
+                list(
+                    OrderedDict.fromkeys(
+                        [libtbb] + os.getenv('PATH', '').split(';')
+                    )
+                )
+            )
 
         if compile and self._exe_file is None:
             self.compile()
@@ -226,7 +230,7 @@ class CmdStanModel():
                     cmd = [
                         make,
                         Path(exe_file).as_posix(),
-                        'STANCFLAGS+=--o={}'.format(hpp_file)
+                        'STANCFLAGS+=--o={}'.format(hpp_file),
                     ]
                     if self._include_paths is not None:
                         bad_paths = [
@@ -241,8 +245,8 @@ class CmdStanModel():
                                 )
                             )
                         cmd.append(
-                            'STANCFLAGS+=--include_paths=' +
-                            ','.join(
+                            'STANCFLAGS+=--include_paths='
+                            + ','.join(
                                 (
                                     Path(p).as_posix()
                                     for p in self._include_paths
@@ -254,7 +258,7 @@ class CmdStanModel():
                     except RuntimeError as e:
                         self._logger.error(
                             'file %s, exception %s', stan_file, repr(e)
-                            )
+                        )
                         compilation_failed = True
 
                 if not compilation_failed:
@@ -801,7 +805,8 @@ class CmdStanModel():
             raise ValueError(
                 'Invalid mcmc_sample, error:\n\t{}\n\t'
                 ' while processing files\n\t{}'.format(
-                    repr(e), '\n\t'.join(sample_csv_files))
+                    repr(e), '\n\t'.join(sample_csv_files)
+                )
             )
 
         generate_quantities_args = GenerateQuantitiesArgs(
@@ -977,10 +982,7 @@ class CmdStanModel():
         self._logger.info('start chain %u', idx + 1)
         self._logger.debug('sampling: %s', cmd)
         proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=os.environ,
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ
         )
         if pbar:
             stdout_pbar = self._read_progress(proc, pbar, idx)
@@ -1109,7 +1111,7 @@ class CmdStanModel():
                 pbar_sampling.update(sampling_cumulative_count)
                 pbar_sampling.refresh()
 
-        except Exception as e:    # pylint: disable=broad-except
+        except Exception as e:  # pylint: disable=broad-except
             self._logger.warning(
                 'Chain %s: Failed to read the progress on the fly. Error: %s',
                 idx,

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -63,7 +63,7 @@ class CmdStanModel:
         """Initialize object."""
         self._stan_file = stan_file
         self._name = None
-        self._exe_file = None
+        self._exe_file = exe_file
         self._include_paths = None
         self._logger = logger or get_logger()
 
@@ -73,7 +73,8 @@ class CmdStanModel:
                     'must specify Stan source or executable program file'
                 )
         else:
-            if not os.path.exists(stan_file):
+            self._stan_file =  os.path.realpath(os.path.expanduser(stan_file))
+            if not os.path.exists(self._stan_file):
                 raise ValueError('no such file {}'.format(self._stan_file))
             _, filename = os.path.split(stan_file)
             if len(filename) < 6 or not filename.endswith('.stan'):
@@ -81,7 +82,6 @@ class CmdStanModel:
                     'invalid stan filename {}'.format(self._stan_file)
                 )
             self._name, _ = os.path.splitext(filename)
-            self._exe_file = None
             # if program has #includes, search program dir
             with open(stan_file, 'r') as fd:
                 program = fd.read()
@@ -93,9 +93,10 @@ class CmdStanModel:
                     include_paths.append(path)
 
         if exe_file is not None:
-            if not os.path.exists(exe_file):
-                raise ValueError('no such file {}'.format(exe_file))
-            _, exename = os.path.split(exe_file)
+            self._exe_file = os.path.realpath(os.path.expanduser(exe_file))
+            if not os.path.exists(self._exe_file):
+                raise ValueError('no such file {}'.format(self._exe_file))
+            _, exename = os.path.split(self._exe_file)
             if self._name is None:
                 self._name, _ = os.path.splitext(exename)
             else:
@@ -105,7 +106,6 @@ class CmdStanModel:
                         ' executable, expecting basename: {}'
                         ' found: {}'.format(self._name, exename)
                     )
-            self._exe_file = exe_file
 
         if include_paths is not None:
             bad_paths = [d for d in include_paths if not os.path.exists(d)]
@@ -641,9 +641,11 @@ class CmdStanModel:
                 method_args=sampler_args,
                 refresh=refresh,
             )
+            print(args)
 
             runset = RunSet(args=args, chains=chains)
-
+            print(runset)
+            
             pbar = None
             pbar_dict = {}
             with ThreadPoolExecutor(max_workers=cores) as executor:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -156,7 +156,7 @@ class RunSet:
         :param dir: directory path
         """
         if dir is None:
-            dir = '.'
+            dir = os.path.realpath('.')
         test_path = os.path.join(dir, str(time()))
         try:
             os.makedirs(dir, exist_ok=True)

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -91,7 +91,7 @@ class RunSet:
                 self._cmds.append(args.compose_command(i, self._csv_files[i],
                                                     self._diagnostic_files[i]))
             else:
-                self._cmds.append(args.compose_command(i, self._csv_files[i])
+                self._cmds.append(args.compose_command(i, self._csv_files[i]))
 
 
     def __repr__(self) -> str:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -458,8 +458,6 @@ class CmdStanMCMC:
         + Low E-BFMI values (sampler transitions HMC potential energy)
         + Low effective sample sizes
         + High R-hat values
-
-        :return str empty if no problems found
         """
         cmd_path = os.path.join(cmdstan_path(), 'bin', 'diagnose' + EXTENSION)
         cmd = [cmd_path] + self.runset.csv_files

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -85,14 +85,17 @@ class RunSet:
                     diag_file = os.path.join(
                         output_dir,
                         '{}-diagnostic-{}.{}'.format(
-                            file_basename, i + 1, 'csv')
+                            file_basename, i + 1, 'csv'
+                        ),
                     )
                 self._diagnostic_files.append(diag_file)
-                self._cmds.append(args.compose_command(i, self._csv_files[i],
-                                                    self._diagnostic_files[i]))
+                self._cmds.append(
+                    args.compose_command(
+                        i, self._csv_files[i], self._diagnostic_files[i]
+                    )
+                )
             else:
                 self._cmds.append(args.compose_command(i, self._csv_files[i]))
-
 
     def __repr__(self) -> str:
         repr = 'RunSet: chains={}'.format(self._chains)

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -26,7 +26,7 @@ from cmdstanpy.utils import (
 from cmdstanpy.cmdstan_args import Method, CmdStanArgs
 
 
-class RunSet():
+class RunSet:
     """
     Record of CmdStan run for a specified configuration and number of chains.
     """
@@ -55,7 +55,7 @@ class RunSet():
             output_dir = args.output_dir
         else:
             output_dir = TMPDIR
-            
+
         self._csv_files = []
         self._console_files = []
         self._cmds = []
@@ -67,7 +67,9 @@ class RunSet():
                     suffix='.csv',
                 )
             else:
-                csv_file = os.path.join(output_dir, '{}-{}.{}'.format(file_basename, i + 1, 'csv'))
+                csv_file = os.path.join(
+                    output_dir, '{}-{}.{}'.format(file_basename, i + 1, 'csv')
+                )
             self._csv_files.append(csv_file)
             txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
             self._console_files.append(txt_file)
@@ -169,13 +171,13 @@ class RunSet():
                 raise ValueError(
                     'cannot access csv file {}'.format(self._csv_files[i])
                 )
-            
+
             path, filename = os.path.split(self._csv_files[i])
-            if path == TMPDIR:   # cleanup tmpstr in filename
+            if path == TMPDIR:  # cleanup tmpstr in filename
                 root, ext = os.path.splitext(filename)
                 rlist = root.split('-')
                 root = '-'.join(rlist[:-1])
-                filename = ''.join([root,ext])
+                filename = ''.join([root, ext])
 
             to_path = os.path.join(dir, filename)
             if os.path.exists(to_path):
@@ -194,7 +196,7 @@ class RunSet():
                 ) from e
 
 
-class CmdStanMCMC():
+class CmdStanMCMC:
     """
     Container for outputs from CmdStan sampler run.
     """
@@ -471,7 +473,7 @@ class CmdStanMCMC():
         self.runset.save_csvfiles(dir)
 
 
-class CmdStanMLE():
+class CmdStanMLE:
     """
     Container for outputs from CmdStan optimization.
     """
@@ -542,7 +544,7 @@ class CmdStanMLE():
         self.runset.save_csvfiles(dir)
 
 
-class CmdStanGQ():
+class CmdStanGQ:
     """
     Container for outputs from CmdStan generate_quantities run.
     """
@@ -595,9 +597,7 @@ class CmdStanGQ():
         flattened chain, draw ordering.
         """
         if not self.runset.method == Method.GENERATE_QUANTITIES:
-            raise ValueError(
-                'Bad runset method {}.'.format(self.runset.method)
-            )
+            raise ValueError('Bad runset method {}.'.format(self.runset.method))
         if self._generated_quantities is None:
             self._assemble_generated_quantities()
         return self._generated_quantities
@@ -609,9 +609,7 @@ class CmdStanGQ():
         one column per quantity of interest and one row per draw.
         """
         if not self.runset.method == Method.GENERATE_QUANTITIES:
-            raise ValueError(
-                'Bad runset method {}.'.format(self.runset.method)
-            )
+            raise ValueError('Bad runset method {}.'.format(self.runset.method))
         if self._generated_quantities is None:
             self._assemble_generated_quantities()
         return pd.DataFrame(
@@ -628,9 +626,7 @@ class CmdStanGQ():
         values in the generate quantities drawset.
         """
         if not self.runset.method == Method.GENERATE_QUANTITIES:
-            raise ValueError(
-                'Bad runset method {}.'.format(self.runset.method)
-            )
+            raise ValueError('Bad runset method {}.'.format(self.runset.method))
         if self._generated_quantities is None:
             self._assemble_generated_quantities()
 
@@ -674,7 +670,7 @@ class CmdStanGQ():
         self.runset.save_csvfiles(dir)
 
 
-class CmdStanVB():
+class CmdStanVB:
     """
     Container for outputs from CmdStan variational run.
     """

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -713,6 +713,7 @@ def do_command(cmd: str, cwd: str = None, logger: logging.Logger = None) -> str:
     Spawn process, print stdout/stderr to console.
     Throws RuntimeError on non-zero returncode.
     """
+    print(cmd)
     if logger:
         logger.debug('cmd: %s', cmd)
     proc = subprocess.Popen(

--- a/cmdstanpy_tutorial.ipynb
+++ b/cmdstanpy_tutorial.ipynb
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,26 +132,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:cmdstanpy:stan to c++ (/Users/mitzi/.cmdstanpy/cmdstan-2.20.0/examples/bernoulli/bernoulli.hpp)\n",
-      "INFO:cmdstanpy:compiling c++\n",
-      "INFO:cmdstanpy:compiled model file: /Users/mitzi/.cmdstanpy/cmdstan-2.20.0/examples/bernoulli/bernoulli\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CmdStanModel(name=bernoulli,  stan_file=\"/Users/mitzi/.cmdstanpy/cmdstan-2.20.0/examples/bernoulli/bernoulli.stan\", exe_file=\"/Users/mitzi/.cmdstanpy/cmdstan-2.20.0/examples/bernoulli/bernoulli\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
     "print(bernoulli_model)"
@@ -173,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,24 +188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:cmdstanpy:start chain 1\n",
-      "INFO:cmdstanpy:start chain 2\n",
-      "INFO:cmdstanpy:finish chain 1\n",
-      "INFO:cmdstanpy:start chain 3\n",
-      "INFO:cmdstanpy:finish chain 2\n",
-      "INFO:cmdstanpy:start chain 4\n",
-      "INFO:cmdstanpy:finish chain 3\n",
-      "INFO:cmdstanpy:finish chain 4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_fit = bernoulli_model.sample(data=bern_data)"
    ]
@@ -245,99 +213,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Mean</th>\n",
-       "      <th>MCSE</th>\n",
-       "      <th>StdDev</th>\n",
-       "      <th>5%</th>\n",
-       "      <th>50%</th>\n",
-       "      <th>95%</th>\n",
-       "      <th>N_Eff</th>\n",
-       "      <th>N_Eff/s</th>\n",
-       "      <th>R_hat</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>name</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>lp__</th>\n",
-       "      <td>-7.267660</td>\n",
-       "      <td>0.016792</td>\n",
-       "      <td>0.710076</td>\n",
-       "      <td>-8.741910</td>\n",
-       "      <td>-6.98903</td>\n",
-       "      <td>-6.750200</td>\n",
-       "      <td>1788.22</td>\n",
-       "      <td>12930.90</td>\n",
-       "      <td>1.00091</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>theta</th>\n",
-       "      <td>0.251933</td>\n",
-       "      <td>0.003337</td>\n",
-       "      <td>0.121042</td>\n",
-       "      <td>0.084919</td>\n",
-       "      <td>0.23354</td>\n",
-       "      <td>0.475669</td>\n",
-       "      <td>1315.97</td>\n",
-       "      <td>9516.05</td>\n",
-       "      <td>1.00363</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           Mean      MCSE    StdDev        5%      50%       95%    N_Eff  \\\n",
-       "name                                                                        \n",
-       "lp__  -7.267660  0.016792  0.710076 -8.741910 -6.98903 -6.750200  1788.22   \n",
-       "theta  0.251933  0.003337  0.121042  0.084919  0.23354  0.475669  1315.97   \n",
-       "\n",
-       "        N_Eff/s    R_hat  \n",
-       "name                      \n",
-       "lp__   12930.90  1.00091  \n",
-       "theta   9516.05  1.00363  "
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_fit.summary()"
    ]
@@ -353,42 +231,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:cmdstanpy:Processing csv files: /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-1-aszft12v.csv, /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-2-r838n4df.csv, /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-3-pyop7x1l.csv, /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-4-z74wnt9b.csv\n",
-      "\n",
-      "Checking sampler transitions treedepth.\n",
-      "Treedepth satisfactory for all transitions.\n",
-      "\n",
-      "Checking sampler transitions for divergences.\n",
-      "No divergent transitions found.\n",
-      "\n",
-      "Checking E-BFMI - sampler transitions HMC potential energy.\n",
-      "E-BFMI satisfactory for all transitions.\n",
-      "\n",
-      "Effective sample size satisfactory.\n",
-      "\n",
-      "Split R-hat values satisfactory all parameters.\n",
-      "\n",
-      "Processing complete, no problems detected.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Processing csv files: /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-1-aszft12v.csv, /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-2-r838n4df.csv, /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-3-pyop7x1l.csv, /var/folders/sc/0f0wdc_11_xgjs2v52g20fvr0000gn/T/tmpcu006e0e/stan-bernoulli-Method.SAMPLE-4-z74wnt9b.csv\\n\\nChecking sampler transitions treedepth.\\nTreedepth satisfactory for all transitions.\\n\\nChecking sampler transitions for divergences.\\nNo divergent transitions found.\\n\\nChecking E-BFMI - sampler transitions HMC potential energy.\\nE-BFMI satisfactory for all transitions.\\n\\nEffective sample size satisfactory.\\n\\nSplit R-hat values satisfactory all parameters.\\n\\nProcessing complete, no problems detected.'"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_fit.diagnose()"
    ]
@@ -404,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,23 +265,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "((4000, 8),\n",
-       " Index(['lp__', 'accept_stat__', 'stepsize__', 'treedepth__', 'n_leapfrog__',\n",
-       "        'divergent__', 'energy__', 'theta'],\n",
-       "       dtype='object'))"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_drawset.shape, bern_drawset.columns"
    ]
@@ -450,20 +281,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(4000, 1)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "thetas = bern_fit.get_drawset(params=['theta'])\n",
     "thetas.shape\n"
@@ -471,94 +291,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>theta</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0.246078</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.254398</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.326366</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      theta\n",
-       "0  0.246078\n",
-       "1  0.254398\n",
-       "2  0.326366"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "thetas[0:3]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x11e1325f8>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAD8CAYAAACYebj1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJzt3Xl0XPWZ5//3o81avMiW5EWyFq+AbTDYMtiYLTshxPQkMEBCwBlomiSdTrp75kx6+WXSyfSZ7pmkZ5JOOtNkBSYhJCGLISQkYUnA2GDZ2NjGu7xJ3iRblrVY+/P7o0pGyLJUlnTrVpU+r3PquJavbn0sW3rqfrdr7o6IiAhAWtgBREQkcagoiIjIOSoKIiJyjoqCiIico6IgIiLnqCiIiMg5KgoiInJOYEXBzLLN7DUz22Jm283sHwZos9rM6sxsc/T2QFB5RERkaBkBHrsdeKe7N5tZJvCymf3a3df3a/eEu/95gDlERCRGgRUFjyyVbo4+zIzeRrx8urCw0CsqKkZ6GBGRMWXjxo317l40VLsgzxQws3RgIzAX+Ia7vzpAsw+b2Q3AbuAv3f3wYMesqKigqqpq9MOKiKQwMzsYS7tAB5rdvdvdrwRmAleb2aJ+TZ4CKtz9CuB3wCMDHcfMHjSzKjOrqqurCzKyiMiYFpfZR+5+GngBuLnf8yfdvT368NvA0gt8/cPuXunulUVFQ579iIjIMAU5+6jIzPKj93OA9wA7+7WZ0efhKmBHUHlERGRoQY4pzAAeiY4rpAE/dvenzeyLQJW7rwH+wsxWAV3AKWB1gHlERGQIlmzXU6isrHQNNIuIXBwz2+julUO104pmERE5R0VBRETOCXSdgshoOtvRze92HOdgfQuFE8bxjkumMn1SdtixRFKKioIkhVf21vOZJzZT19R+7rk0gz+5soS/ueUyiiaMCzGdSOpQUZCE98q+elZ/bwNlBbl89a4rWVI2mZqGVn5cVcP31u7npb31fG/1MhaVTAo7qkjS05iCJLT65nY+/cPXKS/I5acPreDaOYVkZ6Yzd+oE/vaWy3jq09eRmWbc/fB6dh1rCjuuSNJTUZCE9qWn36SpvYtvfHQJ+blZ571+6fSJ/PQT15KTlc4Dj26gub0rhJQiqUNFQRLW9iON/HLzEf70+lnMnzbhgu2K83P4t48uoabhLP/0ay2KFxkJFQVJWF9+dheTcjJ58IY5Q7atrJjC6msr+OGrh9h57Ewc0omkJhUFSUh7TzTxwq46HrhuFpNyMmP6ms+8ax7jx2Xw5Wd3B5xOJHWpKEhCeuSVg2RlpPGRa8pi/pr83CxWX1vBczuPs7++JcB0IqlLRUESTlNbJ09uqmHV4mIKxl/c+oN7VpSTmZbG99fuDyidSGpTUZCE8+z247R2dHP31bGfJfSaOiGbDy4u5icba2jt0EwkkYuloiAJ55ebaymbksuSsvxhff2dy0pp7ejm2e3HRjmZSOpTUZCEcqKpjbV767ntymLMbFjHqCyfzMzJOfxsU+0opxNJfSoKklCe2nKUHofbriwe9jHS0owPXVXC2r31HD/TNorpRFKfioIklN9sO8ql0ycwd+qFF6vF4oOLi+lx+K26kEQuioqCJIyGlg42HmzgvQumjfhYc6eOZ3ZhHr998/goJBMZO1QUJGG8sOsEPQ7vumzkRcHMeM/Caazbd5LG1s5RSCcyNqgoSMJ4bscJiiaM4/JR2gL7fQun09XjPL9LZwsisVJRkITQ0dXDH3bX8e7LppKWNrxZR/1dOTOfqRPG8dvtKgoisQqsKJhZtpm9ZmZbzGy7mf3DAG3GmdkTZrbXzF41s4qg8khi23Sogeb2Lm66ZOqoHTMtzXjPgmm8uKuOts7uUTuuSCoL8kyhHXinuy8GrgRuNrPl/drcDzS4+1zgfwP/HGAeSWCv7DtJmsHy2QWjetx3XTaVs53dvLb/1KgeVyRVBVYUPKI5+jAzevN+zW4DHone/ynwLhvuiiVJauv21XN5yaSYd0SN1YrZhWRlpPHirrpRPa5Iqgp0TMHM0s1sM3AC+J27v9qvSQlwGMDdu4BG4LyPimb2oJlVmVlVXZ1+uFNNa0cXrx86zYo5haN+7JysdJbPLuDF3SdG/dgiqSjQouDu3e5+JTATuNrMFg3zOA+7e6W7VxYVFY1uSAndhgMNdPU4184Z3a6jXjfNL6K6roVDJ1sDOb5IKonL7CN3Pw28ANzc76VaoBTAzDKAScDJeGSSxLFu30ky043KismBHP8dl0YGr3W2IDK0IGcfFZlZfvR+DvAeYGe/ZmuA+6L3bweed/f+4w6S4tbtq+eq0snkZmUEcvxZhXmUF+Tywk4VBZGhBHmmMAN4wczeADYQGVN42sy+aGarom2+AxSY2V7gr4DPBZhHElBLexdbaxtZPntKoO9z0/wi1lWf1NRUkSEE89EMcPc3gKsGeP7zfe63AXcElUES35bDp+lxWFoRcFG4dCqPrDvIq/tPceN8jUuJXIhWNEuoNh5sAODK0uFdUCdWK2YXMC4jTV1IIkNQUZBQbTrUwLyp40d9fUJ/2ZnprJhTwB92a0qzyGBUFCQ07s7rh0+zpCyYWUf93TS/iP31LRyob4nL+4kkIxUFCU11fQunWztZWh6nohDdV0lnCyIXpqIgoekdT1hSHux4Qq+KwjzKpuTy0h4VBZELUVGQ0Lx+qIGJ2RnMLhwft/e8fl4h6/adpKOrJ27vKZJMVBQkNK8fOs1VZZNH7foJsbhhfhEtHd1sOtQQt/cUSSYqChKKts5u9pxo5oqZo3OVtVitmFNAepqpC0nkAlQUJBQ7jzXR3eMsLI5vUZiYncmSsnz+uLs+ru8rkixUFCQUW2sbAbg8zmcKANfPK2LbkUZONrfH/b1FEp2KgoRie20jk3MzKZ6UHff3vmF+Ee6wdp825BXpT0VBQrHtSCOLSiYRxoX2Li+ZRH5uJn/UegWR86goSNy1d3Wz61gTi0ri33UEkJ5mrJxbyEt76tBO7SJvp6IgcbfneDOd3c6iOA8y93XDvEKOn2ln9/HmoRuLjCEqChJ3vYPMi0omhpbh+nmR7bM1NVXk7VQUJO621TYyITuDsim5oWUozs9h7tTx2gdJpB8VBYm7bUfOsKg4nEHmvm6YV8Rr+0/pamwifagoSFx19zg7j55hYXF4XUe9rp9fSHtXDxsOnAo7ikjCUFGQuDp4soX2rh4unRF+UVg+q4Cs9DRNTRXpQ0VB4mrXsSYALpk2IeQkkJOVTmXFZF7eq0VsIr0CKwpmVmpmL5jZm2a23cw+M0Cbm8ys0cw2R2+fDyqPJIZdx5swg3nT4rdd9mCum1fIjqNnqGvSlhciEOyZQhfw1+6+AFgOfMrMFgzQ7iV3vzJ6+2KAeSQB7DrWREVBHtmZ6WFHAeC6uYUAvLJPG+SJQIBFwd2Puvum6P0mYAdQEtT7SXLYdbyJ+QlylgCwsHgSk3IyWbtXRUEE4jSmYGYVwFXAqwO8vMLMtpjZr81sYTzySDjaOrs5UN/CJdPDH2TuFdnyooCX99RrywsR4lAUzGw88CTwWXc/0+/lTUC5uy8G/hX4xQWO8aCZVZlZVV2dZookq70nmunxxBhk7mvl3EKONLaxv74l7CgioQu0KJhZJpGC8AN3/1n/1939jLs3R+8/A2SaWeEA7R5290p3rywqKgoysgTo3Myj6YlVFHrHFdSFJBLs7CMDvgPscPd/uUCb6dF2mNnV0TyaH5iidh1vIisjjYqC8La3GEh5QR6lU3J4aY+KgkhGgMdeCXwM2Gpmm6PP/S1QBuDu/xe4HfiEmXUBZ4G7XB27KWvXsSbmFo0nIz3xlsdcN7eQp984Sld3T0LmE4mXwIqCu78MDLq5jbt/Hfh6UBkksew61sSKOQVhxxjQyrmFPP7aYbbWNnJV2eSw44iERh+JJC4az3Zy7Ewb8xNskLnXtXMKMdO4goiKgsRFdV3kYjZzpybOGoW+puRlsbB4osYVZMxTUZC42FcXme45uygv5CQXtnJuIZsONdDa0RV2FJHQqChIXFTXNZORZqFeWGco180tpLPbeW2/ttKWsUtFQeJiX10zZQW5ZCbwzJ5lFVPIykjjZXUhyRiWuD+hklKq61qYU5SY4wm9sjPTWVYxmZc12CxjmIqCBK6ru4eDJ1sTejyh18q5hew81qSttGXMUlGQwNU0nKWjuyfhzxQArp8b2UZFW2nLWKWiIIGrro9MR52TBGcKC4onkp+bqXEFGbNUFCRw+05Ep6MWJv6ZQnqace2cAtbu1VbaMjapKEjgquubmZKXxeS8rLCjxKR3K+1qbaUtY5CKggRu34kWZhcmftdRr95xBW15IWORioIErrq+JSlmHvUqK8ildEqOxhVkTFJRkEC1tHdR39xOeUHyFAWIrG5et+8kXd09YUcRiSsVBQnUwZOtAJQn2IV1hnLd3CKa2rt4o7Yx7CgicaWiIIE6dCoyWFs+JbnOFFbMKYhspa0uJBljVBQkUL1nCmVJdqbQu5W2tryQsUZFQQJ18FQr+bmZTMrJDDvKRbtubhGbDjXQ0q6ttGXsUFGQQB062Up5Am+XPZhzW2kf0FbaMnaoKEigDp5qoSzJZh71qqyYTFZGmsYVZExRUZDAdHb3cOR0W9KeKWRnpnN1xRSNK8iYElhRMLNSM3vBzN40s+1m9pkB2piZfc3M9prZG2a2JKg8En+1DWfp7vGkm47aV+9W2ifOtIUdRSQugjxT6AL+2t0XAMuBT5nZgn5t3g/Mi94eBL4ZYB6Js4OnetcoJGf3EcA7L50KwG/fPB5yEpH4CKwouPtRd98Uvd8E7ABK+jW7DXjUI9YD+WY2I6hMEl+HTkbXKCTxmcL8aeOZXZjHb7YdCzuKSFzEZUzBzCqAq4BX+71UAhzu87iG8wsHZvagmVWZWVVdXV1QMWWUHTzZSnZmGlMnjAs7yrCZGe9bNJ111Sc53doRdhyRwAVeFMxsPPAk8Fl3PzOcY7j7w+5e6e6VRUVFoxtQAnPwVCtlU3Ixs7CjjMj7F02nu8f5nbqQZAyIqSiY2c/M7ANmdlFFxMwyiRSEH7j7zwZoUguU9nk8M/qcpICDJ1soS7LtLQZyeckkSvJz1IUkY0Ksv+T/DfgIsMfM/snMLhnqCyzy8fA7wA53/5cLNFsD3BudhbQcaHT3ozFmkgTm7hw61ZrU4wm9zIz3LZzOS3vqaWrrDDuOSKBiKgru/nt3/yiwBDgA/N7MXjGzj0fPBgayEvgY8E4z2xy93WJmD5nZQ9E2zwDVwF7gW8AnR/KXkcRR39xBW2cPpZNzwo4yKm65fDod3T3qQpKUlxFrQzMrAO4h8ov+deAHwHXAfcBN/du7+8vAoJ3JHrkI7qdijyvJoqYhMh115uTkP1MAWFI2mdIpOfxsUy0fWjIz7DgigYl1TOHnwEtALvBBd1/l7k+4+6eBxL8au8Rd7emzAJSkyJlCWprxoatmsnZfPUeifzeRVBTrmMK33H2Bu/+P3j5/MxsH4O6VgaWTpFXbkFpFAeDDS2biDj9/XXMhJHXFWhT++wDPrRvNIJJaak+fZWJ2BhOzk2/L7AspK8hlWcVkfraphkjPp0jqGbQomNl0M1sK5JjZVWa2JHq7iUhXksiAahrOUpIi4wl93b50JvvqWqg62BB2FJFADDXQ/D5gNZH1A32nlTYBfxtQJkkBtQ1nKU3S3VEH88HFxfzjr3bw6LqDLKuYEnYckVE3aFFw90eAR8zsw+7+ZJwySZJzd2pPn2XFnIKwo4y63KwM/mNlKd9/5QAnPnAZUydmhx1JZFQN1X10T/RuhZn9Vf9bHPJJEmo820lzexczU2iQua97lpfT7c4PXzsUdhSRUTfUQHPvHgXjgQkD3ETOU9M78yg/NYtCRWEeN84v4gevHqKjqyfsOCKjaqjuo3+P/vkP8YkjqaB3jUKqLFwbyH0rKvj49zfwm+3HWLW4OOw4IqMm1sVr/9PMJppZppk9Z2Z1fbqWRN4mFdco9Hfj/CJmFebxvbX7w44iMqpiXafw3ui217cS2ftoLvBfggolya2m4Sw5melMzk2dNQr9paUZ960o5/VDp9l8+HTYcURGTaxFobeb6QPAT9y9MaA8kgJqT7dSMjkn6a+jMJTbK0uZMC5DZwuSUmItCk+b2U5gKfCcmRUBupK5DKj29NmUnXnU1/hxGdxRWcqv3jjK8TP6cZDUEOvW2Z8DrgUq3b0TaCFyfWWR89Q0nE3ZmUf9rb62gm53/t/6g2FHERkVF3MltUuBO83sXuB24L3BRJJk1tLexenWzpQeZO6rrCCXd106jR++eoi2zu6w44iMWKyzjx4Dvkzk+gnLojftjirnGQvTUfv7+MoKTrZ0sGbLkbCjiIxYrBfZqQQWuLaGlCHUpvjCtYFcO6eAS6ZN4HtrD3DH0pkpP8AuqS3W7qNtwPQgg0hqeOuKa2OnKJgZq1dWsOPoGTZq91RJcrEWhULgTTN71szW9N6CDCbJqeb0WbLS0ygaPy7sKHG1anExuVnpPLmpJuwoIiMSa/fRF4IMIamjtuEsxfnZpKWNrS6UvHEZ3LxoOk9vOcp/++BCsjPTw44kMiyxTkn9A5GVzJnR+xuATYN9jZl918xOmNm2C7x+k5k1mtnm6O3zF5ldElDk4jpjp+uor9uXzKSpvYtntx8LO4rIsMU6++hPgZ8C/x59qgT4xRBf9n3g5iHavOTuV0ZvX4wliyS22tNjZ41Cf8tnF1CSn8OTm3QNZ0lesY4pfApYCZwBcPc9wNTBvsDd/wicGlE6SSptnd3UNbWPqemofaWlGf/hqhJe3lPHiSatcJbkFGtRaHf3jt4HZpYBjMb01BVmtsXMfm1mC0fheBKio42RX4Rj9UwBYNWVxfQ4PLtNXUiSnGItCn8ws78FcszsPcBPgKdG+N6bgHJ3Xwz8K4N0R5nZg2ZWZWZVdXV1I3xbCUrvdNSxOqYAMH/aBOZNHc/TbxwNO4rIsMRaFD4H1AFbgT8DngH+fiRv7O5n3L05ev8ZINPMCi/Q9mF3r3T3yqKiopG8rQRoLC5cG8gHrpjBawdOcUKb5EkSinX2UQ+RT/KfdPfb3f1bI13dbGbTLbr008yujmY5OZJjSrhqT58lPc2YMWlsX8z+1itm4A7PbNXZgiSfQYuCRXzBzOqBXcCu6FXXhpw+amaPA+uAS8ysxszuN7OHzOyhaJPbgW1mtgX4GnCXttFIbrUNZ5k+MZuM9IvZZzH1zJ06gUunT+BXKgqShIZavPaXRGYdLXP3/QBmNhv4ppn9pbv/7wt9obvfPdiB3f3rwNcvMq8ksJoxPB21vw9cPoOv/G43xxrbmD7Gz5wkuQz1ke5jwN29BQHA3auBe4B7gwwmyad2DC9c6++WK2YA6kKS5DNUUch09/r+T7p7HZC6F+CVi9bV3cOxM206U4iaUzSey2ZMVBeSJJ2hikLHMF+TMeZ4UzvdPa4zhT5uvWIGGw82nLvGhEgyGKooLDazMwPcmoDL4xFQkoOmo57v1mgX0tO6+I4kkUGLgrunu/vEAW4T3F3dR3JO7WktXOuvvCCPxaX5uiKbJJWxPXdQRo3OFAa2anEx24+cYV9dc9hRRGKioiCjovb0WQrHZ+k6Av3cesUMzGDNZp0tSHJQUZBRUdOgNQoDmTYxm2tmTeGpLUfQ2kxJBioKMipqT2uNwoWsWlxCdX0L24+cCTuKyJBUFGTE3D2ycE1nCgN6/6LpZKYbP39dF9+RxKeiICNW39xBe1ePisIFTM7L4t2XTePnr9fS3tUddhyRQakoyIj1Ls4qGaNXXIvFnctKOdXSwe/fPBF2FJFBqSjIiGk66tCun1dE8aRsfrThUNhRRAaloiAjpoVrQ0tPM+6oLOXlvfXnrlAnkohUFGTEahvOMmFcBpNytMh9MHdUzgTgx1U1IScRuTAVBRkxTUeNzczJudw4v4jHXzukAWdJWCoKMmJauBa7j6+cRV1TO796Q1tqS2JSUZAR05lC7G6YV8icojy+u3a/VjhLQlJRkBE509ZJU1uXzhRiZGZ8fOUsttWeoepgQ9hxRM6joiAjUnMqMh11ptYoxOxDS0qYmJ3B99buH7qxSJwFVhTM7LtmdsLMtl3gdTOzr5nZXjN7w8yWBJVFgnPoVGR6ZXmBikKscrMyuPuaMn6z7Zimp0rCCfJM4fvAzYO8/n5gXvT2IPDNALNIQA5Hi0LpFBWFi3HvigrMjMfWHQw7isjbBFYU3P2PwKlBmtwGPOoR64F8M5sRVB4JxqFTrUzKydQahYtUkp/D+xZO4/HXDtHa0RV2HJFzwhxTKAEO93lcE31OksihU62U6SxhWD6+chZn2rq0e6oklKQYaDazB82sysyq6urqwo4jfRxWURi2yvLJLCyeyPfXHtD0VEkYYRaFWqC0z+OZ0efO4+4Pu3ulu1cWFRXFJZwMrbvHqWk4y8wpmo46HL3TU/ecaOblvfVhxxEBwi0Ka4B7o7OQlgON7q5lnknk+Jk2Orp7dKYwAh9cPIPC8Vl8b+2BsKOIAMFOSX0cWAdcYmY1Zna/mT1kZg9FmzwDVAN7gW8BnwwqiwSjdzqqisLwjctI5yPXlPP8zhPsr28JO44IGUEd2N3vHuJ1Bz4V1PtL8FQURsc9y8v45ot7eeSVA3xh1cKw48gYlxQDzZKYDp9qJc2gWFtcjMjUCdncekUxP6k6THO7pqdKuFQUZNgOnWqlOD+HzHT9Nxqpe5aX09LRzVNbjoQdRcY4/TTLsGmNwuhZUpbP/Gnj+dFrulynhEtFQYbt8KlWSrUR3qgwM+5aVsaWmkbePHIm7DgyhqkoyLCcaeukvrmDWUV5YUdJGR9aUkJWRho/2qCzBQmPioIMy/66yPTJWYUqCqMlPzeL9y+azs9fr+Vshy7XKeFQUZBh6Z1TP0dnCqPqrmVlNLV18cxWreOUcKgoyLBU1zWTZtoye7Qtnz2FWYV56kKS0KgoyLBU17dQOiWXcRnpYUdJKWbGnctK2XCggb0nmsKOI2OQioIMS3Vdi8YTAnL70plkphuPv3Z46MYio0xFQS6au7O/XkUhKIXjx/HehdN5clMNbZ0acJb4UlGQi3b8TDtnO7uZXTQ+7Cgp6yNXl3G6tZNntx8LO4qMMSoKctGq65oBmK0zhcCsmF1AeUEuP3hVA84SXyoKctGqo9NRZ2s6amDS0iIrnF/bf4q9J5rDjiNjiIqCXLQ9x5vIy0pn2oTssKOktDsqIwPO2g9J4klFQS7aruNNzJ8+gbQ0CztKSiscP473LtCAs8SXioJcFHdn17EmLpk2IewoY8LdV5fR0NrJb7ZpwFniQ0VBLkp9cwcNrZ1cMl1FIR6unVPA7KI8vv1yNZGLFYoES0VBLsquY5FVtjpTiI+0NOOB62azrfYM66tPhR1HxgAVBbkou45HisJ8nSnEzYeWlFCQl8W3XqoOO4qMASoKclF2H2uiIC+LwvHjwo4yZmRnpvOxFeU8v/MEu49rPyQJVqBFwcxuNrNdZrbXzD43wOurzazOzDZHbw8EmUdGbtfxJo0nhODeFRXkZaXzf36/O+wokuICKwpmlg58A3g/sAC428wWDND0CXe/Mnr7dlB5ZOR6epw9x5uYr/GEuJuSl8X918/mma3H2FbbGHYcSWFBnilcDex192p37wB+BNwW4PtJwPafbKGlo5uFxRPDjjImPXD9LPJzM/nyb3eFHUVSWJBFoQTou/dvTfS5/j5sZm+Y2U/NrHSgA5nZg2ZWZWZVdXV1QWSVGGytiXxCvXzmpJCTjE0TszP5xI1zeHFXHS/uOhF2HElRYQ80PwVUuPsVwO+ARwZq5O4Pu3ulu1cWFRXFNaC85Y2aRrIz05ir3VFDs3plBbOL8vj/frlN13GWQARZFGqBvp/8Z0afO8fdT7p7e/Tht4GlAeaREdpW28iCGRPJSA/7s8TYNS4jnX/8k8s5fOosX1E3kgQgyJ/uDcA8M5tlZlnAXcCavg3MbEafh6uAHQHmkRHo7nG2HWnkipn5YUcZ81bMKeCe5WV8++X9PL/zeNhxJMUEVhTcvQv4c+BZIr/sf+zu283si2a2KtrsL8xsu5ltAf4CWB1UHhmZ6rpmWju6WVSi8YRE8PcfWMCCGRP5zOObNRtJRlWg/QDu/oy7z3f3Oe7+j9HnPu/ua6L3/8bdF7r7Ynd/h7vvDDKPDN/Ggw0ALCnTmUIiyM5M59v3VTIxJ5N7v/saGw9qCwwZHeoclphsONBAQV6WrsucQIrzc/jBA9cwMTuDux9+la8/v4eOrp6wY0mSU1GQmGw8eIql5ZMx0zUUEklFYR6/+NRK3r1gKl/+7W5u/uofeW7Hce2oKsOmoiBDOtHUxoGTrSyrmBJ2FBlAfm4W//bRpXxv9TJwuP+RKj72nde0T5IMi4qCDGnjgch4QmXF5JCTyGDecelUfvPZG/j8rQvYWtvIrf/6Mk9urAk7liQZFQUZ0st768nLSmdhsWYeJbqsjDT+03WzeO6vb2RJWT5//ZMtfH/t/rBjSRJRUZAhvbSnnhVzCsjK0H+XZFE4fhyP3X8N710wjS889Sa/eL126C8SQUVBhnCgvoVDp1q5Yb62F0k2melpfP0jS7hm1hT+65Nv8EbN6bAjSRJQUZBBvbQnsgHh9fNUFJJRVkYa//bRJRSOH8efPbaRk83tQ3+RjGkqCjKo53eeoHRKDhUFuWFHkWEqGD+Of//YUk62dPDZJzbT3aPpqnJhKgpyQY1nO3l5bz03L5yu9QlJblHJJL64aiEv7annq8/tCTuOJDAVBbmg53Ycp7Pbef/lM4ZuLAnvzmWl3L50Jl97bg8v7NT1GGRgKgpyQc9sPUrxpGyuKtV+R6nAzPjSbYu4bMZEPvvEZg6fag07kiQgFQUZUF1TOy/uquMDV8xQ11EKyclK55sfXUKPO5/8wSbaOnWhHnk7FQUZ0E831tDV49y5rCzsKDLKKgrz+Modi9la28infrCJ9i4VBnmLioKcp6fH+dGGQ1wzawpzp+rSm6novQun89//ZBHP7TzBA49Ucbq1I+xIkiBUFOQ8v9l+jIMnW7lneXnYUSRA9ywNBmlzAAAJfklEQVQv53/dfgXrq09y67++zPrqk2FHkgSgoiBv09PjfO25PcwuyuMWzTpKeXdUlvKTh64F4K6H1/Ppx19nX11zyKkkTCoK8jZrthxh57EmPv3OuaSnaYB5LLiyNJ/f/eWN/MW75vHb7cd497/8gT97rIq1e+vp0UK3MScj7ACSOBpaOvjS02+yuDSfVYtLwo4jcZSTlc5fvWc+964o59FXDvDo+oM8u/04MyfncMfSUj68tISZk7WqfSywZLtCU2VlpVdVVYUdI+V09zh/9thGXtx1gqc+fR2XzZgYdiQJUVtnN89uP8aPqw6zdm9krGFp+WRuuXwGt1w+nRmTckJOKBfLzDa6e+WQ7YIsCmZ2M/BVIB34trv/U7/XxwGPAkuBk8Cd7n5gsGOqKIy+nh7nv63ZzmPrD/KFDy5g9cpZYUeSBHL4VCu/3FzLr7YeY8fRM0CkQNw4v4iVcwu4YmY+menqiU50oRcFM0sHdgPvAWqADcDd7v5mnzafBK5w94fM7C7gP7j7nYMdV0VhdB1rbOPvf7GV3+84wZ9eP4u/+8CCsCNJAquua+aZrUf5zfZjbD9yBnciF2AqmcSi4kksKpnIguKJVBTkkZ2ZHnZc6SMRisIK4Avu/r7o478BcPf/0afNs9E268wsAzgGFPkgoVQURqajq4fjZ9rYVtvIC7tO8NSWo3S78zfvv5TV11Zo9bLErKGlg3XVJ1lffZKttY3sOHqGts4eAMygeFIOswrzKC/IZeqEbArGZ1GQl8WE7ExystLIzkwnJzOdnKzIn9mZ6WSmp2mCQ0BiLQpBDjSXAIf7PK4BrrlQG3fvMrNGoACoH+0wf9hdx5eejpyk9Nact1UeP/9u39r01nN92/V53c9//a3Xzj/O275moOMM0K7vKx5j3r5te9xpaus693xuVjofXDyDT71jLuUFeecHFxnE5Lys6BhDZOpyV3cP1fUt7Dh6hgP1reyvb2Z/fQu/2nqU062dMR83zSIXCMpKTyMzI43MdCMzPY3M9DQGLBcDPDlQu4E+8CRb+blzWSkPXD870PdIitlHZvYg8CBAWdnwtl0YPy6DS6ZN6HPQt/3R+z79X6bv/yMbpN3bj9nn9QHfp++X2PnP2VuvDvw1MR7nbe8ZeTQ5N4tpE8cxf/oEFhVP0iU2ZdRkpKcxf9oE5vf9OYvq6OqhobWD+uZ2Wtq7OdvZzdmObto6I7ez0Vtnl9PZ3RO9vXW/I/q4v4E6FQbsZhjow9rALRNa4fhxgb9HkEWhFijt83hm9LmB2tREu48mERlwfht3fxh4GCLdR8MJs7R8MkvLJw/nS0VkhLIy0pg2MZtpE7PDjiJDCPJj4gZgnpnNMrMs4C5gTb82a4D7ovdvB54fbDxBRESCFdiZQnSM4M+BZ4lMSf2uu283sy8CVe6+BvgO8JiZ7QVOESkcIiISkkDHFNz9GeCZfs99vs/9NuCOIDOIiEjsNMooIiLnqCiIiMg5KgoiInKOioKIiJyjoiAiIuck3dbZZlYHHOzzVCEBbIsRAOUcXco5upIlJyRP1kTLWe7uRUM1Srqi0J+ZVcWyyVPYlHN0KefoSpackDxZkyVnf+o+EhGRc1QURETknFQoCg+HHSBGyjm6lHN0JUtOSJ6syZLzbZJ+TEFEREZPKpwpiIjIKEm6omBmU8zsd2a2J/rnBS+SYGYTzazGzL4ez4zR9x4yp5ldaWbrzGy7mb1hZoNen3qU891sZrvMbK+ZfW6A18eZ2RPR1181s4p4ZeuXY6icf2Vmb0a/f8+ZWXki5uzT7sNm5mYWyqyUWHKa2X+Mfk+3m9kP450xmmGof/cyM3vBzF6P/tvfElLO75rZCTPbdoHXzcy+Fv17vGFmS+Kd8aK5e1LdgP8JfC56/3PAPw/S9qvAD4GvJ2JOYD4wL3q/GDgK5MchWzqwD5gNZAFbgAX92nwS+L/R+3cBT4TwPYwl5zuA3Oj9TyRqzmi7CcAfgfVAZSLmBOYBrwOTo4+nJmjOh4FPRO8vAA7EO2f0vW8AlgDbLvD6LcCviVwIcTnwahg5L+aWdGcKwG3AI9H7jwB/MlAjM1sKTAN+G6dc/Q2Z0913u/ue6P0jwAlgyMUlo+BqYK+7V7t7B/CjaN6++ub/KfAuG+git8EaMqe7v+DurdGH64lc4S/eYvl+AnwJ+GegLZ7h+ogl558C33D3BgB3PxHnjBBbTgcmRu9PAo7EMd9bIdz/SORaMBdyG/CoR6wH8s1sRnzSDU8yFoVp7n40ev8YkV/8b2NmacBXgP8cz2D9DJmzLzO7msinon1BBwNKgMN9HtdEnxuwjbt3AY1AQRyyDZghaqCcfd1P5FNZvA2ZM9ptUOruv4pnsH5i+X7OB+ab2VozW29mN8ct3VtiyfkF4B4zqyFyzZZPxyfaRbvY/8OhC/QiO8NlZr8Hpg/w0t/1feDubmYDTZ/6JPCMu9cE+eF2FHL2HmcG8Bhwn7v3jG7KscHM7gEqgRvDztJf9EPKvwCrQ44SiwwiXUg3ETnr+qOZXe7up0NNdb67ge+7+1fMbAWRKzgu0s/PyCVkUXD3d1/oNTM7bmYz3P1o9JfpQKe3K4DrzeyTwHggy8ya3f2CA4Ah5cTMJgK/Av4uenoZD7VAaZ/HM6PPDdSmxswyiJyin4xPvPMy9BooJ2b2biKF+EZ3b49Ttr6GyjkBWAS8GP2QMh1YY2ar3L0qbilj+37WEOn37gT2m9luIkViQ3wiArHlvB+4GcDd15lZNpG9hsLo7hpMTP+HE0kydh+tAe6L3r8P+GX/Bu7+UXcvc/cKIl1Ij452QYjBkDnNLAv4OZF8P41jtg3APDObFc1wF5G8ffXNfzvwvEdHzuJoyJxmdhXw78CqkPq/YYic7t7o7oXuXhH9P7meSN54FoQhc0b9gshZAmZWSKQ7qTqeIYkt5yHgXQBmdhmQDdTFNWVs1gD3RmchLQca+3QrJ6awR7ov9kakX/s5YA/we2BK9PlK4NsDtF9NOLOPhswJ3AN0Apv73K6MU75bgN1ExjD+LvrcF4n8soLID9lPgL3Aa8DskP69h8r5e+B4n+/fmkTM2a/ti4Qw+yjG76cR6ep6E9gK3JWgORcAa4nMTNoMvDeknI8TmTXYSeQs637gIeChPt/Pb0T/HlvD+ne/mJtWNIuIyDnJ2H0kIiIBUVEQEZFzVBREROQcFQURETlHRUFERM5RURARkXNUFERE5BwVBREROef/B06JJsiWbspVAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_drawset.theta.plot.density()"
    ]
@@ -595,20 +339,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('theta', array([0.246078, 0.254398, 0.326366]))"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_fit.column_names[7], bern_fit.sample[0:3,0,7]"
    ]
@@ -628,20 +361,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0.948194, 0.96125 , 1.06474 , 1.17857 ])"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_fit.stepsize"
    ]
@@ -659,23 +381,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('diag_e', array([[0.512243],\n",
-       "        [0.584738],\n",
-       "        [0.390916],\n",
-       "        [0.508692]]))"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bern_fit.metric_type,  bern_fit.metric"
    ]

--- a/docs/common_config.rst
+++ b/docs/common_config.rst
@@ -5,5 +5,5 @@
 
 - ``inits``:  Specifies how the sampler initializes parameter values.
             
-- ``csv_basename``:  A path or file name which will be used as the basename for the CmdStan output files.
+- ``output_dir``:  A path or file name which will be used as the basename for the CmdStan output files.
 

--- a/docs/generate_quantities.rst
+++ b/docs/generate_quantities.rst
@@ -53,7 +53,7 @@ Configuration
 
 - ``seed``: The seed for random number generator.
             
-- ``gq_csv_basename``:  A path or file name which will be used as the basename for the CmdStan output files.
+- ``gq_output_dir``:  A path or file name which will be used as the basename for the CmdStan output files.
 
 
 Example: add posterior predictive checks to ``bernoulli.stan``

--- a/docs/hello_world.rst
+++ b/docs/hello_world.rst
@@ -54,6 +54,18 @@ If no output file path is specified, the sampler outputs
 are written to a temporary directory which is deleted
 when the current Python session is terminated.
 
+The ``CmdStanMLE`` object records the command, the return code,
+and the paths to the optimize method output csv and console files.
+The output files are written either to a specified output directory
+or to a temporary directory which is deleted upon session exit.
+
+Output filenames are composed of the model name, a timestamp
+in the form YYYYMMDDhhmm and the chain id, plus the corresponding
+filetype suffix, either '.csv' for the CmdStan output or '.txt' for
+the console messages, e.g. ``bernoulli-201912081451-1.csv``. Output files
+written to the temporary directory contain an additional 8-character
+random string, e.g. ``bernoulli-201912081451-1-5nm6as7u.csv``.
+
 
 Access the sample
 ^^^^^^^^^^^^^^^^^
@@ -135,17 +147,14 @@ and prints the output to the console.
 
     bern_fit.diagnose()
 
-By default, CmdStanPy will save all CmdStan outputs in a temporary
-directory which is deleted when the Python session exits.
-In particular, unless the ``output_dir`` argument to the ``sample``
-function is overtly specified, all the csv output files will be written into
-this temporary directory and then when the session exits.
+The sampler output files are written to a temporary directory which
+is deleted upon session exit unless the ``output_dir`` argument is specified.
 The ``save_csvfiles`` function moves the CmdStan csv output files
-to the specified location, renaming them using a specified basename.
+to a specified directory without having to re-run the sampler.
 
 .. code-block:: python
 
-    bern_fit.save_csvfiles(dir='some/path', basename='descriptive-name')
+    bern_fit.save_csvfiles(dir='some/path')
 
 .. comment
   Progress bar

--- a/docs/hello_world.rst
+++ b/docs/hello_world.rst
@@ -46,11 +46,10 @@ and returns a ``CmdStanMCMC`` object:
 .. code-block:: python
 
     bernoulli_data = { "N" : 10, "y" : [0,1,0,0,0,0,0,0,0,1] }
-    bern_fit = bernoulli_model.sample(data=bernoulli_data, csv_basename='./bern')
+    bern_fit = bernoulli_model.sample(data=bernoulli_data, output_dir='.')
 
 By default, the ``sample`` command runs 4 sampler chains.
-The ``csv_basename`` argument specifies the path and filename prefix
-of the sampler output files.
+The ``output_dir`` argument specifies the path to the sampler output files.
 If no output file path is specified, the sampler outputs
 are written to a temporary directory which is deleted
 when the current Python session is terminated.
@@ -138,7 +137,7 @@ and prints the output to the console.
 
 By default, CmdStanPy will save all CmdStan outputs in a temporary
 directory which is deleted when the Python session exits.
-In particular, unless the ``csv_basename`` argument to the ``sample``
+In particular, unless the ``output_dir`` argument to the ``sample``
 function is overtly specified, all the csv output files will be written into
 this temporary directory and then when the session exits.
 The ``save_csvfiles`` function moves the CmdStan csv output files

--- a/docs/notebooks/MCMC Sampling.ipynb
+++ b/docs/notebooks/MCMC Sampling.ipynb
@@ -54,11 +54,58 @@
     "\n",
     "# instantiate, compile bernoulli model\n",
     "bernoulli_model = CmdStanModel(stan_file=bernoulli_path)\n",
+    "bernoulli_model.compile()\n",
     "\n",
     "# run CmdStan's sample method, returns object `CmdStanMCMC`\n",
     "bern_fit = bernoulli_model.sample(data=bernoulli_data)\n",
     "bern_fit.sample.shape\n",
     "bern_fit.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``bern_fit`` object records the command, the return code,\n",
+    "and the paths to the sampler output csv and console files.\n",
+    "The string representation of this object displays the CmdStan commands and\n",
+    "the location of the output files.\n",
+    "\n",
+    "Output filenames are composed of the model name, a timestamp\n",
+    "in the form YYYYMMDDhhmm and the chain id, plus the corresponding\n",
+    "filetype suffix, either '.csv' for the CmdStan output or '.txt' for\n",
+    "the console messages, e.g. `bernoulli-201912081451-1.csv`. Output files\n",
+    "written to the temporary directory contain an additional 8-character\n",
+    "random string, e.g. `bernoulli-201912081451-1-5nm6as7u.csv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bern_fit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The sampler output files are written to a temporary directory which\n",
+    "is deleted upon session exit unless the ``output_dir`` argument is specified.\n",
+    "The ``save_csvfiles`` function moves the CmdStan csv output files\n",
+    "to a specified directory without having to re-run the sampler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bern_fit.save_csvfiles(dir='~')\n",
+    "bern_fit"
    ]
   },
   {

--- a/test/data/bernoulli.stan
+++ b/test/data/bernoulli.stan
@@ -6,7 +6,6 @@ parameters {
   real<lower=0,upper=1> theta;
 }
 model {
-  theta ~ beta(1,1);
-  for (n in 1:N)
-    y[n] ~ bernoulli(theta);
+  theta ~ beta(1,1);  // uniform prior on interval 0,1
+  y ~ bernoulli(theta);
 }

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -1,6 +1,7 @@
 """CmdStan argument tests"""
 
 import os
+import platform
 import unittest
 
 from cmdstanpy import TMPDIR
@@ -493,18 +494,18 @@ class CmdStanArgsTest(unittest.TestCase):
             )
 
         with self.assertRaises(ValueError):
-            # can't write to output_dir - valid for all platforms?
-            read_only = os.path.join(
-                os.path.dirname(os.path.dirname(TMPDIR)), 'read_only'
-            )
-            os.mkdir(read_only, mode=0o444)
-            CmdStanArgs(
-                model_name='bernoulli',
-                model_exe='bernoulli.exe',
-                chain_ids=[1, 2, 3, 4],
-                output_dir=read_only,
-                method_args=sampler_args,
-            )
+            # testing this on *nix, MacOS
+            if platform.system() != 'Windows':
+                read_only = os.path.join(TMPDIR, 'read_only')
+                os.mkdir(read_only, mode=0o444)
+                CmdStanArgs(
+                    model_name='bernoulli',
+                    model_exe='bernoulli.exe',
+                    chain_ids=[1, 2, 3, 4],
+                    output_dir=read_only,
+                    method_args=sampler_args,
+                )
+            # todo: similar test Windows - set ACLS using windows apis
 
 
 class GenerateQuantitesTest(unittest.TestCase):

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -493,10 +493,9 @@ class CmdStanArgsTest(unittest.TestCase):
                 method_args=sampler_args,
             )
 
-        with self.assertRaises(ValueError):
-            if platform.system().lower().startswith('win'):
-                pass  # TODO - logic to set ACLs on Windows
-            else:
+        # TODO: read-only dir test for Windows - set ACLs, not mode
+        if platform.system() == 'Darwin' or platform.system() == 'Linux':
+            with self.assertRaises(ValueError):
                 read_only = os.path.join(TMPDIR, 'read_only')
                 os.mkdir(read_only, mode=0o444)
                 CmdStanArgs(

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -10,7 +10,7 @@ from cmdstanpy.cmdstan_args import (
     CmdStanArgs,
     OptimizeArgs,
     GenerateQuantitiesArgs,
-    VariationalArgs
+    VariationalArgs,
 )
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -159,14 +159,16 @@ class SamplerArgsTest(unittest.TestCase):
         args = SamplerArgs(adapt_engaged=False)
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc adapt engaged=0',
-                      ' '.join(cmd))
+        self.assertIn(
+            'method=sample algorithm=hmc adapt engaged=0', ' '.join(cmd)
+        )
 
         args = SamplerArgs(adapt_engaged=True)
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc adapt engaged=1',
-                      ' '.join(cmd))
+        self.assertIn(
+            'method=sample algorithm=hmc adapt engaged=1', ' '.join(cmd)
+        )
 
         args = SamplerArgs()
         args.validate(chains=4)
@@ -178,26 +180,30 @@ class SamplerArgsTest(unittest.TestCase):
         args = SamplerArgs(metric='dense_e')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=dense_e',
-                      ' '.join(cmd))
+        self.assertIn(
+            'method=sample algorithm=hmc metric=dense_e', ' '.join(cmd)
+        )
 
         args = SamplerArgs(metric='dense')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=dense_e',
-                      ' '.join(cmd))
+        self.assertIn(
+            'method=sample algorithm=hmc metric=dense_e', ' '.join(cmd)
+        )
 
         args = SamplerArgs(metric='diag_e')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=diag_e',
-                      ' '.join(cmd))
+        self.assertIn(
+            'method=sample algorithm=hmc metric=diag_e', ' '.join(cmd)
+        )
 
         args = SamplerArgs(metric='diag')
         args.validate(chains=4)
         cmd = args.compose(1, cmd=[])
-        self.assertIn('method=sample algorithm=hmc metric=diag_e',
-                      ' '.join(cmd))
+        self.assertIn(
+            'method=sample algorithm=hmc metric=diag_e', ' '.join(cmd)
+        )
 
         args = SamplerArgs()
         args.validate(chains=4)
@@ -268,7 +274,7 @@ class CmdStanArgsTest(unittest.TestCase):
                 seed=[1, 2, 3],
                 data=jdata,
                 inits=jinits,
-                method_args=sampler_args
+                method_args=sampler_args,
             )
 
         with self.assertRaises(ValueError):
@@ -278,7 +284,7 @@ class CmdStanArgsTest(unittest.TestCase):
                 chain_ids=None,
                 data=jdata,
                 inits=[jinits],
-                method_args=sampler_args
+                method_args=sampler_args,
             )
 
     def test_args_good(self):
@@ -482,7 +488,7 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_name='bernoulli',
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
-                output_dir= 'no/such/path',
+                output_dir='no/such/path',
                 method_args=sampler_args,
             )
 
@@ -494,7 +500,7 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_name='bernoulli',
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
-                output_dir= read_only,
+                output_dir=read_only,
                 method_args=sampler_args,
             )
 

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -494,8 +494,9 @@ class CmdStanArgsTest(unittest.TestCase):
             )
 
         with self.assertRaises(ValueError):
-            # testing this on *nix, MacOS
-            if platform.system() != 'Windows':
+            if platform.system().lower().startswith('win'):
+                pass  # TODO - logic to set ACLs on Windows
+            else:
                 read_only = os.path.join(TMPDIR, 'read_only')
                 os.mkdir(read_only, mode=0o444)
                 CmdStanArgs(
@@ -505,7 +506,6 @@ class CmdStanArgsTest(unittest.TestCase):
                     output_dir=read_only,
                     method_args=sampler_args,
                 )
-            # todo: similar test Windows - set ACLS using windows apis
 
 
 class GenerateQuantitesTest(unittest.TestCase):

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -494,7 +494,9 @@ class CmdStanArgsTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             # can't write to output_dir - valid for all platforms?
-            read_only = os.path.join(os.path.dirname(os.path.dirname(TMPDIR)), 'read_only')
+            read_only = os.path.join(
+                os.path.dirname(os.path.dirname(TMPDIR)), 'read_only'
+            )
             os.mkdir(read_only, mode=0o444)
             CmdStanArgs(
                 model_name='bernoulli',

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 
+from cmdstanpy import TMPDIR
 from cmdstanpy.cmdstan_args import (
     Method,
     SamplerArgs,
@@ -476,12 +477,24 @@ class CmdStanArgsTest(unittest.TestCase):
             )
 
         with self.assertRaises(ValueError):
-            # bad output basename
+            # bad output_dir name
             CmdStanArgs(
                 model_name='bernoulli',
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
-                output_basename='no/such/path/to.file',
+                output_dir= 'no/such/path',
+                method_args=sampler_args,
+            )
+
+        with self.assertRaises(ValueError):
+            # can't write to output_dir - valid for all platforms?
+            read_only = os.path.join(TMPDIR, 'read_only')
+            os.mkdir(read_only, mode=0o444)
+            CmdStanArgs(
+                model_name='bernoulli',
+                model_exe='bernoulli.exe',
+                chain_ids=[1, 2, 3, 4],
+                output_dir= read_only,
                 method_args=sampler_args,
             )
 

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -494,7 +494,7 @@ class CmdStanArgsTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             # can't write to output_dir - valid for all platforms?
-            read_only = os.path.join(TMPDIR, 'read_only')
+            read_only = os.path.join(os.path.dirname(os.path.dirname(TMPDIR)), 'read_only')
             os.mkdir(read_only, mode=0o444)
             CmdStanArgs(
                 model_name='bernoulli',

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -77,7 +77,8 @@ class CmdStanModelTest(unittest.TestCase):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
         exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         # pylint: disable=unused-variable
-        model = CmdStanModel(stan_file=stan, exe_file=exe)  # instantiates exe
+        model = CmdStanModel(stan_file=stan)  # instantiates exe
+        self.assertTrue(os.path.exists(exe))
 
         # relative paths ".."
         dotdot_stan = os.path.realpath(os.path.join('..', 'bernoulli.stan'))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -20,9 +20,8 @@ parameters {
   real<lower=0,upper=1> theta;
 }
 model {
-  theta ~ beta(1,1);
-  for (n in 1:N)
-    y[n] ~ bernoulli(theta);
+  theta ~ beta(1,1);  // uniform prior on interval 0,1
+  y ~ bernoulli(theta);
 }
 """
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -80,7 +80,6 @@ class CmdStanModelTest(unittest.TestCase):
         model = CmdStanModel(stan_file=stan)  # instantiates exe
         self.assertTrue(os.path.exists(exe))
 
-        # relative paths ".."
         dotdot_stan = os.path.realpath(os.path.join('..', 'bernoulli.stan'))
         dotdot_exe = os.path.realpath(
             os.path.join('..', 'bernoulli' + EXTENSION)
@@ -91,20 +90,17 @@ class CmdStanModelTest(unittest.TestCase):
             stan_file=os.path.join('..', 'bernoulli.stan'),
             exe_file=os.path.join('..', 'bernoulli' + EXTENSION),
         )
-        print(model1)
         self.assertEqual(model1.stan_file, dotdot_stan)
         self.assertEqual(model1.exe_file, dotdot_exe)
         os.remove(dotdot_stan)
         os.remove(dotdot_exe)
 
-        # user home ~
         tilde_stan = os.path.realpath(
             os.path.join(os.path.expanduser('~'), 'bernoulli.stan')
         )
         tilde_exe = os.path.realpath(
             os.path.join(os.path.expanduser('~'), 'bernoulli' + EXTENSION)
         )
-
         shutil.copyfile(stan, tilde_stan)
         shutil.copyfile(exe, tilde_exe)
         model2 = CmdStanModel(

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,6 +1,7 @@
 """CmdStanModel tests"""
 
 import os
+import shutil
 import unittest
 import pytest
 
@@ -71,6 +72,48 @@ class CmdStanModelTest(unittest.TestCase):
         model = CmdStanModel(stan_file=stan, compile=False)
         self.assertEqual(stan, model.stan_file)
         self.assertEqual(None, model.exe_file)
+
+    def test_model_paths(self):
+        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
+        # pylint: disable=unused-variable
+        model = CmdStanModel(stan_file=stan, exe_file=exe)  # instantiates exe
+
+        # relative paths ".."
+        dotdot_stan = os.path.realpath(os.path.join('..', 'bernoulli.stan'))
+        dotdot_exe = os.path.realpath(
+            os.path.join('..', 'bernoulli' + EXTENSION)
+        )
+        shutil.copyfile(stan, dotdot_stan)
+        shutil.copyfile(exe, dotdot_exe)
+        model1 = CmdStanModel(
+            stan_file=os.path.join('..', 'bernoulli.stan'),
+            exe_file=os.path.join('..', 'bernoulli' + EXTENSION),
+        )
+        print(model1)
+        self.assertEqual(model1.stan_file, dotdot_stan)
+        self.assertEqual(model1.exe_file, dotdot_exe)
+        os.remove(dotdot_stan)
+        os.remove(dotdot_exe)
+
+        # user home ~
+        tilde_stan = os.path.realpath(
+            os.path.join(os.path.expanduser('~'), 'bernoulli.stan')
+        )
+        tilde_exe = os.path.realpath(
+            os.path.join(os.path.expanduser('~'), 'bernoulli' + EXTENSION)
+        )
+
+        shutil.copyfile(stan, tilde_stan)
+        shutil.copyfile(exe, tilde_exe)
+        model2 = CmdStanModel(
+            stan_file=os.path.join('~', 'bernoulli.stan'),
+            exe_file=os.path.join('~', 'bernoulli' + EXTENSION),
+        )
+        self.assertEqual(model2.stan_file, tilde_stan)
+        self.assertEqual(model2.exe_file, tilde_exe)
+        os.remove(tilde_stan)
+        os.remove(tilde_exe)
 
     def test_model_none(self):
         with self.assertRaises(ValueError):

--- a/test/test_runset.py
+++ b/test/test_runset.py
@@ -40,7 +40,6 @@ class RunSetTest(unittest.TestCase):
             runset._set_retcode(i, 0)
         self.assertTrue(runset._check_retcodes())
 
-
     def test_output_filenames(self):
         exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
@@ -57,8 +56,6 @@ class RunSetTest(unittest.TestCase):
         self.assertIn('-1-', runset._csv_files[0])
         self.assertIn('-4-', runset._csv_files[3])
 
-
-
     def test_commands(self):
         exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
@@ -73,8 +70,6 @@ class RunSetTest(unittest.TestCase):
         runset = RunSet(args=cmdstan_args, chains=4)
         self.assertIn('id=1', runset._cmds[0])
         self.assertIn('id=4', runset._cmds[3])
-
-
 
 
 if __name__ == '__main__':

--- a/test/test_runset.py
+++ b/test/test_runset.py
@@ -41,5 +41,41 @@ class RunSetTest(unittest.TestCase):
         self.assertTrue(runset._check_retcodes())
 
 
+    def test_output_filenames(self):
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+        sampler_args = SamplerArgs()
+        cmdstan_args = CmdStanArgs(
+            model_name='bernoulli',
+            model_exe=exe,
+            chain_ids=[1, 2, 3, 4],
+            data=jdata,
+            method_args=sampler_args,
+        )
+        runset = RunSet(args=cmdstan_args, chains=4)
+        self.assertIn('bernoulli-', runset._csv_files[0])
+        self.assertIn('-1-', runset._csv_files[0])
+        self.assertIn('-4-', runset._csv_files[3])
+
+
+
+    def test_commands(self):
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+        sampler_args = SamplerArgs()
+        cmdstan_args = CmdStanArgs(
+            model_name='bernoulli',
+            model_exe=exe,
+            chain_ids=[1, 2, 3, 4],
+            data=jdata,
+            method_args=sampler_args,
+        )
+        runset = RunSet(args=cmdstan_args, chains=4)
+        self.assertIn('id=1', runset._cmds[0])
+        self.assertIn('id=4', runset._cmds[3])
+
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -69,14 +69,13 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(bern_fit.stepsize.shape, (4,))
         self.assertEqual(bern_fit.metric.shape, (4, 1))
 
-        output = os.path.join(DATAFILES_PATH, 'test1-bernoulli-output')
         bern_fit = bern_model.sample(
             data=jdata,
             chains=4,
             cores=2,
             seed=12345,
             sampling_iters=100,
-            csv_basename=output,
+            output_dir=DATAFILES_PATH,
         )
         for i in range(bern_fit.runset.chains):
             csv_file = bern_fit.runset.csv_files[i]
@@ -295,7 +294,6 @@ class CmdStanMCMCTest(unittest.TestCase):
         # construct fit using existing sampler output
         exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
-        output = os.path.join(GOODFILES_PATH, 'bern')
         sampler_args = SamplerArgs(
             sampling_iters=100, max_treedepth=11, adapt_delta=0.95
         )
@@ -305,10 +303,16 @@ class CmdStanMCMCTest(unittest.TestCase):
             chain_ids=[1, 2, 3, 4],
             seed=12345,
             data=jdata,
-            output_basename=output,
+            output_dir=DATAFILES_PATH,
             method_args=sampler_args,
         )
         runset = RunSet(args=cmdstan_args, chains=4)
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'runset-good', 'bern-1.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-good', 'bern-2.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-good', 'bern-3.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-good', 'bern-4.csv'),
+            ]
         self.assertEqual(4, runset.chains)
         retcodes = runset._retcodes
         for i in range(len(retcodes)):
@@ -347,17 +351,20 @@ class CmdStanMCMCTest(unittest.TestCase):
         exe = os.path.join(
             DATAFILES_PATH, 'bernoulli' + EXTENSION
         )
-        output = os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc')
         sampler_args = SamplerArgs()
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
             model_exe=exe,
             chain_ids=[1, 2],
             seed=12345,
-            output_basename=output,
+            output_dir=DATAFILES_PATH,
             method_args=sampler_args,
         )
         runset = RunSet(args=cmdstan_args, chains=2)
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc-1.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc-1.csv'),
+            ]
         fit = CmdStanMCMC(runset)
         fit._validate_csv_files()
         sampler_state = [
@@ -405,13 +412,12 @@ class CmdStanMCMCTest(unittest.TestCase):
             self.assertTrue(os.path.exists(txt_file))
 
         # save files to good dir
-        basename = 'bern_save_csvfiles_test'
-        bern_fit.save_csvfiles(dir=DATAFILES_PATH, basename=basename)
+        bern_fit.save_csvfiles(dir=DATAFILES_PATH)
         for i in range(bern_fit.runset.chains):
             csv_file = bern_fit.runset.csv_files[i]
             self.assertTrue(os.path.exists(csv_file))
         with self.assertRaisesRegex(Exception, 'file exists'):
-            bern_fit.save_csvfiles(dir=DATAFILES_PATH, basename=basename)
+            bern_fit.save_csvfiles(dir=DATAFILES_PATH)
         for i in range(bern_fit.runset.chains):  # cleanup datafile_path dir
             os.remove(bern_fit.runset.csv_files[i])
             os.remove(bern_fit.runset.console_files[i])
@@ -420,7 +426,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         bern_fit = bern_model.sample(
             data=jdata, chains=4, cores=2, seed=12345, sampling_iters=200
         )
-        bern_fit.save_csvfiles(basename=basename)  # default dir
+        bern_fit.save_csvfiles()  # default dir
         for i in range(bern_fit.runset.chains):
             csv_file = bern_fit.runset.csv_files[i]
             self.assertTrue(os.path.exists(csv_file))
@@ -431,20 +437,21 @@ class CmdStanMCMCTest(unittest.TestCase):
     def test_diagnose_divergences(self):
         exe = os.path.join(
             DATAFILES_PATH, 'bernoulli' + EXTENSION
-        )  # fake out validation
-        output = os.path.join(
-            DATAFILES_PATH, 'diagnose-good', 'corr_gauss_depth8'
         )
         sampler_args = SamplerArgs()
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
             model_exe=exe,
             chain_ids=[1],
-            output_basename=output,
+            output_dir=DATAFILES_PATH,
             method_args=sampler_args,
         )
-        sampler_runset = RunSet(args=cmdstan_args, chains=1)
-        fit = CmdStanMCMC(sampler_runset)
+        runset = RunSet(args=cmdstan_args, chains=1)
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'diagnose-good',
+                             'corr_gauss_depth8-1.csv'),
+            ]
+        fit = CmdStanMCMC(runset)
         # TODO - use cmdstan test files instead
         expected = '\n'.join(
             [
@@ -466,76 +473,64 @@ class CmdStanMCMCTest(unittest.TestCase):
         )
 
         # some chains had errors
-        output = os.path.join(BADFILES_PATH, 'bad-transcript-bern')
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
             model_exe=exe,
             chain_ids=[1, 2, 3, 4],
             seed=12345,
             data=jdata,
-            output_basename=output,
+            output_dir=DATAFILES_PATH,
             method_args=sampler_args,
         )
         runset = RunSet(args=cmdstan_args, chains=4)
+        for i in range(4):
+            runset._set_retcode(i, 0)
+        self.assertTrue(runset._check_retcodes())
+
+        # errors reported
+        runset._console_files = [
+            os.path.join(DATAFILES_PATH, 'runset-bad',
+                             'bad-transcript-bern-1.txt'),
+            os.path.join(DATAFILES_PATH, 'runset-bad',
+                             'bad-transcript-bern-2.txt'),
+            os.path.join(DATAFILES_PATH, 'runset-bad',
+                             'bad-transcript-bern-3.txt'),
+            os.path.join(DATAFILES_PATH, 'runset-bad',
+                             'bad-transcript-bern-4.txt'),
+            ]
         with self.assertRaisesRegex(Exception, 'Exception'):
             runset._check_console_msgs()
 
+
         # csv file headers inconsistent
-        output = os.path.join(BADFILES_PATH, 'bad-hdr-bern')
-        cmdstan_args = CmdStanArgs(
-            model_name='bernoulli',
-            model_exe=exe,
-            chain_ids=[1, 2, 3, 4],
-            seed=12345,
-            data=jdata,
-            output_basename=output,
-            method_args=sampler_args,
-        )
-        runset = RunSet(args=cmdstan_args, chains=4)
-        retcodes = runset._retcodes
-        for i in range(len(retcodes)):
-            runset._set_retcode(i, 0)
-        self.assertTrue(runset._check_retcodes())
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-1.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-2.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-3.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-4.csv'),
+            ]
         fit = CmdStanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'header mismatch'):
             fit._validate_csv_files()
 
         # bad draws
-        output = os.path.join(BADFILES_PATH, 'bad-draws-bern')
-        cmdstan_args = CmdStanArgs(
-            model_name='bernoulli',
-            model_exe=exe,
-            chain_ids=[1, 2, 3, 4],
-            seed=12345,
-            data=jdata,
-            output_basename=output,
-            method_args=sampler_args,
-        )
-        runset = RunSet(args=cmdstan_args, chains=4)
-        retcodes = runset._retcodes
-        for i in range(len(retcodes)):
-            runset._set_retcode(i, 0)
-        self.assertTrue(runset._check_retcodes())
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-1.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-2.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-3.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-4.csv'),
+            ]
         fit = CmdStanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'draws'):
             fit._validate_csv_files()
 
         # mismatch - column headers, draws
-        output = os.path.join(BADFILES_PATH, 'bad-cols-bern')
-        cmdstan_args = CmdStanArgs(
-            model_name='bernoulli',
-            model_exe=exe,
-            chain_ids=[1, 2, 3, 4],
-            seed=12345,
-            data=jdata,
-            output_basename=output,
-            method_args=sampler_args,
-        )
-        runset = RunSet(args=cmdstan_args, chains=4)
-        retcodes = runset._retcodes
-        for i in range(len(retcodes)):
-            runset._set_retcode(i, 0)
-        self.assertTrue(runset._check_retcodes())
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-1.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-2.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-3.csv'),
+            os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-4.csv'),
+            ]
         fit = CmdStanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'bad draw'):
             fit._validate_csv_files()

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import shutil
 from multiprocessing import cpu_count
 import unittest
 from testfixtures import LogCapture
@@ -404,7 +405,6 @@ class CmdStanMCMCTest(unittest.TestCase):
         bern_fit = bern_model.sample(
             data=jdata, chains=4, cores=2, seed=12345, sampling_iters=200
         )
-
         for i in range(bern_fit.runset.chains):
             csv_file = bern_fit.runset.csv_files[i]
             txt_file = ''.join([os.path.splitext(csv_file)[0], '.txt'])
@@ -418,9 +418,17 @@ class CmdStanMCMCTest(unittest.TestCase):
             self.assertTrue(os.path.exists(csv_file))
         with self.assertRaisesRegex(Exception, 'file exists'):
             bern_fit.save_csvfiles(dir=DATAFILES_PATH)
+
+        tmp2_dir = os.path.join(HERE, 'tmp2')
+        os.mkdir(tmp2_dir)
+        bern_fit.save_csvfiles(dir=tmp2_dir)
+        for i in range(bern_fit.runset.chains):
+            csv_file = bern_fit.runset.csv_files[i]
+            self.assertTrue(os.path.exists(csv_file))
         for i in range(bern_fit.runset.chains):  # cleanup datafile_path dir
             os.remove(bern_fit.runset.csv_files[i])
             os.remove(bern_fit.runset.console_files[i])
+        shutil.rmtree(tmp2_dir, ignore_errors=True)
 
         # regenerate to tmpdir, save to good dir
         bern_fit = bern_model.sample(

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -501,7 +501,6 @@ class CmdStanMCMCTest(unittest.TestCase):
         with self.assertRaisesRegex(Exception, 'Exception'):
             runset._check_console_msgs()
 
-
         # csv file headers inconsistent
         runset._csv_files = [
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-1.csv'),


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Addresses issues #185 and #133, also makes output file names match CmdStanR output filenames.

With this change, there is no longer a concept of "basename", that is, the user doesn't get to specify the prefix used for the output filenames.  Instead,  output filenames are composed as follows

- output files written to a user specified directory have basename: 
model_name-YYMMDDhhmm-chain_id

- output files written to the temporary directory (TMPDIR) have basename: 
model_name-YYMMDDhhmm-chain_id-8tmpstr

Method `save_csvfiles` removes the 8-tmpstr (if any) when moving the output files to the specified destination.  

As part of this PR I cleaned up the documentation around output files and how to save them to a specified directory.   Spellchecked all docstrings and error messages in file `model.py` and corrected types.

I also made the filepath handling more robust, allowing use of relative paths and "~" and added unit tests.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:  
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

