### PR TITLE
Bugfix/228 create output dir

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -532,7 +532,7 @@ class CmdStanArgs:
                 try:
                     os.makedirs(self.output_dir)
                     self._logger.info(
-                        'created output directory: {}'.format(self.output_dir)
+                        'created output directory: %s', self.output_dir
                         )
                 except (RuntimeError, PermissionError):
                     raise ValueError(

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -113,8 +113,8 @@ class SamplerArgs:
             else:
                 if len(self.step_size) != chains:
                     raise ValueError(
-                        'number of step_sizes must match number of chains '
-                        ' found {} step_sizes for {} chains '.format(
+                        'number of step_sizes must match number of chains,'
+                        ' found {} step_sizes for {} chains'.format(
                             len(self.step_size), chains
                         )
                     )
@@ -137,8 +137,8 @@ class SamplerArgs:
             elif isinstance(self.metric, (list, tuple)):
                 if len(self.metric) != chains:
                     raise ValueError(
-                        'number of metric files must match number of chains '
-                        ' found {} metric files for {} chains '.format(
+                        'number of metric files must match number of chains,'
+                        ' found {} metric files for {} chains'.format(
                             len(self.metric), chains
                         )
                     )
@@ -519,13 +519,18 @@ class CmdStanArgs:
                     raise ValueError(
                         'invalid chain_id {}'.format(self.chain_ids[i])
                     )
-
         if self.output_dir is not None:
             self.output_dir = os.path.realpath(os.path.expanduser(
                 self.output_dir))
-            if not os.path.exists(os.path.dirname(self.output_dir)):
+            if not os.path.exists(self.output_dir):
                 raise ValueError(
                     'invalid path for output files, no such dir: {}'.format(
+                        self.output_dir
+                    )
+                )
+            if not os.path.isdir(self.output_dir):
+                raise ValueError(
+                    'specified output_dir not a directory: {}'.format(
                         self.output_dir
                     )
                 )
@@ -536,8 +541,8 @@ class CmdStanArgs:
                 os.remove(testpath)  # cleanup
             except Exception:
                 raise ValueError(
-                    'invalid path for output files, '
-                    'cannot write to dir: {}'.format(self.output_dir)
+                    'invalid path for output files,'
+                    ' cannot write to dir: {}'.format(self.output_dir)
                 )
 
         if self.seed is None:
@@ -563,7 +568,7 @@ class CmdStanArgs:
 
                 if len(self.seed) != len(self.chain_ids):
                     raise ValueError(
-                        'number of seeds must match number of chains '
+                        'number of seeds must match number of chains,'
                         ' found {} seed for {} chains '.format(
                             len(self.seed), len(self.chain_ids)
                         )
@@ -602,7 +607,7 @@ class CmdStanArgs:
 
                 if len(self.inits) != len(self.chain_ids):
                     raise ValueError(
-                        'number of inits files must match number of chains '
+                        'number of inits files must match number of chains,'
                         ' found {} inits files for {} chains '.format(
                             len(self.inits), len(self.chain_ids)
                         )

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -644,6 +644,7 @@ class CmdStanModel:
                 save_diagnostics=save_diagnostics,
                 method_args=sampler_args,
                 refresh=refresh,
+                logger=self._logger,
             )
             runset = RunSet(args=args, chains=chains)
             pbar = None
@@ -704,7 +705,7 @@ class CmdStanModel:
                 for i in range(chains):
                     if runset._retcode(i) != 0:
                         err_msg = '{}chain {} returned error code {}\n'.format(
-                            err_msg, i+1, runset._retcode(i)
+                            err_msg, i + 1, runset._retcode(i)
                         )
                 console_errs = runset._get_err_msgs()
                 if len(console_errs) > 0:

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -3,6 +3,7 @@
 import os
 import platform
 import unittest
+from time import time
 
 from cmdstanpy import _TMPDIR
 from cmdstanpy.cmdstan_args import (
@@ -317,6 +318,19 @@ class CmdStanArgsTest(unittest.TestCase):
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
         self.assertIn('id=7 random seed=', ' '.join(cmd))
 
+        dirname = 'tmp' + str(time())
+        if os.path.exists(dirname):
+            os.rmdir(dirname)
+        CmdStanArgs(
+            model_name='bernoulli',
+            model_exe='bernoulli.exe',
+            chain_ids=[1, 2, 3, 4],
+            output_dir=dirname,
+            method_args=sampler_args,
+        )
+        self.assertTrue(os.path.exists(dirname))
+        os.rmdir(dirname)
+
     def test_args_inits(self):
         exe = os.path.join(DATAFILES_PATH, 'bernoulli')
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
@@ -485,17 +499,6 @@ class CmdStanArgsTest(unittest.TestCase):
                 model_exe='bernoulli.exe',
                 chain_ids=[1, 2, 3, 4],
                 inits='no/such/path/to.file',
-                method_args=sampler_args,
-            )
-
-        with self.assertRaisesRegex(
-            ValueError, 'invalid path for output files, no such dir'
-        ):
-            CmdStanArgs(
-                model_name='bernoulli',
-                model_exe='bernoulli.exe',
-                chain_ids=[1, 2, 3, 4],
-                output_dir='bad/path',
                 method_args=sampler_args,
             )
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1,10 +1,12 @@
 """CmdStan method sample tests"""
 
 import os
+import platform
 import logging
 import shutil
 from multiprocessing import cpu_count
 import unittest
+from time import time
 from testfixtures import LogCapture
 import pytest
 
@@ -165,11 +167,17 @@ class SampleTest(unittest.TestCase):
                 seed=12345,
                 iter_sampling=100,
             )
-        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
-        with self.assertRaisesRegex(
-            ValueError, 'invalid path for output files'
-        ):
-            bern_model.sample(data=jdata, chains=1, output_dir='/bad')
+        if platform.system() != 'Windows':
+            jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+            dirname1 = 'tmp1' + str(time())
+            os.mkdir(dirname1, mode=644)
+            dirname2 = 'tmp2' + str(time())
+            path = os.path.join(dirname1, dirname2)
+            with self.assertRaisesRegex(
+                    ValueError, 'invalid path for output files'
+                    ):
+                bern_model.sample(data=jdata, chains=1, output_dir=path)
+            os.rmdir(dirname1)
 
     def test_multi_proc(self):
         logistic_stan = os.path.join(DATAFILES_PATH, 'logistic.stan')

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -111,27 +111,43 @@ class SampleTest(unittest.TestCase):
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
 
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-            inits=1.1
+            data=jdata,
+            chains=4,
+            cores=2,
+            seed=12345,
+            iter_sampling=100,
+            inits=1.1,
         )
         self.assertIn('init=1.1', bern_fit.runset.__repr__())
 
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-            inits=1
+            data=jdata,
+            chains=4,
+            cores=2,
+            seed=12345,
+            iter_sampling=100,
+            inits=1,
         )
         self.assertIn('init=1', bern_fit.runset.__repr__())
 
         with self.assertRaises(ValueError):
             bern_model.sample(
-                data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-                inits=(1, 2)
+                data=jdata,
+                chains=4,
+                cores=2,
+                seed=12345,
+                iter_sampling=100,
+                inits=(1, 2),
             )
 
         with self.assertRaises(ValueError):
             bern_model.sample(
-                data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-                inits=-1
+                data=jdata,
+                chains=4,
+                cores=2,
+                seed=12345,
+                iter_sampling=100,
+                inits=-1,
             )
 
     def test_bernoulli_bad(self):
@@ -139,19 +155,21 @@ class SampleTest(unittest.TestCase):
         bern_model = CmdStanModel(stan_file=stan)
 
         with self.assertRaisesRegex(RuntimeError, 'variable does not exist'):
-            bern_model.sample(
-                chains=4, cores=2, seed=12345, iter_sampling=100
-            )
+            bern_model.sample(chains=4, cores=2, seed=12345, iter_sampling=100)
 
         with self.assertRaisesRegex(RuntimeError, 'variable does not exist'):
             bern_model.sample(
                 data={'foo': 1},
-                chains=4, cores=2, seed=12345, iter_sampling=100
+                chains=4,
+                cores=2,
+                seed=12345,
+                iter_sampling=100,
             )
-        # tests current behavoir
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
-        with self.assertRaisesRegex(ValueError, 'invalid path for output files'):
-            bern_model.sample(data=jdata, chains=1, output_dir='foo')
+        with self.assertRaisesRegex(
+            ValueError, 'invalid path for output files'
+        ):
+            bern_model.sample(data=jdata, chains=1, output_dir='/bad')
 
     def test_multi_proc(self):
         logistic_stan = os.path.join(DATAFILES_PATH, 'logistic.stan')
@@ -285,7 +303,7 @@ class SampleTest(unittest.TestCase):
             'eta.17',
             'eta.18',
             'eta.19',
-            'eta.20'
+            'eta.20',
         ]
         self.assertEqual(datagen_fit.column_names, tuple(column_names))
         self.assertEqual(datagen_fit.draws, 100)
@@ -298,8 +316,9 @@ class SampleTest(unittest.TestCase):
         self.test_bernoulli_good('bernoulli with space in name.stan')
 
     def test_bernoulli_path_with_space(self):
-        self.test_bernoulli_good('path with space/'
-                                 'bernoulli_path_with_space.stan')
+        self.test_bernoulli_good(
+            'path with space/' 'bernoulli_path_with_space.stan'
+        )
 
 
 class CmdStanMCMCTest(unittest.TestCase):
@@ -325,7 +344,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-good', 'bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-good', 'bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-good', 'bern-4.csv'),
-            ]
+        ]
         self.assertEqual(4, runset.chains)
         retcodes = runset._retcodes
         for i in range(len(retcodes)):
@@ -341,7 +360,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         drawset = fit.get_drawset()
         self.assertEqual(
             drawset.shape,
-            (fit.runset.chains * fit.draws, len(fit.column_names))
+            (fit.runset.chains * fit.draws, len(fit.column_names)),
         )
         _ = fit.summary()
         self.assertTrue(True)
@@ -361,9 +380,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertIn(expected, fit.diagnose().replace('\r\n', '\n'))
 
     def test_validate_big_run(self):
-        exe = os.path.join(
-            DATAFILES_PATH, 'bernoulli' + EXTENSION
-        )
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         sampler_args = SamplerArgs()
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -377,7 +394,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         runset._csv_files = [
             os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc-1.csv'),
             os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc-1.csv'),
-            ]
+        ]
         fit = CmdStanMCMC(runset)
         fit._validate_csv_files()
         sampler_state = [
@@ -418,7 +435,11 @@ class CmdStanMCMCTest(unittest.TestCase):
         jmetric = os.path.join(DATAFILES_PATH, 'bernoulli.metric.json')
         # just test that it runs without error
         bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=200,
+            data=jdata,
+            chains=4,
+            cores=2,
+            seed=12345,
+            iter_sampling=200,
             metric=jmetric,
         )
 
@@ -473,9 +494,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 os.remove(bern_fit.runset.stderr_files[i])
 
     def test_diagnose_divergences(self):
-        exe = os.path.join(
-            DATAFILES_PATH, 'bernoulli' + EXTENSION
-        )
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         sampler_args = SamplerArgs()
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -486,9 +505,10 @@ class CmdStanMCMCTest(unittest.TestCase):
         )
         runset = RunSet(args=cmdstan_args, chains=1)
         runset._csv_files = [
-            os.path.join(DATAFILES_PATH, 'diagnose-good',
-                             'corr_gauss_depth8-1.csv'),
-            ]
+            os.path.join(
+                DATAFILES_PATH, 'diagnose-good', 'corr_gauss_depth8-1.csv'
+            )
+        ]
         fit = CmdStanMCMC(runset)
         # TODO - use cmdstan test files instead
         expected = '\n'.join(
@@ -527,15 +547,19 @@ class CmdStanMCMCTest(unittest.TestCase):
 
         # errors reported
         runset._stderr_files = [
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-1.txt'),
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-2.txt'),
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-3.txt'),
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-4.txt'),
-            ]
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-1.txt'
+            ),
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-2.txt'
+            ),
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-3.txt'
+            ),
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-4.txt'
+            ),
+        ]
         self.assertEqual(len(runset._get_err_msgs()), 4)
 
         # csv file headers inconsistent
@@ -544,7 +568,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-4.csv'),
-            ]
+        ]
         fit = CmdStanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'header mismatch'):
             fit._validate_csv_files()
@@ -555,7 +579,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-4.csv'),
-            ]
+        ]
         fit = CmdStanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'draws'):
             fit._validate_csv_files()
@@ -566,7 +590,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-4.csv'),
-            ]
+        ]
         fit = CmdStanMCMC(runset)
         with self.assertRaisesRegex(ValueError, 'bad draw'):
             fit._validate_csv_files()

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -148,6 +148,10 @@ class SampleTest(unittest.TestCase):
                 data={'foo': 1},
                 chains=4, cores=2, seed=12345, iter_sampling=100
             )
+        # tests current behavoir
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+        with self.assertRaisesRegex(ValueError, 'invalid path for output files'):
+            bern_model.sample(data=jdata, chains=1, output_dir='foo')
 
     def test_multi_proc(self):
         logistic_stan = os.path.join(DATAFILES_PATH, 'logistic.stan')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix logic for  CmdStanArgs so that If specified output_dir doesn't exist, it will be created (if possible).

In tracking down the bug and cleaning up the unit tests, I noticed too many spaces in a bunch of the error messages, so I cleaned up the error messages. Also added regex logic to unit tests - tests are now more specific and also self-documenting.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:  Columbia University
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

