### PR TITLE
Feature/202 stanc compiler flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 
 CmdStanPy is a lightweight interface to Stan for Python users which
-provides the necessary objects and functions to compile a Stan program
-and run Stan's samplers.
+provides the necessary objects and functions to do Bayesian inference
+given a probability model written as a Stan program and data.
+Under the hood, CmdStanPy uses the CmdStan command line interface
+to compile and run a Stan program.
 
 ### Goals
 

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -582,7 +582,7 @@ class CmdStanArgs:
         elif self.data is None:
             if isinstance(self.method_args, OptimizeArgs):
                 raise ValueError('data must be set when optimizing')
-        elif not isinstance(self.data, dict):
+        elif not isinstance(self.data, (str, dict)):
             raise ValueError('data must be string or dict')
 
         if self.inits is not None:

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -97,7 +97,7 @@ class CompilerOptions:
         Check stanc compiler args and consistency between stanc and c++ options.
         Raise ValueError if bad config is found.
         """
-        #pylint: disable=no-member
+        # pylint: disable=no-member
         if self._stanc_options is None:
             return
         ignore = []

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -2,8 +2,14 @@
 Makefile options for stanc and C++ compilers
 """
 import os
+import logging
+
 from pathlib import Path
 from typing import Dict, List
+
+from cmdstanpy.utils import (
+    get_logger,
+)
 
 STANC_OPTS = [
     'O',

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -1,6 +1,7 @@
 """
 Makefile options for stanc and C++ compilers
 """
+
 import os
 import logging
 

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -97,6 +97,7 @@ class CompilerOptions:
         Check stanc compiler args and consistency between stanc and c++ options.
         Raise ValueError if bad config is found.
         """
+        #pylint: disable=no-member
         if self._stanc_options is None:
             return
         ignore = []

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -54,11 +54,15 @@ class CompilerOptions:
     """
 
     def __init__(
-        self, stanc_options: Dict = None, cpp_options: Dict = None
+        self,
+        stanc_options: Dict = None,
+        cpp_options: Dict = None,
+        logger: logging.Logger = None,
     ) -> None:
         """Initialize object."""
         self._stanc_options = stanc_options
         self._cpp_options = cpp_options
+        self._logger = logger or get_logger()
 
     def __repr__(self) -> str:
         return 'CompilerOptions(stanc_options={}, cpp_options={})'.format(

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -1,0 +1,169 @@
+"""
+Makefile options for stanc and C++ compilers
+"""
+import os
+from pathlib import Path
+from typing import Dict, List
+
+STANC_OPTS = [
+    'O',
+    'allow_undefined',
+    'use-opencl',
+    'warn-uninitialized',
+    'include_paths',
+    'name',
+]
+
+STANC_IGNORE_OPTS = [
+    'debug-lex',
+    'debug-parse',
+    'debug-ast',
+    'debug-decorated-ast',
+    'debug-generate-data',
+    'debug-mir',
+    'debug-mir-pretty',
+    'debug-optimized-mir',
+    'debug-optimized-mir-pretty',
+    'debug-transformed-mir',
+    'debug-transformed-mir-pretty',
+    'dump-stan-math-signatures',
+    'auto-format',
+    'print-canonical',
+    'print-cpp',
+    'o',
+    'help',
+    'version',
+]
+
+CPP_OPTS = [
+    'STAN_OPENCL',
+    'OPENCL_DEVICE_ID',
+    'OPENCL_PLATFORM_ID',
+    'STAN_MPI',
+    'STAN_THREADS',
+]
+
+
+class CompilerOptions:
+    """
+    User-specified flags for stanc and c++ compiler.
+
+    Attributes:
+        stanc_options - stanc compiler flags, options
+        cpp_options - makefile options (NAME=value)
+    """
+
+    def __init__(
+        self, stanc_options: Dict = None, cpp_options: Dict = None
+    ) -> None:
+        """Initialize object."""
+        self._stanc_options = stanc_options
+        self._cpp_options = cpp_options
+
+    def __repr__(self) -> str:
+        return 'CompilerOptions(stanc_options={}, cpp_options={})'.format(
+            self._stanc_options, self._cpp_options
+        )
+
+    @property
+    def stanc_options(self) -> Dict:
+        """Stanc compiler options."""
+        return self._stanc_options
+
+    @property
+    def cpp_options(self) -> Dict:
+        """C++ compiler options."""
+        return self._cpp_options
+
+    def validate(self) -> None:
+        """
+        Check compiler args.
+        Raise ValueError if invalid options are found.
+        """
+        if self._stanc_options is not None and len(self._stanc_options) > 0:
+            self.validate_stanc_opts()
+        if self._cpp_options is not None and len(self._cpp_options) > 0:
+            self.validate_cpp_opts()
+
+    def validate_stanc_opts(self) -> None:
+        """
+        Check stanc compiler args.
+        Raise ValueError if bad config is found.
+        """
+        ignore = []
+        paths = None
+        for key, val in self._stanc_options.items():
+            if key in STANC_IGNORE_OPTS:
+                self._logger.info('ignoring compiler option: %s', key)
+                ignore.append(key)
+            elif key not in STANC_OPTS:
+                raise ValueError(
+                    'unknown stanc compiler option: {}'.format(key)
+                )
+            elif key == 'include_paths':
+                paths = val
+                if isinstance(val, str):
+                    paths = val.split(',')
+                elif not isinstance(val, List):
+                    raise ValueError(
+                        'invalid include_paths, expecting list or '
+                        'string, found type: {}'.format(type(val))
+                    )
+        for opt in ignore:
+            del self._stanc_options[opt]
+        if paths is not None:
+            self._stanc_options['include_paths'] = paths
+            bad_paths = [
+                dir
+                for dir in self._stanc_options['include_paths']
+                if not os.path.exists(dir)
+            ]
+            if any(bad_paths):
+                raise ValueError(
+                    'invalid include paths: {}'.format(', '.join(bad_paths))
+                )
+
+    def validate_cpp_opts(self) -> None:
+        for key, val in self._cpp_options.items():
+            if key not in CPP_OPTS:
+                raise ValueError(
+                    'unknown CmdStan makefile option: {}'.format(key)
+                )
+            if key in ['OPENCL_DEVICE_ID', 'OPENCL_PLATFORM_ID']:
+                if not isinstance(val, int) or val < 0:
+                    raise ValueError(
+                        '{} must be a non-negative integer value,'
+                        ' found {}'.format(key, val)
+                    )
+
+    def add_includes(self, paths: List[str]) -> None:
+        stanc_opts = {'include_paths': paths}
+        if self._stanc_options is None:
+            self._stanc_options = stanc_opts
+        elif 'include_paths' not in self._stanc_options:
+            self._stanc_options['include_paths'] = paths
+        else:
+            self._stanc_options['include_paths'].append(paths)
+
+    def compose(self) -> List[str]:
+        opts = []
+        if self._stanc_options is not None and len(self._stanc_options) > 0:
+            for key, val in self._stanc_options.items():
+                if key == 'include_paths':
+                    opts.append(
+                        'STANCFLAGS+=--include_paths='
+                        + ','.join(
+                            (
+                                Path(p).as_posix()
+                                for p in self._stanc_options['include_paths']
+                            )
+                            )
+                        )
+                elif key == 'name':
+                    opts.append('STANCFLAGS+=--{}={}'.format(key, val))
+                else:
+                    opts.append('STANCFLAGS+=--{}'.format(key))
+        if self._cpp_options is not None and len(self._cpp_options) > 0:
+            for key, val in self._cpp_options.items():
+                opts.append('{}={}'.format(key, val))
+        return opts

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -94,7 +94,7 @@ class CompilerOptions:
 
     def validate_stanc_opts(self) -> None:
         """
-        Check stanc compiler args.
+        Check stanc compiler args and consistency between stanc and c++ options.
         Raise ValueError if bad config is found.
         """
         if self._stanc_options is None:
@@ -115,15 +115,14 @@ class CompilerOptions:
                     paths = val.split(',')
                 elif not isinstance(val, List):
                     raise ValueError(
-                        'invalid include_paths, expecting list or '
-                        'string, found type: {}'.format(type(val))
+                        'Invalid include_paths, expecting list or '
+                        'string, found type: {}.'.format(type(val))
                     )
             elif key == 'use-opencl':
                 if self._cpp_options is None:
                     self._cpp_options = {'STAN_OPENCL': 'TRUE'}
                 else:
                     self._cpp_options['STAN_OPENCL'] = 'TRUE'
-                ignore.append(key)
 
         for opt in ignore:
             del self._stanc_options[opt]
@@ -140,6 +139,10 @@ class CompilerOptions:
                 )
 
     def validate_cpp_opts(self) -> None:
+        """
+        Check cpp compiler args.
+        Raise ValueError if bad config is found.
+        """
         if self._cpp_options is None:
             return
         if (
@@ -157,11 +160,11 @@ class CompilerOptions:
                 if not isinstance(val, int) or val < 0:
                     raise ValueError(
                         '{} must be a non-negative integer value,'
-                        ' found {}'.format(key, val)
+                        ' found {}.'.format(key, val)
                     )
 
     def add(self, new_opts: "CompilerOptions") -> None:  # noqa: disable=Q000
-        """Add to existing stanc compiler options"""
+        """Adds options to existing set of compiler options."""
         if new_opts.stanc_options is not None:
             if self._stanc_options is None:
                 self._stanc_options = new_opts.stanc_options
@@ -176,12 +179,14 @@ class CompilerOptions:
                 self._cpp_options[key] = val
 
     def add_include_path(self, path: str) -> None:
+        """Adds include path to existing set of compiler options."""
         if 'include_paths' not in self._stanc_options:
             self._stanc_options['include_paths'] = [path]
         elif path not in self._stanc_options['include_paths']:
             self._stanc_options['include_paths'].append(path)
 
     def compose(self) -> List[str]:
+        """Format makefile options as list of strings."""
         opts = []
         if self._stanc_options is not None and len(self._stanc_options) > 0:
             for key, val in self._stanc_options.items():

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -276,7 +276,6 @@ class CmdStanModel:
                 if self._compiler_options is not None:
                     cmd.extend(self._compiler_options.compose())
                 cmd.append(Path(exe_file).as_posix())
-                print(cmd)
                 try:
                     do_command(cmd, cmdstan_path(), logger=self._logger)
                 except RuntimeError as e:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -35,6 +35,9 @@ from cmdstanpy.utils import (
     MaybeDictToFilePath,
     TemporaryCopiedFile,
     get_logger,
+    parse_include_paths,
+    parse_stanc_flags,
+    parse_stanc_flags_str,
 )
 
 
@@ -413,7 +416,7 @@ class CmdStanModel:
         fixed_param: bool = False,
         output_dir: str = None,
         save_diagnostics: bool = False,
-        show_progress: Union[bool, str] = False
+        show_progress: Union[bool, str] = False,
     ) -> CmdStanMCMC:
         """
         Run or more chains of the NUTS sampler to produce a set of draws
@@ -678,11 +681,11 @@ class CmdStanModel:
                             dynamic_ncols = True
 
                         pbar = tqdm_pbar(
-                                desc='Chain {} - warmup'.format(i + 1),
-                                position=i,
-                                total=1,  # Will set total from Stan's output
-                                dynamic_ncols=dynamic_ncols,
-                            )
+                            desc='Chain {} - warmup'.format(i + 1),
+                            position=i,
+                            total=1,  # Will set total from Stan's output
+                            dynamic_ncols=dynamic_ncols,
+                        )
 
                         all_pbars.append(pbar)
 
@@ -1027,8 +1030,10 @@ class CmdStanModel:
                         if pbar.total != total_count:
                             pbar.reset(total=total_count)
 
-                        if (match.group(3).lower() == 'sampling' and
-                           not changed_description):
+                        if (
+                            match.group(3).lower() == 'sampling'
+                            and not changed_description
+                        ):
                             pbar.set_description(f'Chain {idx + 1} - sample')
                             changed_description = True
 

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -235,9 +235,8 @@ class CmdStanModel:
                     else 'mingw32-make',
                 )
                 cmd = [make]
-                cmd.append(self._compiler_opts.compose())
+                cmd.append(self._compiler_options.compose())
                 cmd.append(Path(exe_file).as_posix())
-                cmd = self.compose_compile_cmd(exe_file)
                 print(cmd)
                 try:
                     do_command(cmd, cmdstan_path(), logger=self._logger)

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -258,12 +258,11 @@ class CmdStanModel:
                     self._logger.info('found newer exe file, not recompiling')
 
             if do_compile:
-                if self._compiler_options is not None:
-                    self._compiler_options.validate()
                 self._logger.info(
                     'compiling stan program, exe file: %s', exe_file
                 )
                 if self._compiler_options is not None:
+                    self._compiler_options.validate()
                     self._logger.info(
                         'compiler options: %s', self._compiler_options
                     )
@@ -277,6 +276,7 @@ class CmdStanModel:
                 if self._compiler_options is not None:
                     cmd.extend(self._compiler_options.compose())
                 cmd.append(Path(exe_file).as_posix())
+                print(cmd)
                 try:
                     do_command(cmd, cmdstan_path(), logger=self._logger)
                 except RuntimeError as e:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -35,9 +35,6 @@ from cmdstanpy.utils import (
     MaybeDictToFilePath,
     TemporaryCopiedFile,
     get_logger,
-    parse_include_paths,
-    parse_stanc_flags,
-    parse_stanc_flags_str,
 )
 
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -28,44 +28,6 @@ from cmdstanpy import TMPDIR
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
-STANC_OPTS = [
-    'debug-lex',
-    'debug-parse',
-    'debug-ast',
-    'debug-decorated-ast',
-    'debug-generate-data',
-    'debug-mir',
-    'debug-mir-pretty',
-    'debug-optimized-mir',
-    'debug-optimized-mir-pretty',
-    'debug-transformed-mir',
-    'debug-transformed-mir-pretty',
-    'dump-stan-math-signatures',
-    'warn-uninitialized',
-    'auto-format',
-    'print-canonical',
-    'O',
-    'print-cpp',
-    'allow_undefined',
-    'use-opencl',
-]
-
-STANC_OPTS_ARG = ['name', 'o', 'include_paths']
-
-STANC_HELP_OPTS = ['help', 'version']
-
-
-def parse_stanc_flags_str():
-    pass
-
-
-def parse_stanc_flags():
-    pass
-
-
-def parse_include_paths():
-    pass
-
 
 def get_logger():
     """cmdstanpy logger"""

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -28,6 +28,44 @@ from cmdstanpy import TMPDIR
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
+STANC_OPTS = [
+    'debug-lex',
+    'debug-parse',
+    'debug-ast',
+    'debug-decorated-ast',
+    'debug-generate-data',
+    'debug-mir',
+    'debug-mir-pretty',
+    'debug-optimized-mir',
+    'debug-optimized-mir-pretty',
+    'debug-transformed-mir',
+    'debug-transformed-mir-pretty',
+    'dump-stan-math-signatures',
+    'warn-uninitialized',
+    'auto-format',
+    'print-canonical',
+    'O',
+    'print-cpp',
+    'allow_undefined',
+    'use-opencl',
+]
+
+STANC_OPTS_ARG = ['name', 'o', 'include_paths']
+
+STANC_HELP_OPTS = ['help', 'version']
+
+
+def parse_stanc_flags_str():
+    pass
+
+
+def parse_stanc_flags():
+    pass
+
+
+def parse_include_paths():
+    pass
+
 
 def get_logger():
     """cmdstanpy logger"""
@@ -47,7 +85,8 @@ def get_latest_cmdstan(dot_dir: str) -> str:
         name.split('-')[1]
         for name in os.listdir(dot_dir)
         if os.path.isdir(os.path.join(dot_dir, name))
-        and name.startswith('cmdstan-') and name[8].isdigit()
+        and name.startswith('cmdstan-')
+        and name[8].isdigit()
     ]
     versions.sort(key=lambda s: list(map(int, s.split('.'))))
     if len(versions) == 0:
@@ -56,8 +95,9 @@ def get_latest_cmdstan(dot_dir: str) -> str:
     return latest
 
 
-class MaybeDictToFilePath():
+class MaybeDictToFilePath:
     """Context manager for json files."""
+
     def __init__(self, *objs: Union[str, dict], logger: logging.Logger = None):
         self._unlink = [False] * len(objs)
         self._paths = [''] * len(objs)
@@ -117,8 +157,9 @@ def validate_cmdstan_path(path: str) -> None:
         )
 
 
-class TemporaryCopiedFile():
+class TemporaryCopiedFile:
     """Context manager for tmpfiles, handles spaces in filepath."""
+
     def __init__(self, file_path: str):
         self._path = None
         self._tmpdir = None
@@ -230,7 +271,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
                 compiler_path = ''
                 logger.warning(
                     'Found invalid installion for RTools35 on %s',
-                    toolchain_root
+                    toolchain_root,
                 )
                 toolchain_root = ''
         elif os.path.exists(os.path.join(toolchain_root, 'mingw64')):
@@ -253,7 +294,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
                 compiler_path = ''
                 logger.warning(
                     'Found invalid installion for RTools40 on %s',
-                    toolchain_root
+                    toolchain_root,
                 )
                 toolchain_root = ''
     else:
@@ -290,7 +331,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
                 compiler_path = ''
                 logger.warning(
                     'Found invalid installion for RTools35 on %s',
-                    toolchain_root
+                    toolchain_root,
                 )
                 toolchain_root = ''
         if (
@@ -316,7 +357,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
                 compiler_path = ''
                 logger.warning(
                     'Found invalid installion for RTools40 on %s',
-                    toolchain_root
+                    toolchain_root,
                 )
                 toolchain_root = ''
     if not toolchain_root:
@@ -328,7 +369,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
     os.environ['PATH'] = ';'.join(
         list(
             OrderedDict.fromkeys(
-                [compiler_path, tool_path, ] + os.getenv('PATH', '').split(';')
+                [compiler_path, tool_path] + os.getenv('PATH', '').split(';')
             )
         )
     )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@
    generate_quantities
    optimize
    variational_bayes
+   under_the_hood
    api
 
 

--- a/docs/under_the_hood.rst
+++ b/docs/under_the_hood.rst
@@ -1,12 +1,10 @@
-Wrapping CmdStan
-________________
+Under the Hood
+______________
 
 Under the hood, CmdStanPy uses the CmdStan command line interface
-to compile and run a Stan program.
-The CmdStan interface is file-based.
-
-* Stan programs are compiled to c++ executables
-* The c++ executable operates on input files and produces output files.
+to compile and fit a model to data.
+The function `cmdstan_path` returns the path to the local CmdStan installation.
+See the installation section for more details on installing CmdStan.
   
 
 Model Compilation
@@ -34,10 +32,12 @@ allow optional arguments ``stanc_options`` and ``cpp_options`` which
 specify options for each compilation step.
 
 
-
 File Handling
 -------------
 
+CmdStan is file-based interface, therefore CmdStanPy
+maintains the necessary files for all models, data, and
+inference method results.
 CmdStanPy uses the Python library ``tempfile`` module to create
 a temporary directory where all input and output files are written and
 which is deleted when the Python session is terminated.

--- a/docs/under_the_hood.rst
+++ b/docs/under_the_hood.rst
@@ -1,0 +1,69 @@
+Wrapping CmdStan
+________________
+
+Under the hood, CmdStanPy uses the CmdStan command line interface
+to compile and run a Stan program.
+The CmdStan interface is file-based.
+
+* Stan programs are compiled to c++ executables
+* The c++ executable operates on input files and produces output files.
+  
+
+Model Compilation
+-----------------
+
+:ref:`class_cmdstanmodel` objects manage the Stan program and its corresponding
+executable.
+By default, a program is compiled on object instantiation.
+
+Model compilation is carried out via the GNU Make build tool.
+The CmdStan ``makefile`` contains a set of general rules which
+specify the dependencies between the Stan program and the
+Stan platform components and low-level libraries.
+Optional behaviors can be specified by use of variables
+which are passed in to the ``make`` command as name, value pairs.
+
+Model compilation is done in two steps:
+
+* The ``stanc`` compiler translates the Stan program to c++.
+* The c++ compiler compiles the generated code and links in
+  the necessary supporting libraries.
+
+Therefore, both the ``CmdStanModel`` constructor and ``compile`` method
+allow optional arguments ``stanc_options`` and ``cpp_options`` which
+specify options for each compilation step.
+
+
+
+File Handling
+-------------
+
+CmdStanPy uses the Python library ``tempfile`` module to create
+a temporary directory where all input and output files are written and
+which is deleted when the Python session is terminated.
+
+
+Input Data
+^^^^^^^^^^
+
+When the input data for the ``CmdStanModel`` inference methods
+is supplied as a Python dictionary, this data is written to disk as
+the corresponding JSON object.
+
+Output Files
+^^^^^^^^^^^^
+
+Output filenames are composed of the model name, a timestamp
+in the form YYYYMMDDhhmm and the chain id, plus the corresponding
+filetype suffix, either '.csv' for the CmdStan output or '.txt' for
+the console messages, e.g. ``bernoulli-201912081451-1.csv``. Output files
+written to the temporary directory contain an additional 8-character
+random string, e.g. ``bernoulli-201912081451-1-5nm6as7u.csv``.
+
+
+When the ``output_dir`` argument to the ``CmdStanModel`` inference methods
+is given, output files are written to the specified directory, otherwise
+they are written to the session-specific output directory.
+All fitted model objects, i.e. ``CmdStanMCMC``, ``CmdStanVB``, ``CmdStanMLE``,
+and ``CmdStanGQ``, have method ``save_csvfiles`` which moves the output files
+to a specified directory.

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -13,7 +13,7 @@ class CompilerOptsTest(unittest.TestCase):
     def test_opts_empty(self):
         opts = CompilerOptions()
         opts.validate()
-        self.assertTrue(len(opts.compose()) == 0)
+        self.assertEqual(opts.compose(), [])
         self.assertEqual(
             opts.__repr__(),
             'CompilerOptions(stanc_options=None, cpp_options=None)',
@@ -22,35 +22,171 @@ class CompilerOptsTest(unittest.TestCase):
         stanc_opts = {}
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
-        self.assertTrue(len(opts.compose()) == 0)
+        self.assertEqual(opts.compose(), [])
 
         cpp_opts = {}
         opts = CompilerOptions(cpp_options=cpp_opts)
         opts.validate()
-        self.assertTrue(len(opts.compose()) == 0)
+        self.assertEqual(opts.compose(), [])
 
         opts = CompilerOptions(stanc_options=stanc_opts, cpp_options=cpp_opts)
         opts.validate()
-        self.assertTrue(len(opts.compose()) == 0)
+        self.assertEqual(opts.compose(), [])
         self.assertEqual(
             opts.__repr__(), 'CompilerOptions(stanc_options={}, cpp_options={})'
         )
 
     def test_opts_stanc(self):
-        stanc_opts = {'warn-uninitialized': True}
+        stanc_opts = {}
+        opts = CompilerOptions()
+        opts.validate()
+        self.assertEqual(opts.compose(), [])
+
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
-        self.assertTrue(len(opts.compose()) == 1)
+        self.assertEqual(opts.compose(), [])
+
+        stanc_opts['warn-uninitialized'] = True
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
         self.assertEqual(opts.compose(), ['STANCFLAGS+=--warn-uninitialized'])
 
         stanc_opts['name'] = 'foo'
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
-        self.assertTrue(len(opts.compose()) == 2)
         self.assertEqual(
             opts.compose(),
             ['STANCFLAGS+=--warn-uninitialized', 'STANCFLAGS+=--name=foo'],
         )
+
+    def test_opts_stanc_opencl(self):
+        stanc_opts = {}
+        stanc_opts['use-opencl'] = 'foo'
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        self.assertEqual(opts.compose(), ['STAN_OPENCL=TRUE'])
+
+    def test_opts_stanc_ignore(self):
+        stanc_opts = {}
+        stanc_opts['auto-format'] = True
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        self.assertEqual(opts.compose(), [])
+
+    def test_opts_stanc_includes(self):
+        path2 = os.path.join(HERE, 'data', 'optimize')
+        paths_str = ','.join([DATAFILES_PATH, path2])
+        expect = 'STANCFLAGS+=--include_paths=' + paths_str
+
+        stanc_opts = {'include_paths': paths_str}
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        opts_list = opts.compose()
+        self.assertTrue(expect in opts_list)
+
+        stanc_opts = {'include_paths': [DATAFILES_PATH, path2]}
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        opts_list = opts.compose()
+        self.assertTrue(expect in opts_list)
+
+    def test_opts_add_include_paths(self):
+        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH
+        stanc_opts = {'warn-uninitialized': True}
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        opts_list = opts.compose()
+        self.assertTrue(expect not in opts_list)
+
+        opts.add_include_path(DATAFILES_PATH)
+        opts.validate()
+        opts_list = opts.compose()
+        self.assertTrue(expect in opts_list)
+
+        path2 = os.path.join(HERE, 'data', 'optimize')
+        paths_str = ','.join([DATAFILES_PATH, path2])
+        expect = 'STANCFLAGS+=--include_paths=' + paths_str
+        opts.add_include_path(path2)
+        opts.validate()
+        opts_list = opts.compose()
+        self.assertTrue(expect in opts_list)
+
+    def test_opts_cpp(self):
+        cpp_opts = {}
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        opts.validate()
+        self.assertEqual(opts.compose(), [])
+
+        cpp_opts['STAN_MPI'] = 'TRUE'
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        opts.validate()
+        self.assertEqual(opts.compose(), ['STAN_MPI=TRUE'])
+
+        cpp_opts['STAN_BAD'] = 'TRUE'
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        with self.assertRaises(ValueError):
+            opts.validate()
+
+    def test_opts_cpp_opencl(self):
+        cpp_opts = {'OPENCL_DEVICE_ID': 1}
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        opts.validate()
+        opts_list = opts.compose()
+        self.assertTrue('STAN_OPENCL=TRUE' in opts_list)
+        self.assertTrue('OPENCL_DEVICE_ID=1' in opts_list)
+
+        cpp_opts = {'OPENCL_DEVICE_ID': 'BAD'}
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        with self.assertRaises(ValueError):
+            opts.validate()
+
+        cpp_opts = {'OPENCL_DEVICE_ID': -1}
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        with self.assertRaises(ValueError):
+            opts.validate()
+
+        cpp_opts = {'OPENCL_PLATFORM_ID': 'BAD'}
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        with self.assertRaises(ValueError):
+            opts.validate()
+
+        cpp_opts = {'OPENCL_PLATFORM_ID': -1}
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        with self.assertRaises(ValueError):
+            opts.validate()
+
+    def test_opts_add(self):
+        stanc_opts = {'warn-uninitialized': True}
+        cpp_opts = {'STAN_OPENCL': 'TRUE', 'OPENCL_DEVICE_ID': 1}
+        opts = CompilerOptions(stanc_options=stanc_opts, cpp_options=cpp_opts)
+        opts.validate()
+        opts_list = opts.compose()
+        self.assertTrue('STAN_OPENCL=TRUE' in opts_list)
+        self.assertTrue('OPENCL_DEVICE_ID=1' in opts_list)
+        new_opts = CompilerOptions(
+            cpp_options={'STAN_OPENCL': 'FALSE', 'OPENCL_DEVICE_ID': 2}
+        )
+        opts.add(new_opts)
+        opts_list = opts.compose()
+        self.assertTrue('STAN_OPENCL=FALSE' in opts_list)
+        self.assertTrue('OPENCL_DEVICE_ID=2' in opts_list)
+
+        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH
+        stanc_opts2 = {'include_paths': DATAFILES_PATH}
+        new_opts2 = CompilerOptions(stanc_options=stanc_opts2)
+        opts.add(new_opts2)
+        opts_list = opts.compose()
+        self.assertTrue(expect in opts_list)
+
+        path2 = os.path.join(HERE, 'data', 'optimize')
+        expect = 'STANCFLAGS+=--include_paths=' + ','.join(
+            [DATAFILES_PATH, path2]
+        )
+        stanc_opts3 = {'include_paths': path2}
+        new_opts3 = CompilerOptions(stanc_options=stanc_opts3)
+        opts.add(new_opts3)
+        opts_list = opts.compose()
+        self.assertTrue(expect in opts_list)
 
 
 if __name__ == '__main__':

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -1,0 +1,57 @@
+"""Compiler options tests"""
+
+import os
+import unittest
+
+from cmdstanpy.compiler_opts import CompilerOptions
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DATAFILES_PATH = os.path.join(HERE, 'data')
+
+
+class CompilerOptsTest(unittest.TestCase):
+    def test_opts_empty(self):
+        opts = CompilerOptions()
+        opts.validate()
+        self.assertTrue(len(opts.compose()) == 0)
+        self.assertEqual(
+            opts.__repr__(),
+            'CompilerOptions(stanc_options=None, cpp_options=None)',
+        )
+
+        stanc_opts = {}
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        self.assertTrue(len(opts.compose()) == 0)
+
+        cpp_opts = {}
+        opts = CompilerOptions(cpp_options=cpp_opts)
+        opts.validate()
+        self.assertTrue(len(opts.compose()) == 0)
+
+        opts = CompilerOptions(stanc_options=stanc_opts, cpp_options=cpp_opts)
+        opts.validate()
+        self.assertTrue(len(opts.compose()) == 0)
+        self.assertEqual(
+            opts.__repr__(), 'CompilerOptions(stanc_options={}, cpp_options={})'
+        )
+
+    def test_opts_stanc(self):
+        stanc_opts = {'warn-uninitialized': True}
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        self.assertTrue(len(opts.compose()) == 1)
+        self.assertEqual(opts.compose(), ['STANCFLAGS+=--warn-uninitialized'])
+
+        stanc_opts['name'] = 'foo'
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        self.assertTrue(len(opts.compose()) == 2)
+        self.assertEqual(
+            opts.compose(),
+            ['STANCFLAGS+=--warn-uninitialized', 'STANCFLAGS+=--name=foo'],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -64,7 +64,10 @@ class CompilerOptsTest(unittest.TestCase):
         stanc_opts['use-opencl'] = 'foo'
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
-        self.assertEqual(opts.compose(), ['STAN_OPENCL=TRUE'])
+        self.assertEqual(
+            opts.compose(),
+            ['STANCFLAGS+=--use-opencl', 'STAN_OPENCL=TRUE']
+        )
 
     def test_opts_stanc_ignore(self):
         stanc_opts = {}

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -184,10 +184,10 @@ class CompilerOptsTest(unittest.TestCase):
         opts_list = opts.compose()
         self.assertTrue(expect in opts_list)
 
-        path2 = os.path.join(HERE, 'data', 'optimize').replace('\\', '/')
+        path2 = os.path.join(HERE, 'data', 'optimize')
         expect = 'STANCFLAGS+=--include_paths=' + ','.join(
             [DATAFILES_PATH, path2]
-        )
+        ).replace('\\', '/')
         stanc_opts3 = {'include_paths': path2}
         new_opts3 = CompilerOptions(stanc_options=stanc_opts3)
         opts.add(new_opts3)

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -65,8 +65,7 @@ class CompilerOptsTest(unittest.TestCase):
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
         self.assertEqual(
-            opts.compose(),
-            ['STANCFLAGS+=--use-opencl', 'STAN_OPENCL=TRUE']
+            opts.compose(), ['STANCFLAGS+=--use-opencl', 'STAN_OPENCL=TRUE']
         )
 
     def test_opts_stanc_ignore(self):
@@ -94,7 +93,9 @@ class CompilerOptsTest(unittest.TestCase):
         self.assertTrue(expect in opts_list)
 
     def test_opts_add_include_paths(self):
-        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace('\\', '/')
+        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace(
+            '\\', '/'
+        )
         stanc_opts = {'warn-uninitialized': True}
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
@@ -174,7 +175,9 @@ class CompilerOptsTest(unittest.TestCase):
         self.assertTrue('STAN_OPENCL=FALSE' in opts_list)
         self.assertTrue('OPENCL_DEVICE_ID=2' in opts_list)
 
-        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace('\\', '/')
+        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace(
+            '\\', '/'
+        )
         stanc_opts2 = {'include_paths': DATAFILES_PATH}
         new_opts2 = CompilerOptions(stanc_options=stanc_opts2)
         opts.add(new_opts2)

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -78,7 +78,7 @@ class CompilerOptsTest(unittest.TestCase):
 
     def test_opts_stanc_includes(self):
         path2 = os.path.join(HERE, 'data', 'optimize')
-        paths_str = ','.join([DATAFILES_PATH, path2])
+        paths_str = ','.join([DATAFILES_PATH, path2]).replace('\\', '/')
         expect = 'STANCFLAGS+=--include_paths=' + paths_str
 
         stanc_opts = {'include_paths': paths_str}
@@ -94,7 +94,7 @@ class CompilerOptsTest(unittest.TestCase):
         self.assertTrue(expect in opts_list)
 
     def test_opts_add_include_paths(self):
-        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH
+        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace('\\', '/')
         stanc_opts = {'warn-uninitialized': True}
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
@@ -107,7 +107,7 @@ class CompilerOptsTest(unittest.TestCase):
         self.assertTrue(expect in opts_list)
 
         path2 = os.path.join(HERE, 'data', 'optimize')
-        paths_str = ','.join([DATAFILES_PATH, path2])
+        paths_str = ','.join([DATAFILES_PATH, path2]).replace('\\', '/')
         expect = 'STANCFLAGS+=--include_paths=' + paths_str
         opts.add_include_path(path2)
         opts.validate()
@@ -174,14 +174,14 @@ class CompilerOptsTest(unittest.TestCase):
         self.assertTrue('STAN_OPENCL=FALSE' in opts_list)
         self.assertTrue('OPENCL_DEVICE_ID=2' in opts_list)
 
-        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH
+        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace('\\', '/')
         stanc_opts2 = {'include_paths': DATAFILES_PATH}
         new_opts2 = CompilerOptions(stanc_options=stanc_opts2)
         opts.add(new_opts2)
         opts_list = opts.compose()
         self.assertTrue(expect in opts_list)
 
-        path2 = os.path.join(HERE, 'data', 'optimize')
+        path2 = os.path.join(HERE, 'data', 'optimize').replace('\\', '/')
         expect = 'STANCFLAGS+=--include_paths=' + ','.join(
             [DATAFILES_PATH, path2]
         )

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -225,10 +225,7 @@ class CmdStanModelTest(unittest.TestCase):
             os.remove(BERN_EXE)
         model = CmdStanModel(
             stan_file=BERN_STAN,
-            stanc_options={
-                'include_paths': DATAFILES_PATH,
-                'use-opencl' : True
-            }
+            stanc_options={'include_paths': DATAFILES_PATH}
         )
         self.assertEqual(BERN_STAN, model.stan_file)
         self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -11,8 +11,6 @@ import tqdm
 
 from cmdstanpy.utils import EXTENSION
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.compiler_opts import CompilerOptions
-
 from cmdstanpy.utils import cmdstan_path
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -86,53 +84,50 @@ class CmdStanModelTest(unittest.TestCase):
             CmdStanModel(model_name='bad')
 
     def test_stanc_options(self):
-        opts = CompilerOptions(
-            stanc_options={
-                'O': True,
-                'allow_undefined': True,
-                'use-opencl': True,
-                'name': 'foo',
-            }
-        )
+        opts = {
+            'O': True,
+            'allow_undefined': True,
+            'use-opencl': True,
+            'name': 'foo',
+        }
         model = CmdStanModel(
-            stan_file=BERN_STAN, compile=False, compiler_options=opts
+            stan_file=BERN_STAN, compile=False, stanc_options=opts
         )
-        stanc_opts = model.compiler_options.stanc_options
+        stanc_opts = model.stanc_options
         self.assertTrue(stanc_opts['O'])
         self.assertTrue(stanc_opts['allow_undefined'])
+        self.assertTrue(stanc_opts['use-opencl'])
         self.assertTrue(stanc_opts['name'] == 'foo')
 
-        cpp_opts = model.compiler_options.cpp_options
+        cpp_opts = model.cpp_options
         self.assertEqual(cpp_opts['STAN_OPENCL'], 'TRUE')
 
         with self.assertRaises(ValueError):
-            bad_opts = CompilerOptions(stanc_options={'X': True})
+            bad_opts = {'X': True}
             model = CmdStanModel(
-                stan_file=BERN_STAN, compile=False, compiler_options=bad_opts
+                stan_file=BERN_STAN, compile=False, stanc_options=bad_opts
             )
         with self.assertRaises(ValueError):
-            bad_opts = CompilerOptions(stanc_options={'include_paths': True})
+            bad_opts = {'include_paths': True}
             model = CmdStanModel(
-                stan_file=BERN_STAN, compile=False, compiler_options=bad_opts
+                stan_file=BERN_STAN, compile=False, stanc_options=bad_opts
             )
         with self.assertRaises(ValueError):
-            bad_opts = CompilerOptions(stanc_options={'include_paths': 'lkjdf'})
+            bad_opts = {'include_paths': 'lkjdf'}
             model = CmdStanModel(
-                stan_file=BERN_STAN, compile=False, compiler_options=bad_opts
+                stan_file=BERN_STAN, compile=False, stanc_options=bad_opts
             )
 
     def test_cpp_options(self):
-        opts = CompilerOptions(
-            cpp_options={
-                'STAN_OPENCL': 'TRUE',
-                'STAN_MPI': 'TRUE',
-                'STAN_THREADS': 'TRUE',
-            }
-        )
+        opts = {
+            'STAN_OPENCL': 'TRUE',
+            'STAN_MPI': 'TRUE',
+            'STAN_THREADS': 'TRUE',
+        }
         model = CmdStanModel(
-            stan_file=BERN_STAN, compile=False, compiler_options=opts
+            stan_file=BERN_STAN, compile=False, cpp_options=opts
         )
-        cpp_opts = model.compiler_options.cpp_options
+        cpp_opts = model.cpp_options
         self.assertEqual(cpp_opts['STAN_OPENCL'], 'TRUE')
         self.assertEqual(cpp_opts['STAN_MPI'], 'TRUE')
         self.assertEqual(cpp_opts['STAN_THREADS'], 'TRUE')
@@ -228,11 +223,11 @@ class CmdStanModelTest(unittest.TestCase):
     def test_model_includes_explicit(self):
         if os.path.exists(BERN_EXE):
             os.remove(BERN_EXE)
-
-        stanc_opts = {'include_paths': os.path.join(HERE, 'data')}
-        cpp_opts = {'STAN_OPENCL': 'TRUE'}
-        opts = CompilerOptions(stanc_options=stanc_opts, cpp_options=cpp_opts)
-        model = CmdStanModel(stan_file=BERN_STAN, compiler_options=opts)
+        model = CmdStanModel(
+            stan_file=BERN_STAN,
+            stanc_options={'include_paths': os.path.join(HERE, 'data')},
+            cpp_options={'STAN_OPENCL': 'TRUE'},
+        )
         self.assertEqual(BERN_STAN, model.stan_file)
         self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -225,8 +225,7 @@ class CmdStanModelTest(unittest.TestCase):
             os.remove(BERN_EXE)
         model = CmdStanModel(
             stan_file=BERN_STAN,
-            stanc_options={'include_paths': os.path.join(HERE, 'data')},
-            cpp_options={'STAN_OPENCL': 'TRUE'},
+            stanc_options={'include_paths': DATAFILES_PATH}
         )
         self.assertEqual(BERN_STAN, model.stan_file)
         self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -188,7 +188,7 @@ class CmdStanModelTest(unittest.TestCase):
                 CmdStanModel(stan_file=stan)
 
             # Join all the log messages into one string
-            error_message = "@( * O * )@".join(np.array(log.actual())[:, -1])
+            error_message = '@( * O * )@'.join(np.array(log.actual())[:, -1])
 
             # Ensure the new line character in error message is not escaped
             # so the error message is readable

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -225,7 +225,10 @@ class CmdStanModelTest(unittest.TestCase):
             os.remove(BERN_EXE)
         model = CmdStanModel(
             stan_file=BERN_STAN,
-            stanc_options={'include_paths': DATAFILES_PATH}
+            stanc_options={
+                'include_paths': DATAFILES_PATH,
+                'use-opencl' : True
+            }
         )
         self.assertEqual(BERN_STAN, model.stan_file)
         self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -31,6 +31,10 @@ model {
 """
 
 
+BERN_STAN = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+BERN_EXE = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
+
+
 class CmdStanModelTest(unittest.TestCase):
 
     # pylint: disable=no-self-use
@@ -39,7 +43,7 @@ class CmdStanModelTest(unittest.TestCase):
         for root, _, files in os.walk(DATAFILES_PATH):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.hpp', '.exe', ''):
+                if ext.lower() in ('.o', '.d', '.hpp', '.exe', ''):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 
@@ -48,23 +52,21 @@ class CmdStanModelTest(unittest.TestCase):
         self.assertTrue(True)
 
     def test_model_good(self):
-        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
-        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
-
         # compile on instantiation
-        model = CmdStanModel(stan_file=stan)
-        self.assertEqual(stan, model.stan_file)
-        self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
+        model = CmdStanModel(model_name='bern', stan_file=BERN_STAN)
+        self.assertEqual(BERN_STAN, model.stan_file)
+        self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))
+        self.assertEqual('bern', model.name)
 
         # instantiate with existing exe
-        model = CmdStanModel(stan_file=stan, exe_file=exe)
-        self.assertEqual(stan, model.stan_file)
-        self.assertTrue(model.exe_file.endswith(exe))
+        model = CmdStanModel(stan_file=BERN_STAN, exe_file=BERN_EXE)
+        self.assertEqual(BERN_STAN, model.stan_file)
+        self.assertTrue(model.exe_file.endswith(BERN_EXE))
+        self.assertEqual('bernoulli', model.name)
 
         # instantiate with existing exe only - no model
-        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
-        model2 = CmdStanModel(exe_file=exe)
-        self.assertEqual(exe, model2.exe_file)
+        model2 = CmdStanModel(exe_file=BERN_EXE)
+        self.assertEqual(BERN_EXE, model2.exe_file)
         self.assertEqual('bernoulli', model2.name)
         with self.assertRaises(RuntimeError):
             model2.code()
@@ -72,24 +74,75 @@ class CmdStanModelTest(unittest.TestCase):
             model2.compile()
 
         # instantiate, don't compile
-        os.remove(exe)
-        model = CmdStanModel(stan_file=stan, compile=False)
-        self.assertEqual(stan, model.stan_file)
+        os.remove(BERN_EXE)
+        model = CmdStanModel(stan_file=BERN_STAN, compile=False)
+        self.assertEqual(BERN_STAN, model.stan_file)
         self.assertEqual(None, model.exe_file)
 
+    def test_model_bad(self):
+        with self.assertRaises(ValueError):
+            CmdStanModel(stan_file=None, exe_file=None)
+        with self.assertRaises(ValueError):
+            CmdStanModel(model_name='bad')
+
+    def test_stanc_options(self):
+        model = CmdStanModel(
+            stan_file=BERN_STAN,
+            compile=False,
+            stanc_options={
+                'O': True,
+                'allow_undefined': True,
+                'use-opencl': True,
+                'name': 'foo',
+            },
+        )
+        opts = model.stanc_options
+        self.assertTrue(opts['O'])
+        self.assertTrue(opts['allow_undefined'])
+        self.assertTrue(opts['use-opencl'])
+        self.assertTrue(opts['name'] == 'foo')
+
+        with self.assertRaises(ValueError):
+            model = CmdStanModel(
+                stan_file=BERN_STAN, compile=False, stanc_options={'X': True}
+            )
+        with self.assertRaises(ValueError):
+            model = CmdStanModel(
+                stan_file=BERN_STAN,
+                compile=False,
+                stanc_options={'include_paths': True},
+            )
+        with self.assertRaises(ValueError):
+            model = CmdStanModel(
+                stan_file=BERN_STAN,
+                compile=False,
+                stanc_options={'include_paths': 'no_such_dir'},
+            )
+
+    def test_cpp_options(self):
+        model = CmdStanModel(
+            stan_file=BERN_STAN,
+            compile=False,
+            cpp_options={
+                'STAN_OPENCL': 'TRUE',
+                'STAN_MPI': 'TRUE',
+                'STAN_THREADS': 'TRUE',
+            },
+        )
+        opts = model.cpp_options
+        self.assertTrue(opts['STAN_OPENCL'] == 'TRUE')
+
     def test_model_paths(self):
-        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
-        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         # pylint: disable=unused-variable
-        model = CmdStanModel(stan_file=stan)  # instantiates exe
-        self.assertTrue(os.path.exists(exe))
+        model = CmdStanModel(stan_file=BERN_STAN)  # instantiates exe
+        self.assertTrue(os.path.exists(BERN_EXE))
 
         dotdot_stan = os.path.realpath(os.path.join('..', 'bernoulli.stan'))
         dotdot_exe = os.path.realpath(
             os.path.join('..', 'bernoulli' + EXTENSION)
         )
-        shutil.copyfile(stan, dotdot_stan)
-        shutil.copyfile(exe, dotdot_exe)
+        shutil.copyfile(BERN_STAN, dotdot_stan)
+        shutil.copyfile(BERN_EXE, dotdot_exe)
         model1 = CmdStanModel(
             stan_file=os.path.join('..', 'bernoulli.stan'),
             exe_file=os.path.join('..', 'bernoulli' + EXTENSION),
@@ -105,8 +158,8 @@ class CmdStanModelTest(unittest.TestCase):
         tilde_exe = os.path.realpath(
             os.path.join(os.path.expanduser('~'), 'bernoulli' + EXTENSION)
         )
-        shutil.copyfile(stan, tilde_stan)
-        shutil.copyfile(exe, tilde_exe)
+        shutil.copyfile(BERN_STAN, tilde_stan)
+        shutil.copyfile(BERN_EXE, tilde_exe)
         model2 = CmdStanModel(
             stan_file=os.path.join('~', 'bernoulli.stan'),
             exe_file=os.path.join('~', 'bernoulli' + EXTENSION),
@@ -121,16 +174,15 @@ class CmdStanModelTest(unittest.TestCase):
             _ = CmdStanModel(exe_file=None, stan_file=None)
 
     def test_model_file_does_not_exist(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             CmdStanModel(stan_file='xdlfkjx', exe_file='sdfndjsds')
 
         stan = os.path.join(DATAFILES_PATH, 'b')
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             CmdStanModel(stan_file=stan)
 
     def test_model_syntax_error(self):
         stan = os.path.join(DATAFILES_PATH, 'bad_syntax.stan')
-
         with LogCapture() as log:
             with self.assertRaises(Exception):
                 CmdStanModel(stan_file=stan)
@@ -143,64 +195,53 @@ class CmdStanModelTest(unittest.TestCase):
             self.assertRegex(error_message, r'parsing error:(\r\n|\r|\n)')
 
     def test_repr(self):
-        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
-        model = CmdStanModel(stan_file=stan)
+        model = CmdStanModel(stan_file=BERN_STAN)
         model_repr = repr(model)
         self.assertIn('name=bernoulli', model_repr)
 
     def test_print(self):
-        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
-        model = CmdStanModel(stan_file=stan)
+        model = CmdStanModel(stan_file=BERN_STAN)
         self.assertEqual(CODE, model.code())
 
     def test_model_compile(self):
-        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
-        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
+        model = CmdStanModel(stan_file=BERN_STAN)
+        self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))
 
-        model = CmdStanModel(stan_file=stan)
-        self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
-
-        model = CmdStanModel(stan_file=stan)
-        self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
+        model = CmdStanModel(stan_file=BERN_STAN)
+        self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))
         old_exe_time = os.path.getmtime(model.exe_file)
-        os.remove(exe)
+        os.remove(BERN_EXE)
         model.compile()
         new_exe_time = os.path.getmtime(model.exe_file)
         self.assertTrue(new_exe_time > old_exe_time)
 
         # test compile with existing exe - timestamp on exe unchanged
         exe_time = os.path.getmtime(model.exe_file)
-        model2 = CmdStanModel(stan_file=stan)
+        model2 = CmdStanModel(stan_file=BERN_STAN)
         self.assertEqual(exe_time, os.path.getmtime(model2.exe_file))
 
-    def test_model_compile_includes(self):
+    def test_model_includes_explicit(self):
+        if os.path.exists(BERN_EXE):
+            os.remove(BERN_EXE)
+
+        datafiles_abspath = os.path.join(HERE, 'data')
+        model = CmdStanModel(
+            stan_file=BERN_STAN,
+            stanc_options={'include_paths': [datafiles_abspath]},
+        )
+        self.assertEqual(BERN_STAN, model.stan_file)
+        self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))
+
+    def test_model_includes_implicit(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli_include.stan')
         exe = os.path.join(DATAFILES_PATH, 'bernoulli_include' + EXTENSION)
         if os.path.exists(exe):
             os.remove(exe)
-
-        datafiles_abspath = os.path.join(HERE, 'data')
-        include_paths = [datafiles_abspath]
-
-        # test compile with explicit include paths
-        model = CmdStanModel(stan_file=stan, include_paths=include_paths)
-        self.assertEqual(stan, model.stan_file)
-        self.assertTrue(model.exe_file.endswith(exe.replace('\\', '/')))
-
-        # test compile - implicit include path is current dir
-        os.remove(os.path.join(DATAFILES_PATH, 'bernoulli_include' + '.hpp'))
-        os.remove(os.path.join(DATAFILES_PATH, 'bernoulli_include' + '.o'))
-        os.remove(exe)
         model2 = CmdStanModel(stan_file=stan)
-        self.assertEqual(model2.include_paths, include_paths)
-
-        # already compiled
-        model3 = CmdStanModel(stan_file=stan)
-        self.assertTrue(model3.exe_file.endswith(exe.replace('\\', '/')))
+        self.assertTrue(model2.exe_file.endswith(exe.replace('\\', '/')))
 
     def test_read_progress(self):
-        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
-        model = CmdStanModel(stan_file=stan, compile=False)
+        model = CmdStanModel(stan_file=BERN_STAN, compile=False)
 
         proc_mock = Mock()
         proc_mock.poll.side_effect = [None, None, 'finish']
@@ -209,7 +250,9 @@ class CmdStanModelTest(unittest.TestCase):
         pbar = tqdm.tqdm(desc='Chain 1 - warmup', position=1, total=1)
 
         proc_mock.stdout.readline.side_effect = [
-            stan_output1.encode('utf-8'), stan_output2.encode('utf-8')]
+            stan_output1.encode('utf-8'),
+            stan_output2.encode('utf-8'),
+        ]
 
         with LogCapture() as log:
             result = model._read_progress(proc=proc_mock, pbar=pbar, idx=0)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Change arguments to both `CmdStanModel` constructor and method `compile` allowing the user to specify options to the stanc and c++ compilers.

Introduced class `CompilerOptions` which contains information about current CmdStan makefile, Stanc3 compiler options, and makefile variables needed for compiling for GPUs, MPI, and TBB threads.  Added tests for this class, and modified existing tests for the CmdStanModel class in `test/test_model.py`.

The `CompilerOptions` object is used under the hood; in the CmdStanPy API, the user uses arguments  `stanc_options` and `cpp_options` which are Python dictionaries of name value pairs corresponding to allowed options.

As this is a power user feature, this is not particularly well-documented.  I have added a section to the docs called `Under the Hood` which needs more information, but I think is the right place to document advanced model compilation options.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

