### PR TITLE
Use single progress bar

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -23,11 +23,6 @@ class Method(Enum):
         return '<%s.%s>' % (self.__class__.__name__, self.name)
 
 
-class SamplerArgsDefaults:
-    warmup_iters = 1000
-    sampling_iters = 1000
-
-
 class SamplerArgs:
     """Arguments for the NUTS adaptive sampler."""
 

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -23,6 +23,11 @@ class Method(Enum):
         return '<%s.%s>' % (self.__class__.__name__, self.name)
 
 
+class SamplerArgsDefaults:
+    warmup_iters = 1000
+    sampling_iters = 1000
+
+
 class SamplerArgs:
     """Arguments for the NUTS adaptive sampler."""
 

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -601,21 +601,6 @@ class CmdStanModel:
             try:
                 import tqdm
 
-                # progress bar updates - 100 per warmup, sampling
-                if fixed_param or not adapt_engaged or warmup_iters == 0:
-                    num_updates = 100
-                    w_iters = 0
-                else:
-                    num_updates = 200
-                    if warmup_iters is None:
-                        w_iters = 1000
-                    else:
-                        w_iters = warmup_iters
-                s_iters = sampling_iters
-                if s_iters is None:
-                    s_iters = 1000
-                refresh = max(int((s_iters + w_iters) // num_updates), 1)
-                # disable logger for console (temporary) - use tqdm
                 self._logger.propagate = False
             except ImportError:
                 self._logger.warning(
@@ -681,6 +666,7 @@ class CmdStanModel:
                                 tqdm_pbar = tqdm.tqdm
                         else:
                             tqdm_pbar = tqdm.tqdm
+
                         # enable dynamic_ncols for advanced users
                         # currently hidden feature
                         dynamic_ncols = os.environ.get(
@@ -690,24 +676,25 @@ class CmdStanModel:
                             dynamic_ncols = False
                         else:
                             dynamic_ncols = True
-                        pbar = [
-                            # warmup
-                            tqdm_pbar(
-                                desc='Chain {} - warmup'.format(i + 1),
-                                position=i * 2,
-                                total=sampler_args.warmup_iters,
-                                dynamic_ncols=dynamic_ncols,
-                            ),
-                            # sampling
-                            tqdm_pbar(
-                                desc='Chain {} - sample'.format(i + 1),
-                                position=i * 2 + 1,
-                                total=sampler_args.sampling_iters,
-                                dynamic_ncols=dynamic_ncols,
-                            ),
-                        ]
 
-                        all_pbars += pbar
+                        # Total number of iterations (warmup + sample)
+                        # 2000 is default in cmdstan
+                        total_iters = 2000
+
+                        if (sampler_args.warmup_iters is not None and
+                           sampler_args.sampling_iters is not None):
+
+                            total_iters = sampler_args.warmup_iters \
+                                + sampler_args.sampling_iters
+
+                        pbar = tqdm_pbar(
+                                desc='Chain {} - warmup'.format(i + 1),
+                                position=i,
+                                total=total_iters,
+                                dynamic_ncols=dynamic_ncols,
+                            )
+
+                        all_pbars.append(pbar)
 
                     executor.submit(self._run_cmdstan, runset, i, pbar)
 
@@ -990,7 +977,7 @@ class CmdStanModel:
         return vb
 
     def _run_cmdstan(
-        self, runset: RunSet, idx: int = 0, pbar: List[Any] = None
+        self, runset: RunSet, idx: int = 0, pbar: Any = None
     ) -> None:
         """
         Encapsulates call to CmdStan.
@@ -1018,7 +1005,7 @@ class CmdStanModel:
         runset._set_retcode(idx, proc.returncode)
 
     def _read_progress(
-        self, proc: subprocess.Popen, pbar: List[Any], idx: int
+        self, proc: subprocess.Popen, pbar: Any, idx: int
     ) -> bytes:
         """
         Update tqdm progress bars according to CmdStan console progress msgs.
@@ -1030,12 +1017,10 @@ class CmdStanModel:
             r'^Iteration\:\s*(\d+)\s*/\s*(\d+)\s*\[\s*\d+%\s*\]\s*\((\S*)\)$'
         )
         pattern_compiled = re.compile(pattern, flags=re.IGNORECASE)
-        pbar_warmup, pbar_sampling = pbar
-        num_warmup = pbar_warmup.total
-        num_sampling = pbar_sampling.total
-        count_warmup = 0
-        count_sampling = 0
+        previous_count = 0
         stdout = b''
+        changed_description = False  # Changed from 'warmup' to 'sample'
+        pbar.set_description(desc=f'Chain {idx + 1} - warmup', refresh=True)
 
         try:
             # iterate while process is sampling
@@ -1043,90 +1028,24 @@ class CmdStanModel:
                 output = proc.stdout.readline()
                 stdout += output
                 output = output.decode('utf-8').strip()
-                refresh_warmup = True
                 if output.startswith('Iteration'):
                     match = re.search(pattern_compiled, output)
                     if match:
-                        # check if pbars need reset
-                        if num_warmup is None or num_sampling is None:
-                            total_count = int(match.group(2))
-                            if num_warmup is None and num_sampling is None:
-                                num_warmup = total_count // 2
-                                num_sampling = total_count - num_warmup
-                                pbar_warmup.total = num_warmup
-                                pbar_sampling.total = num_sampling
-                            elif num_warmup is None:
-                                num_warmup = total_count - num_sampling
-                                pbar_warmup.total = num_warmup
-                            else:
-                                num_sampling = total_count - num_warmup
-                                pbar_sampling.total = num_sampling
-                        # raw_count = warmup + sampling
-                        raw_count = int(match.group(1))
-                        if match.group(3).lower() == 'warmup':
-                            count, count_warmup = (
-                                raw_count - count_warmup,
-                                raw_count,
-                            )
-                            pbar_warmup.update(count)
-                        elif match.group(3).lower() == 'sampling':
-                            # refresh warmup and close the progress bar
-                            if refresh_warmup:
-                                pbar_warmup.update(num_warmup - count_warmup)
-                                pbar_warmup.refresh()
-                                refresh_warmup = False
-                            # update values to full
-                            count, count_sampling = (
-                                raw_count - num_warmup - count_sampling,
-                                raw_count - num_warmup,
-                            )
-                            pbar_sampling.update(count)
+                        current_count = int(match.group(1))
 
-            # read and process rest of the stdout if needed
-            warmup_cumulative_count = 0
-            sampling_cumulative_count = 0
-            for output in proc.stdout:
-                stdout += output
-                output = output.decode('utf-8').strip()
-                if output.startswith('Iteration'):
-                    match = re.search(pattern_compiled, output)
-                    if match:
-                        # check if pbars need reset
-                        if num_warmup is None or num_sampling is None:
-                            total_count = int(match.group(2))
-                            if num_warmup is None and num_sampling is None:
-                                num_warmup = total_count // 2
-                                num_sampling = total_count - num_warmup
-                                pbar_warmup.total = num_warmup
-                                pbar_sampling.total = num_sampling
-                            elif num_warmup is None:
-                                num_warmup = total_count - num_sampling
-                                pbar_warmup.total = num_warmup
-                            else:
-                                num_sampling = total_count - num_warmup
-                                pbar_sampling.total = num_sampling
-                        # raw_count = warmup + sampling
-                        raw_count = int(match.group(1))
-                        if match.group(3).lower() == 'warmup':
-                            count, count_warmup = (
-                                raw_count - count_warmup,
-                                raw_count,
-                            )
-                            warmup_cumulative_count += count
-                        elif match.group(3).lower() == 'sampling':
-                            count, count_sampling = (
-                                raw_count - num_warmup - count_sampling,
-                                raw_count - num_warmup,
-                            )
-                            sampling_cumulative_count += count
-            # update warmup pbar if needed
-            if warmup_cumulative_count:
-                pbar_warmup.update(warmup_cumulative_count)
-                pbar_warmup.refresh()
-            # update sampling pbar if needed
-            if sampling_cumulative_count:
-                pbar_sampling.update(sampling_cumulative_count)
-                pbar_sampling.refresh()
+                        if (match.group(3).lower() == 'sampling' and
+                           not changed_description):
+                            pbar.set_description(f'Chain {idx + 1} - sample')
+                            changed_description = True
+
+                        pbar.update(current_count - previous_count)
+                        previous_count = current_count
+
+            pbar.set_description(f'Chain {idx + 1} -   done', refresh=True)
+
+            if "notebook" in type(pbar).__name__:
+                # In Jupyter make the bar green by closing it
+                pbar.close()
 
         except Exception as e:  # pylint: disable=broad-except
             self._logger.warning(
@@ -1135,5 +1054,4 @@ class CmdStanModel:
                 repr(e),
             )
 
-        # return stdout
         return stdout

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Union
 
 from cmdstanpy.cmdstan_args import (
     CmdStanArgs,
+    SamplerArgsDefaults,
     SamplerArgs,
     OptimizeArgs,
     GenerateQuantitiesArgs,
@@ -677,15 +678,17 @@ class CmdStanModel:
                         else:
                             dynamic_ncols = True
 
-                        # Total number of iterations (warmup + sample)
-                        # 2000 is default in cmdstan
-                        total_iters = 2000
+                        total_iters = 0
 
-                        if (sampler_args.warmup_iters is not None and
-                           sampler_args.sampling_iters is not None):
+                        if sampler_args.warmup_iters is None:
+                            total_iters += SamplerArgsDefaults.warmup_iters
+                        else:
+                            total_iters += sampler_args.warmup_iters
 
-                            total_iters = sampler_args.warmup_iters \
-                                + sampler_args.sampling_iters
+                        if sampler_args.sampling_iters is None:
+                            total_iters += SamplerArgsDefaults.sampling_iters
+                        else:
+                            total_iters += sampler_args.sampling_iters
 
                         pbar = tqdm_pbar(
                                 desc='Chain {} - warmup'.format(i + 1),

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Union
 
 from cmdstanpy.cmdstan_args import (
     CmdStanArgs,
-    SamplerArgsDefaults,
     SamplerArgs,
     OptimizeArgs,
     GenerateQuantitiesArgs,
@@ -678,22 +677,10 @@ class CmdStanModel:
                         else:
                             dynamic_ncols = True
 
-                        total_iters = 0
-
-                        if sampler_args.warmup_iters is None:
-                            total_iters += SamplerArgsDefaults.warmup_iters
-                        else:
-                            total_iters += sampler_args.warmup_iters
-
-                        if sampler_args.sampling_iters is None:
-                            total_iters += SamplerArgsDefaults.sampling_iters
-                        else:
-                            total_iters += sampler_args.sampling_iters
-
                         pbar = tqdm_pbar(
                                 desc='Chain {} - warmup'.format(i + 1),
                                 position=i,
-                                total=total_iters,
+                                total=1,  # Will set total from Stan's output
                                 dynamic_ncols=dynamic_ncols,
                             )
 
@@ -1035,6 +1022,10 @@ class CmdStanModel:
                     match = re.search(pattern_compiled, output)
                     if match:
                         current_count = int(match.group(1))
+                        total_count = int(match.group(2))
+
+                        if pbar.total != total_count:
+                            pbar.reset(total=total_count)
 
                         if (match.group(3).lower() == 'sampling' and
                            not changed_description):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ pylint
 pytest
 pytest-cov
 testfixtures
+tqdm

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3,9 +3,11 @@
 import os
 import shutil
 import unittest
+from unittest.mock import Mock
 import pytest
 from testfixtures import LogCapture
 import numpy as np
+import tqdm
 
 from cmdstanpy.utils import EXTENSION
 from cmdstanpy.model import CmdStanModel
@@ -195,6 +197,36 @@ class CmdStanModelTest(unittest.TestCase):
         # already compiled
         model3 = CmdStanModel(stan_file=stan)
         self.assertTrue(model3.exe_file.endswith(exe.replace('\\', '/')))
+
+    def test_read_progress(self):
+        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        model = CmdStanModel(stan_file=stan, compile=False)
+
+        proc_mock = Mock()
+        proc_mock.poll.side_effect = [None, None, 'finish']
+        stan_output1 = 'Iteration: 12100 / 31000 [ 39%]  (Warmup)'
+        stan_output2 = 'Iteration: 14000 / 31000 [ 45%]  (Warmup)'
+        pbar = tqdm.tqdm(desc='Chain 1 - warmup', position=1, total=1)
+
+        proc_mock.stdout.readline.side_effect = [
+            stan_output1.encode('utf-8'), stan_output2.encode('utf-8')]
+
+        with LogCapture() as log:
+            result = model._read_progress(proc=proc_mock, pbar=pbar, idx=0)
+            self.assertEqual([], log.actual())
+            self.assertEqual(31000, pbar.total)
+
+            # Expect progress bar output to be something like this:
+            # 'Chain 1 -   done:  45%|████▌     | 14000/31000'
+            # --------
+
+            self.assertIn('Chain 1 -   done:  45%', str(pbar))
+            self.assertIn('14000/31000', str(pbar))
+
+            # Check Stan's output is returned
+            output = result.decode('utf-8')
+            self.assertIn(stan_output1, output)
+            self.assertIn(stan_output2, output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

* Use a single progress bar instead of separate bars for warmup and sampling. This simplifies code since cmdstan output also combines warmup and sampling.

* Change the description of the bar from "warmup", to "sample" to "done" to indicate the stage of sampling.

* For Jupyter only, make each bar green as soon as it's done.

* I've deleted a lot of progress bar code following comment "read and process rest of the stdout if needed", I could not figure out what it was for, and everything worked for me without it.

#### In terminal

![cmdstanpy_single_bar_terminal](https://user-images.githubusercontent.com/880411/72219875-03ea9980-359f-11ea-84a5-0de83f7a0852.gif)

#### In Jupyter

![cmdstanpy_single_bar_jupyter](https://user-images.githubusercontent.com/880411/72219874-03ea9980-359f-11ea-852c-d04ce9640ee3.gif)



#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): me



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

Yes, agree


## Code

To test the progress bar, run

```
python eight_schools.py
```

### eight_schools.py

```python
from cmdstanpy import CmdStanModel

model = CmdStanModel(stan_file="eight_schools.stan")

data = {
    "J": 8,
    "y": [28,  8, -3,  7, -1,  1, 18, 12],
    "sigma": [15, 10, 16, 11,  9, 11, 10, 18]
}

fit = model.sample(data=data, show_progress=True,
                   chains=4, cores=2,
                   sampling_iters=15000, warmup_iters=15000)

print(fit.summary())
```

### eight_schools.stan

```stan
data {
  int<lower=0> J;         // number of schools
  real y[J];              // estimated treatment effects
  real<lower=0> sigma[J]; // standard error of effect estimates
}
parameters {
  real mu;                // population treatment effect
  real<lower=0> tau;      // standard deviation in treatment effects
  vector[J] eta;          // unscaled deviation from mu by school
}
transformed parameters {
  vector[J] theta = mu + tau * eta;        // school treatment effects
}
model {
  target += normal_lpdf(eta | 0, 1);       // prior log-density
  target += normal_lpdf(y | theta, sigma); // log-likelihood
}
```

