### PR TITLE
Fix warmup progress bar

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1036,6 +1036,7 @@ class CmdStanModel:
         count_warmup = 0
         count_sampling = 0
         stdout = b''
+        refresh_warmup = True
 
         try:
             # iterate while process is sampling
@@ -1043,7 +1044,6 @@ class CmdStanModel:
                 output = proc.stdout.readline()
                 stdout += output
                 output = output.decode('utf-8').strip()
-                refresh_warmup = True
                 if output.startswith('Iteration'):
                     match = re.search(pattern_compiled, output)
                     if match:
@@ -1070,7 +1070,7 @@ class CmdStanModel:
                             )
                             pbar_warmup.update(count)
                         elif match.group(3).lower() == 'sampling':
-                            # refresh warmup and close the progress bar
+                            # refresh warmup to 100%
                             if refresh_warmup:
                                 pbar_warmup.update(num_warmup - count_warmup)
                                 pbar_warmup.refresh()


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is a fix for a bug which was caused by a combination of two things:

  1. My previous pull request https://github.com/stan-dev/cmdstanpy/pull/195. 
  1. Incorrect (I think) location of `refresh_warmup = True` line.

For some values of `warmup_iters` parameter, the warmup progress bars became no longer visible after warmup has finished. Please find examples of the output below.

What was causing this bug? The sampling consists of two consecutive stages: 'warmup' and 'sampling'. 'Sampling' comes after the 'warmup'. The program detects that 'warmup' has finished when it starts receive 'sampling' output. During each 'sampling' iteration, the program updated the warmup progress bar to make it look fully finished, and this was meant to happen only once. However, because `refresh_warmup = True` line was misplaced (and also because I moved the `close()` call for warmup progress bar) this code was called multiple times. As a result, the warmup progress bar was overfilled and became invisible.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): me



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

I agree.

## Code

To reproduce the problem, run

```
python eight_schools.py
```

### eight_schools.py

```python
from cmdstanpy import CmdStanModel

model = CmdStanModel(stan_file="eight_schools.stan")

data = {
    "J": 8,
    "y": [28,  8, -3,  7, -1,  1, 18, 12],
    "sigma": [15, 10, 16, 11,  9, 11, 10, 18]
}

fit = model.sample(data=data, show_progress=True,
                   chains=4, cores=2,
                   sampling_iters=30000, warmup_iters=5000)

print(fit.summary())
```

### eight_schools.stan

```stan
data {
  int<lower=0> J;         // number of schools
  real y[J];              // estimated treatment effects
  real<lower=0> sigma[J]; // standard error of effect estimates
}
parameters {
  real mu;                // population treatment effect
  real<lower=0> tau;      // standard deviation in treatment effects
  vector[J] eta;          // unscaled deviation from mu by school
}
transformed parameters {
  vector[J] theta = mu + tau * eta;        // school treatment effects
}
model {
  target += normal_lpdf(eta | 0, 1);       // prior log-density
  target += normal_lpdf(y | theta, sigma); // log-likelihood
}

```

## Output before the fix

The warmup progress bars are no longer visible during the `sampling` stage:

```
Chain 1 - warmup: 22200it [00:07, 2922.45it/s]                                                                           
Chain 1 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:07<00:00, 3949.41it/s]
Chain 2 - warmup: 22200it [00:07, 2922.74it/s]                                                                           
Chain 2 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:07<00:00, 3949.66it/s]
Chain 3 - warmup: 22200it [00:07, 2924.18it/s]                                                                           
Chain 3 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:07<00:00, 3953.90it/s]
Chain 4 - warmup: 22200it [00:07, 2927.45it/s]                                                                           
Chain 4 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:07<00:00, 3958.00it/s]
```

## Output after the fix

Warmup progress bars are visible

```
Chain 1 - warmup: 100%|█████████████████████████████████████████████████████████████| 5000/5000 [00:06<00:00, 714.81it/s]
Chain 1 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:06<00:00, 4288.90it/s]
Chain 2 - warmup: 100%|█████████████████████████████████████████████████████████████| 5000/5000 [00:06<00:00, 715.07it/s]
Chain 2 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:06<00:00, 4292.27it/s]
Chain 3 - warmup: 100%|█████████████████████████████████████████████████████████████| 5000/5000 [00:06<00:00, 715.46it/s]
Chain 3 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:06<00:00, 4292.98it/s]
Chain 4 - warmup: 100%|█████████████████████████████████████████████████████████████| 5000/5000 [00:06<00:00, 715.77it/s]
Chain 4 - sample: 100%|██████████████████████████████████████████████████████████| 30000/30000 [00:06<00:00, 4295.78it/s]
```

### Jupyter notebook

Looks good after the fix:

<img width="912" alt="cmdstanpy_warmaup_progress_bar_fix" src="https://user-images.githubusercontent.com/880411/72216472-78a8de00-3575-11ea-9c05-64cc4aeccbe2.png">
