### PR TITLE
Don't quote metric files.

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -228,9 +228,9 @@ class SamplerArgs:
             cmd.append('metric={}'.format(self.metric))
         if self.metric_file is not None:
             if not isinstance(self.metric_file, list):
-                cmd.append('metric_file="{}"'.format(self.metric_file))
+                cmd.append('metric_file={}'.format(self.metric_file))
             else:
-                cmd.append('metric_file="{}"'.format(self.metric_file[idx]))
+                cmd.append('metric_file={}'.format(self.metric_file[idx]))
         if self.adapt_engaged is not None or self.adapt_delta is not None:
             cmd.append('adapt')
         if self.adapt_engaged is not None:

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -398,6 +398,17 @@ class CmdStanMCMCTest(unittest.TestCase):
         with self.assertRaises(Exception):
             fit.get_drawset(params=['ph'])
 
+    def test_custom_metric(self):
+        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+        bern_model = CmdStanModel(stan_file=stan)
+        jmetric = os.path.join(DATAFILES_PATH, 'bernoulli.metric.json')
+        # just test that it runs without error
+        bern_model.sample(
+            data=jdata, chains=4, cores=2, seed=12345, sampling_iters=200,
+            metric=jmetric,
+        )
+
     def test_save_csv(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -398,6 +398,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         with self.assertRaises(Exception):
             fit.get_drawset(params=['ph'])
 
+    # pylint: disable=no-self-use
     def test_custom_metric(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

cmdstan interprets the quotes as parts of the filename, causing it to fail to find the files.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Google Inc.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

