### PR TITLE
Bugfix/188 cmdstan env var

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -192,6 +192,7 @@ def cmdstan_path() -> str:
                 'run command line script "install_cmdstan"'
             )
         cmdstan = os.path.join(cmdstan_dir, latest_cmdstan)
+        os.environ['CMDSTAN'] = cmdstan
     validate_cmdstan_path(cmdstan)
     return cmdstan
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -33,11 +33,15 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 
 
 class CmdStanPathTest(unittest.TestCase):
+
     def test_default_path(self):
-        abs_rel_path = os.path.expanduser(
-            os.path.join('~', '.cmdstanpy', 'cmdstan')
-        )
-        self.assertTrue(cmdstan_path().startswith(abs_rel_path))
+        if 'CMDSTAN' in os.environ:
+            self.assertEqual(cmdstan_path(), os.environ['CMDSTAN'])
+        else:
+            abs_rel_path = os.path.expanduser(
+                os.path.join('~', '.cmdstanpy', 'cmdstan')
+                )
+            self.assertTrue(cmdstan_path().startswith(abs_rel_path))
 
     def test_non_spaces_location(self):
         good_path = os.path.join(TMPDIR, 'good_dir')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -60,7 +60,6 @@ class CmdStanPathTest(unittest.TestCase):
                 if 'CMDSTAN' in os.environ:
                     del os.environ['CMDSTAN']
 
-
     def test_non_spaces_location(self):
         good_path = os.path.join(TMPDIR, 'good_dir')
         with TemporaryCopiedFile(good_path) as (pth, is_changed):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -81,12 +81,16 @@ class CmdStanPathTest(unittest.TestCase):
         shutil.rmtree(bad_path, ignore_errors=True)
 
     def test_set_path(self):
-        install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
-        install_version = os.path.expanduser(
-            os.path.join(install_dir, get_latest_cmdstan(install_dir))
-        )
-        set_cmdstan_path(install_version)
-        self.assertEqual(install_version, cmdstan_path())
+        if 'CMDSTAN' in os.environ:
+            self.assertEqual(cmdstan_path(), os.environ['CMDSTAN'])
+        else:
+            install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
+            install_version = os.path.expanduser(
+                os.path.join(install_dir, get_latest_cmdstan(install_dir))
+                )
+            set_cmdstan_path(install_version)
+            self.assertEqual(install_version, cmdstan_path())
+            self.assertEqual(install_version, os.environ['CMDSTAN'])
 
     def test_validate_path(self):
         install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -48,10 +48,11 @@ class CmdStanPathTest(unittest.TestCase):
                 self.assertEqual(cmdstan_path(), path)
                 self.assertTrue('CMDSTAN' in os.environ)
             else:
-                abs_rel_path = os.path.expanduser(
-                    os.path.join('~', '.cmdstanpy', 'cmdstan')
+                install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
+                install_version = os.path.expanduser(
+                    os.path.join(install_dir, get_latest_cmdstan(install_dir))
                     )
-                self.assertTrue(cmdstan_path().startswith(abs_rel_path))
+                self.assertTrue(os.path.samefile(cmdstan_path(), install_version))
                 self.assertTrue('CMDSTAN' in os.environ)
         finally:
             if cur_value is not None:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -35,7 +35,9 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 class CmdStanPathTest(unittest.TestCase):
 
     def test_default_path(self):
-        cur_value = os.environ['CMDSTAN']
+        cur_value = None
+        if 'CMDSTAN' in os.environ:
+            cur_value = os.environ['CMDSTAN']
         try:
             if 'CMDSTAN' in os.environ:
                 self.assertEqual(cmdstan_path(), os.environ['CMDSTAN'])
@@ -52,7 +54,12 @@ class CmdStanPathTest(unittest.TestCase):
                 self.assertTrue(cmdstan_path().startswith(abs_rel_path))
                 self.assertTrue('CMDSTAN' in os.environ)
         finally:
-            os.environ['CMDSTAN'] = cur_value
+            if cur_value is not None:
+                os.environ['CMDSTAN'] = cur_value
+            else:
+                if 'CMDSTAN' in os.environ:
+                    del os.environ['CMDSTAN']
+
 
     def test_non_spaces_location(self):
         good_path = os.path.join(TMPDIR, 'good_dir')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -37,11 +37,18 @@ class CmdStanPathTest(unittest.TestCase):
     def test_default_path(self):
         if 'CMDSTAN' in os.environ:
             self.assertEqual(cmdstan_path(), os.environ['CMDSTAN'])
+            path = os.environ['CMDSTAN']
+            del os.environ['CMDSTAN']
+            self.assertFalse('CMDSTAN' in os.environ)
+            set_cmdstan_path(path)
+            self.assertEqual(cmdstan_path(), path)
+            self.assertTrue('CMDSTAN' in os.environ)
         else:
             abs_rel_path = os.path.expanduser(
                 os.path.join('~', '.cmdstanpy', 'cmdstan')
                 )
             self.assertTrue(cmdstan_path().startswith(abs_rel_path))
+            self.assertTrue('CMDSTAN' in os.environ)
 
     def test_non_spaces_location(self):
         good_path = os.path.join(TMPDIR, 'good_dir')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -35,20 +35,24 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 class CmdStanPathTest(unittest.TestCase):
 
     def test_default_path(self):
-        if 'CMDSTAN' in os.environ:
-            self.assertEqual(cmdstan_path(), os.environ['CMDSTAN'])
-            path = os.environ['CMDSTAN']
-            del os.environ['CMDSTAN']
-            self.assertFalse('CMDSTAN' in os.environ)
-            set_cmdstan_path(path)
-            self.assertEqual(cmdstan_path(), path)
-            self.assertTrue('CMDSTAN' in os.environ)
-        else:
-            abs_rel_path = os.path.expanduser(
-                os.path.join('~', '.cmdstanpy', 'cmdstan')
-                )
-            self.assertTrue(cmdstan_path().startswith(abs_rel_path))
-            self.assertTrue('CMDSTAN' in os.environ)
+        cur_value = os.environ['CMDSTAN']
+        try:
+            if 'CMDSTAN' in os.environ:
+                self.assertEqual(cmdstan_path(), os.environ['CMDSTAN'])
+                path = os.environ['CMDSTAN']
+                del os.environ['CMDSTAN']
+                self.assertFalse('CMDSTAN' in os.environ)
+                set_cmdstan_path(path)
+                self.assertEqual(cmdstan_path(), path)
+                self.assertTrue('CMDSTAN' in os.environ)
+            else:
+                abs_rel_path = os.path.expanduser(
+                    os.path.join('~', '.cmdstanpy', 'cmdstan')
+                    )
+                self.assertTrue(cmdstan_path().startswith(abs_rel_path))
+                self.assertTrue('CMDSTAN' in os.environ)
+        finally:
+            os.environ['CMDSTAN'] = cur_value
 
     def test_non_spaces_location(self):
         good_path = os.path.join(TMPDIR, 'good_dir')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -33,7 +33,6 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 
 
 class CmdStanPathTest(unittest.TestCase):
-
     def test_default_path(self):
         cur_value = None
         if 'CMDSTAN' in os.environ:
@@ -48,11 +47,15 @@ class CmdStanPathTest(unittest.TestCase):
                 self.assertEqual(cmdstan_path(), path)
                 self.assertTrue('CMDSTAN' in os.environ)
             else:
-                install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
+                install_dir = os.path.expanduser(
+                    os.path.join('~', '.cmdstanpy')
+                )
                 install_version = os.path.expanduser(
                     os.path.join(install_dir, get_latest_cmdstan(install_dir))
-                    )
-                self.assertTrue(os.path.samefile(cmdstan_path(), install_version))
+                )
+                self.assertTrue(
+                    os.path.samefile(cmdstan_path(), install_version)
+                )
                 self.assertTrue('CMDSTAN' in os.environ)
         finally:
             if cur_value is not None:
@@ -98,7 +101,7 @@ class CmdStanPathTest(unittest.TestCase):
             install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
             install_version = os.path.expanduser(
                 os.path.join(install_dir, get_latest_cmdstan(install_dir))
-                )
+            )
             set_cmdstan_path(install_version)
             self.assertEqual(install_version, cmdstan_path())
             self.assertEqual(install_version, os.environ['CMDSTAN'])


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

added test logic to `test_utils.py` tests for location of cmdstan.
- `test_default_path` checks `CMDSTAN` env var is set
- `test_set_path` also checks that `CMDSTAN` env var is set after calling this function.

also changed logic to `utils.py` function `cmdstan_path` so that `CMDSTAN` env var will be set to default path. this is consistent with behavior in `set_cmdstan_path` which also sets the env var after validating the path.

Fixes #188.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

