### PR TITLE
Make Stan model syntax errors readable

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -257,7 +257,7 @@ class CmdStanModel:
                         do_command(cmd, cmdstan_path(), logger=self._logger)
                     except RuntimeError as e:
                         self._logger.error(
-                            'file %s, exception %s', stan_file, e
+                            'file %s, exception %s', stan_file, str(e)
                         )
                         compilation_failed = True
 

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -257,7 +257,7 @@ class CmdStanModel:
                         do_command(cmd, cmdstan_path(), logger=self._logger)
                     except RuntimeError as e:
                         self._logger.error(
-                            'file %s, exception %s', stan_file, repr(e)
+                            'file %s, exception %s', stan_file, e
                         )
                         compilation_failed = True
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -4,6 +4,8 @@ import os
 import shutil
 import unittest
 import pytest
+from testfixtures import LogCapture
+import numpy as np
 
 from cmdstanpy.utils import EXTENSION
 from cmdstanpy.model import CmdStanModel
@@ -116,7 +118,7 @@ class CmdStanModelTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             _ = CmdStanModel(exe_file=None, stan_file=None)
 
-    def test_model_bad(self):
+    def test_model_file_does_not_exist(self):
         with self.assertRaises(Exception):
             CmdStanModel(stan_file='xdlfkjx', exe_file='sdfndjsds')
 
@@ -124,9 +126,19 @@ class CmdStanModelTest(unittest.TestCase):
         with self.assertRaises(Exception):
             CmdStanModel(stan_file=stan)
 
+    def test_model_syntax_error(self):
         stan = os.path.join(DATAFILES_PATH, 'bad_syntax.stan')
-        with self.assertRaises(Exception):
-            CmdStanModel(stan_file=stan)
+
+        with LogCapture() as log:
+            with self.assertRaises(Exception):
+                CmdStanModel(stan_file=stan)
+
+            # Join all the log messages into one string
+            error_message = "@( * O * )@".join(np.array(log.actual())[:, -1])
+
+            # Ensure the new line character in error message is not escaped
+            # so the error message is readable
+            self.assertRegex(error_message, r'PARSER EXPECTED: ";"\n')
 
     def test_repr(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -138,7 +138,7 @@ class CmdStanModelTest(unittest.TestCase):
 
             # Ensure the new line character in error message is not escaped
             # so the error message is readable
-            self.assertRegex(error_message, r'PARSER EXPECTED: ";"\n')
+            self.assertRegex(error_message, r'PARSER EXPECTED: ";"(\r\n|\r|\n)')
 
     def test_repr(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

It was not easy to read the error messages for .stan file with syntax errors. The error messages were all printed out in one line because the new line characters were escaped. I've changed it so the new lines are shown as new lines, so the errors are now more readable. :) See #193.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Me



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

Yes, agree

