### PR TITLE
Bug: fix the `metric` option

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -124,7 +124,7 @@ class SamplerArgs:
                             'step_size must be > 0, found {}'.format(step_size)
                         )
         if self.metric is not None:
-            dims = None
+            dims = []
             if isinstance(self.metric, str):
                 if self.metric in ['diag', 'diag_e']:
                     self.metric = 'diag_e'
@@ -170,7 +170,7 @@ class SamplerArgs:
                                         self.metric[0], metric
                                     )
                                 )
-            if dims is not None:
+            if any(dims):
                 if len(dims) > 2 or (len(dims) == 2 and dims[0] != dims[1]):
                     raise ValueError('bad metric specifiation')
                 self.metric_file = self.metric

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -124,7 +124,7 @@ class SamplerArgs:
                             'step_size must be > 0, found {}'.format(step_size)
                         )
         if self.metric is not None:
-            dims = []
+            dims = None
             if isinstance(self.metric, str):
                 if self.metric in ['diag', 'diag_e']:
                     self.metric = 'diag_e'

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -140,7 +140,7 @@ class CmdStanModelTest(unittest.TestCase):
 
             # Ensure the new line character in error message is not escaped
             # so the error message is readable
-            self.assertRegex(error_message, r'PARSER EXPECTED: ";"(\r\n|\r|\n)')
+            self.assertRegex(error_message, r'parsing error:(\r\n|\r|\n)')
 
     def test_repr(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
I got an error when trying to use the 'dense' metric option. This code should reproduce the error: 

```
import cmdstanpy
import os

bernoulli_stan = os.path.join(
    cmdstanpy.cmdstan_path(), 'examples', 'bernoulli', 'bernoulli.stan'
)
bernoulli_model = cmdstanpy.CmdStanModel(stan_file=bernoulli_stan)
bernoulli_data = { "N" : 10, "y" : [0,1,0,0,0,0,0,0,0,1] }
bern_fit = bernoulli_model.sample(
    data=bernoulli_data, output_dir='.', metric='dense'
)
```

From the output `.txt` files it looks like the problem is that the `metric_file` isn't being set correctly, which I think happens because of a clash in `cmdstan_args` between `dims = []` at line 127 and `if dims is not None` at line 173. 

This change makes those two statements agree and fixed the error on my computer.

I've also bundled an unrelated change to a regex in `test_model.py` which was causing a test failure.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Teddy Groves


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

