### PR TITLE
Feature/207 save warmup

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -18,6 +18,8 @@ _STANSUMMARY_STATS = [
 ]
 
 _TMPDIR = tempfile.mkdtemp()
+_CMDSTAN_WARMUP = 1000
+_CMDSTAN_SAMPLING = 1000
 
 
 def _cleanup_tmpdir():

--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -20,6 +20,7 @@ _STANSUMMARY_STATS = [
 _TMPDIR = tempfile.mkdtemp()
 _CMDSTAN_WARMUP = 1000
 _CMDSTAN_SAMPLING = 1000
+_CMDSTAN_THIN = 1
 
 
 def _cleanup_tmpdir():

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -711,7 +711,7 @@ class CmdStanModel:
                     err_msg = '{}{}'.format(err_msg, ''.join(console_errs))
                 raise RuntimeError(err_msg)
 
-            mcmc = CmdStanMCMC(runset, fixed_param)
+            mcmc = CmdStanMCMC(runset)
             mcmc._validate_csv_files()
         return mcmc
 

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -36,6 +36,7 @@ from cmdstanpy.utils import (
     MaybeDictToFilePath,
     TemporaryCopiedFile,
     get_logger,
+    scan_sampler_csv,
 )
 
 
@@ -395,7 +396,6 @@ class CmdStanModel:
                 )
                 raise RuntimeError(msg)
         mle = CmdStanMLE(runset)
-        mle._set_mle_attrs(runset.csv_files[0])
         return mle
 
     def sample(
@@ -704,7 +704,7 @@ class CmdStanModel:
                 for i in range(chains):
                     if runset._retcode(i) != 0:
                         err_msg = '{}chain {} returned error code {}\n'.format(
-                            err_msg, i+1, runset._retcode(i)
+                            err_msg, i + 1, runset._retcode(i)
                         )
                 console_errs = runset._get_err_msgs()
                 if len(console_errs) > 0:
@@ -712,7 +712,6 @@ class CmdStanModel:
                 raise RuntimeError(err_msg)
 
             mcmc = CmdStanMCMC(runset)
-            mcmc._validate_csv_files()
         return mcmc
 
     def generate_quantities(
@@ -785,7 +784,24 @@ class CmdStanModel:
         try:
             chains = len(sample_csv_files)
             if sample_drawset is None:  # assemble sample from csv files
-                sampler_args = SamplerArgs()
+                config = {}
+                # scan 1st csv file to get config
+                try:
+                    config = scan_sampler_csv(sample_csv_files[0])
+                except ValueError:
+                    config = scan_sampler_csv(sample_csv_files[0], True)
+                conf_iter_sampling = int(config['iter_sampling'])
+                conf_iter_warmup = None
+                if 'iter_warmup' in config:
+                    conf_iter_warmup = int(config['iter_warmup'])
+                conf_thin = None
+                if 'thin' in config:
+                    conf_thin = int(config['thin'])
+                sampler_args = SamplerArgs(
+                    iter_sampling=conf_iter_sampling,
+                    iter_warmup=conf_iter_warmup,
+                    thin=conf_thin,
+                )
                 args = CmdStanArgs(
                     self._name,
                     self._exe_file,
@@ -795,7 +811,6 @@ class CmdStanModel:
                 runset = RunSet(args=args, chains=chains)
                 runset._csv_files = sample_csv_files
                 sample_fit = CmdStanMCMC(runset)
-                sample_fit._validate_csv_files()
                 sample_drawset = sample_fit.get_drawset()
         except ValueError as e:
             raise ValueError(
@@ -836,7 +851,6 @@ class CmdStanModel:
                         )
                 raise RuntimeError(msg)
             quantities = CmdStanGQ(runset=runset, mcmc_sample=sample_drawset)
-            quantities._set_attrs_gq_csv_files(sample_csv_files[0])
         return quantities
 
     def variational(
@@ -971,7 +985,6 @@ class CmdStanModel:
                 raise RuntimeError(msg)
         # pylint: disable=invalid-name
         vb = CmdStanVB(runset)
-        vb._set_variational_attrs(runset.csv_files[0])
         return vb
 
     def _run_cmdstan(

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -809,10 +809,12 @@ class CmdStanModel:
                     config = scan_sampler_csv(sample_csv_files[0])
                 except ValueError:
                     config = scan_sampler_csv(sample_csv_files[0], True)
-                conf_iter_sampling = int(config['iter_sampling'])
+                conf_iter_sampling = None
+                if 'num_samples' in config:
+                    conf_iter_sampling = int(config['num_samples'])
                 conf_iter_warmup = None
-                if 'iter_warmup' in config:
-                    conf_iter_warmup = int(config['iter_warmup'])
+                if 'num_warmup' in config:
+                    conf_iter_warmup = int(config['num_warmup'])
                 conf_thin = None
                 if 'thin' in config:
                     conf_thin = int(config['thin'])

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -735,12 +735,6 @@ class CmdStanGQ:
             axis=1,
         )
 
-    def _set_attrs_gq_csv_files(self, sample_csv_0: str) -> None:
-        """
-        Propogate information from original sample to additional sample
-        returned by generate_quantities.
-        """
-
     def _assemble_generated_quantities(self) -> None:
         drawset_list = []
         for chain in range(self.runset.chains):

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -257,12 +257,15 @@ class CmdStanMCMC:
                 'found method {}'.format(runset.method)
             )
         self.runset = runset
-        self._iter_sampling = runset._args.method_args.iter_sampling
-        self._save_warmup = runset._args.method_args.save_warmup
-        self._iter_warmup = runset._args.method_args.iter_warmup
+        # copy info from runset
         self._is_fixed_param = runset._args.method_args.fixed_param
-        self._draws_sampling = None  # iter_sampling / thin
-        self._draws_warmup = None  # iter_wamup / thin
+        self._iter_sampling = runset._args.method_args.iter_sampling
+        self._iter_warmup = runset._args.method_args.iter_warmup
+        self._save_warmup = runset._args.method_args.save_warmup
+        self._thin = runset._args.method_args.thin
+        # parse the remainder from csv files
+        self._draws_sampling = None
+        self._draws_warmup = None
         self._column_names = ()
         self._num_params = None  # metric dim(s)
         self._metric_type = None
@@ -378,6 +381,7 @@ class CmdStanMCMC:
                     iter_sampling=self._iter_sampling,
                     iter_warmup=self._iter_warmup,
                     save_warmup=self._save_warmup,
+                    thin=self._thin,
                 )
             else:
                 drest = check_sampler_csv(
@@ -386,6 +390,7 @@ class CmdStanMCMC:
                     iter_sampling=self._iter_sampling,
                     iter_warmup=self._iter_warmup,
                     save_warmup=self._save_warmup,
+                    thin=self._thin,
                 )
                 for key in dzero:
                     if (

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -451,17 +451,15 @@ def check_sampler_csv(
         if 'thin' not in meta:
             raise ValueError(
                 'bad csv file {}, '
-                'config error, expected thin = {}'.format(
-                path, thin
+                'config error, expected thin = {}'.format(path, thin)
             )
-        )
         if meta['thin'] != thin:
             raise ValueError(
                 'bad csv file {}, '
                 'config error, expected thin = {}, found {}'.format(
-                path, thin, meta['thin']
+                    path, thin, meta['thin']
+                )
             )
-        )
     draws_sampling = iter_sampling
     if draws_sampling is None:
         draws_sampling = _CMDSTAN_SAMPLING

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -451,23 +451,24 @@ def check_sampler_csv(
     if 'thin' in meta:
         iter_warmup = int(math.ceil(iter_warmup / meta['thin']))
         iter_sampling = int(math.ceil(iter_sampling / meta['thin']))
-    if meta['iter_sampling'] != iter_sampling:
+    if meta['draws_sampling'] != iter_sampling:
         raise ValueError(
-            'bad csv file {}, expected {} sampling iterations, found {}'.format(
-                path, iter_sampling, meta['iter_sampling']
+            'bad csv file {}, expected {} draws, found {}'.format(
+                path, iter_sampling, meta['draws_sampling']
             )
         )
     if save_warmup:
-        if not ('save_warmup' in meta and meta['save_warmup'] == '1'):
+        if not ('save_warmup' in meta and meta['save_warmup'] == 1):
+            print(meta)
             raise ValueError(
                 'bad csv file {}, '
                 'config error, expected save_warmup = 1'.format(path)
             )
-        if meta['iter_warmup'] != iter_warmup:
+        if meta['draws_warmup'] != iter_warmup:
             raise ValueError(
                 'bad csv file {}, '
-                'expected {} warmup iterations, found {}'.format(
-                    path, iter_warmup, meta['iter_warmup']
+                'expected {} warmup draws, found {}'.format(
+                    path, iter_warmup, meta['draws_warmup']
                 )
             )
     return meta
@@ -587,14 +588,14 @@ def scan_warmup_iters(fd: TextIO, config_dict: Dict, lineno: int) -> int:
         return lineno
     cur_pos = fd.tell()
     line = fd.readline().strip()
-    iters_found = 0
+    draws_found = 0
     while len(line) > 0 and not line.startswith('#'):
         lineno += 1
-        iters_found += 1
+        draws_found += 1
         cur_pos = fd.tell()
         line = fd.readline().strip()
     fd.seek(cur_pos)
-    config_dict['iter_warmup'] = iters_found
+    config_dict['draws_warmup'] = draws_found
     return lineno
 
 
@@ -675,13 +676,13 @@ def scan_sampling_iters(fd: TextIO, config_dict: Dict, lineno: int) -> int:
     """
     Parse sampling iteration, save number of iterations to config_dict.
     """
-    iters_found = 0
+    draws_found = 0
     num_cols = len(config_dict['column_names'])
     cur_pos = fd.tell()
     line = fd.readline().strip()
     while len(line) > 0 and not line.startswith('#'):
         lineno += 1
-        iters_found += 1
+        draws_found += 1
         data = line.split(',')
         if len(data) != num_cols:
             raise ValueError(
@@ -691,7 +692,7 @@ def scan_sampling_iters(fd: TextIO, config_dict: Dict, lineno: int) -> int:
             )
         cur_pos = fd.tell()
         line = fd.readline().strip()
-    config_dict['iter_sampling'] = iters_found
+    config_dict['draws_sampling'] = draws_found
     fd.seek(cur_pos)
     return lineno
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -686,7 +686,7 @@ def scan_sampling_iters(fd: TextIO, config_dict: Dict, lineno: int) -> int:
         data = line.split(',')
         if len(data) != num_cols:
             raise ValueError(
-                'line {}: bad iteration, expecting {} items, found {}'.format(
+                'line {}: bad draw, expecting {} items, found {}'.format(
                     lineno, num_cols, len(line.split(','))
                 )
             )

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -27,7 +27,7 @@ class CmdStanMLETest(unittest.TestCase):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 
-    def test_set_mle_attrs(self):
+    def test_instantiate(self):
         stan = os.path.join(DATAFILES_PATH, 'optimize', 'rosenbrock.stan')
         model = CmdStanModel(stan_file=stan)
         no_data = {}
@@ -40,15 +40,12 @@ class CmdStanMLETest(unittest.TestCase):
             method_args=args,
         )
         runset = RunSet(args=cmdstan_args, chains=1)
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'optimize', 'rosenbrock_mle.csv')
+            ]
         mle = CmdStanMLE(runset)
         self.assertIn('CmdStanMLE: model=rosenbrock', mle.__repr__())
         self.assertIn('method=optimize', mle.__repr__())
-
-        self.assertEqual(mle._column_names, ())
-        self.assertEqual(mle._mle, {})
-
-        output = os.path.join(DATAFILES_PATH, 'optimize', 'rosenbrock_mle.csv')
-        mle._set_mle_attrs(output)
         self.assertEqual(mle.column_names, ('lp__', 'x', 'y'))
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -111,27 +111,43 @@ class SampleTest(unittest.TestCase):
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
 
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-            inits=1.1
+            data=jdata,
+            chains=4,
+            cores=2,
+            seed=12345,
+            iter_sampling=100,
+            inits=1.1,
         )
         self.assertIn('init=1.1', bern_fit.runset.__repr__())
 
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-            inits=1
+            data=jdata,
+            chains=4,
+            cores=2,
+            seed=12345,
+            iter_sampling=100,
+            inits=1,
         )
         self.assertIn('init=1', bern_fit.runset.__repr__())
 
         with self.assertRaises(ValueError):
             bern_model.sample(
-                data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-                inits=(1, 2)
+                data=jdata,
+                chains=4,
+                cores=2,
+                seed=12345,
+                iter_sampling=100,
+                inits=(1, 2),
             )
 
         with self.assertRaises(ValueError):
             bern_model.sample(
-                data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100,
-                inits=-1
+                data=jdata,
+                chains=4,
+                cores=2,
+                seed=12345,
+                iter_sampling=100,
+                inits=-1,
             )
 
     def test_bernoulli_bad(self):
@@ -139,14 +155,15 @@ class SampleTest(unittest.TestCase):
         bern_model = CmdStanModel(stan_file=stan)
 
         with self.assertRaisesRegex(RuntimeError, 'variable does not exist'):
-            bern_model.sample(
-                chains=4, cores=2, seed=12345, iter_sampling=100
-            )
+            bern_model.sample(chains=4, cores=2, seed=12345, iter_sampling=100)
 
         with self.assertRaisesRegex(RuntimeError, 'variable does not exist'):
             bern_model.sample(
                 data={'foo': 1},
-                chains=4, cores=2, seed=12345, iter_sampling=100
+                chains=4,
+                cores=2,
+                seed=12345,
+                iter_sampling=100,
             )
 
     def test_multi_proc(self):
@@ -281,7 +298,7 @@ class SampleTest(unittest.TestCase):
             'eta.17',
             'eta.18',
             'eta.19',
-            'eta.20'
+            'eta.20',
         ]
         self.assertEqual(datagen_fit.column_names, tuple(column_names))
         self.assertEqual(datagen_fit.draws, 100)
@@ -294,8 +311,9 @@ class SampleTest(unittest.TestCase):
         self.test_bernoulli_good('bernoulli with space in name.stan')
 
     def test_bernoulli_path_with_space(self):
-        self.test_bernoulli_good('path with space/'
-                                 'bernoulli_path_with_space.stan')
+        self.test_bernoulli_good(
+            'path with space/' 'bernoulli_path_with_space.stan'
+        )
 
 
 class CmdStanMCMCTest(unittest.TestCase):
@@ -321,7 +339,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-good', 'bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-good', 'bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-good', 'bern-4.csv'),
-            ]
+        ]
         self.assertEqual(4, runset.chains)
         retcodes = runset._retcodes
         for i in range(len(retcodes)):
@@ -329,7 +347,6 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertTrue(runset._check_retcodes())
 
         fit = CmdStanMCMC(runset)
-        fit._validate_csv_files()
         self.assertEqual(100, fit.draws)
         self.assertEqual(8, len(fit.column_names))
         self.assertEqual('lp__', fit.column_names[0])
@@ -337,7 +354,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         drawset = fit.get_drawset()
         self.assertEqual(
             drawset.shape,
-            (fit.runset.chains * fit.draws, len(fit.column_names))
+            (fit.runset.chains * fit.draws, len(fit.column_names)),
         )
         _ = fit.summary()
         self.assertTrue(True)
@@ -357,10 +374,8 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertIn(expected, fit.diagnose().replace('\r\n', '\n'))
 
     def test_validate_big_run(self):
-        exe = os.path.join(
-            DATAFILES_PATH, 'bernoulli' + EXTENSION
-        )
-        sampler_args = SamplerArgs()
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
+        sampler_args = SamplerArgs(iter_warmup=1500, iter_sampling=1000)
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
             model_exe=exe,
@@ -373,9 +388,8 @@ class CmdStanMCMCTest(unittest.TestCase):
         runset._csv_files = [
             os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc-1.csv'),
             os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc-1.csv'),
-            ]
+        ]
         fit = CmdStanMCMC(runset)
-        fit._validate_csv_files()
         sampler_state = [
             'lp__',
             'accept_stat__',
@@ -414,7 +428,11 @@ class CmdStanMCMCTest(unittest.TestCase):
         jmetric = os.path.join(DATAFILES_PATH, 'bernoulli.metric.json')
         # just test that it runs without error
         bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=200,
+            data=jdata,
+            chains=4,
+            cores=2,
+            seed=12345,
+            iter_sampling=200,
             metric=jmetric,
         )
 
@@ -469,9 +487,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 os.remove(bern_fit.runset.stderr_files[i])
 
     def test_diagnose_divergences(self):
-        exe = os.path.join(
-            DATAFILES_PATH, 'bernoulli' + EXTENSION
-        )
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         sampler_args = SamplerArgs()
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -482,9 +498,10 @@ class CmdStanMCMCTest(unittest.TestCase):
         )
         runset = RunSet(args=cmdstan_args, chains=1)
         runset._csv_files = [
-            os.path.join(DATAFILES_PATH, 'diagnose-good',
-                             'corr_gauss_depth8-1.csv'),
-            ]
+            os.path.join(
+                DATAFILES_PATH, 'diagnose-good', 'corr_gauss_depth8-1.csv'
+            )
+        ]
         fit = CmdStanMCMC(runset)
         # TODO - use cmdstan test files instead
         expected = '\n'.join(
@@ -502,9 +519,7 @@ class CmdStanMCMCTest(unittest.TestCase):
     def test_validate_bad_run(self):
         exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
-        sampler_args = SamplerArgs(
-            iter_sampling=100, max_treedepth=11, adapt_delta=0.95
-        )
+        sampler_args = SamplerArgs(max_treedepth=11, adapt_delta=0.95)
 
         # some chains had errors
         cmdstan_args = CmdStanArgs(
@@ -523,15 +538,19 @@ class CmdStanMCMCTest(unittest.TestCase):
 
         # errors reported
         runset._stderr_files = [
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-1.txt'),
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-2.txt'),
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-3.txt'),
-            os.path.join(DATAFILES_PATH, 'runset-bad',
-                             'bad-transcript-bern-4.txt'),
-            ]
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-1.txt'
+            ),
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-2.txt'
+            ),
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-3.txt'
+            ),
+            os.path.join(
+                DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-4.txt'
+            ),
+        ]
         self.assertEqual(len(runset._get_err_msgs()), 4)
 
         # csv file headers inconsistent
@@ -540,10 +559,9 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-4.csv'),
-            ]
-        fit = CmdStanMCMC(runset)
-        with self.assertRaisesRegex(ValueError, 'header mismatch'):
-            fit._validate_csv_files()
+        ]
+        with self.assertRaisesRegex(ValueError, 'csv file header mismatch'):
+            CmdStanMCMC(runset)
 
         # bad draws
         runset._csv_files = [
@@ -551,10 +569,11 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-draws-bern-4.csv'),
-            ]
-        fit = CmdStanMCMC(runset)
-        with self.assertRaisesRegex(ValueError, 'draws'):
-            fit._validate_csv_files()
+        ]
+        with self.assertRaisesRegex(
+            ValueError, 'expected 1000 sampling iterations, found 988'
+        ):
+            CmdStanMCMC(runset)
 
         # mismatch - column headers, draws
         runset._csv_files = [
@@ -562,10 +581,11 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-2.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-4.csv'),
-            ]
-        fit = CmdStanMCMC(runset)
-        with self.assertRaisesRegex(ValueError, 'bad draw'):
-            fit._validate_csv_files()
+        ]
+        with self.assertRaisesRegex(
+            ValueError, 'bad iteration, expecting 9 items, found 8'
+        ):
+            CmdStanMCMC(runset)
 
 
 if __name__ == '__main__':

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -607,7 +607,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-4.csv'),
         ]
         with self.assertRaisesRegex(
-            ValueError, 'bad iteration, expecting 9 items, found 8'
+            ValueError, 'bad draw, expecting 9 items, found 8'
         ):
             CmdStanMCMC(runset)
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -39,7 +39,7 @@ class SampleTest(unittest.TestCase):
 
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=100
+            data=jdata, chains=2, cores=2, seed=12345, iter_sampling=100
         )
         self.assertIn('CmdStanMCMC: model=bernoulli', bern_fit.__repr__())
         self.assertIn('method=sample', bern_fit.__repr__())
@@ -52,8 +52,8 @@ class SampleTest(unittest.TestCase):
             self.assertTrue(os.path.exists(csv_file))
             self.assertTrue(os.path.exists(stdout_file))
 
-        self.assertEqual(bern_fit.runset.chains, 4)
-        self.assertEqual(bern_fit.draws, 100)
+        self.assertEqual(bern_fit.runset.chains, 2)
+        self.assertEqual(bern_fit.num_draws, 100)
         column_names = [
             'lp__',
             'accept_stat__',
@@ -67,14 +67,14 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(bern_fit.column_names, tuple(column_names))
 
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
         self.assertEqual(bern_fit.metric_type, 'diag_e')
-        self.assertEqual(bern_fit.stepsize.shape, (4,))
-        self.assertEqual(bern_fit.metric.shape, (4, 1))
+        self.assertEqual(bern_fit.stepsize.shape, (2,))
+        self.assertEqual(bern_fit.metric.shape, (2, 1))
 
         bern_fit = bern_model.sample(
             data=jdata,
-            chains=4,
+            chains=2,
             cores=2,
             seed=12345,
             iter_sampling=100,
@@ -86,7 +86,7 @@ class SampleTest(unittest.TestCase):
             self.assertTrue(os.path.exists(csv_file))
             self.assertTrue(os.path.exists(stdout_file))
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
         for i in range(bern_fit.runset.chains):  # cleanup datafile_path dir
             os.remove(bern_fit.runset.csv_files[i])
             if os.path.exists(bern_fit.runset.stdout_files[i]):
@@ -95,17 +95,17 @@ class SampleTest(unittest.TestCase):
                 os.remove(bern_fit.runset.stderr_files[i])
         rdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.R')
         bern_fit = bern_model.sample(
-            data=rdata, chains=4, cores=2, seed=12345, iter_sampling=100
+            data=rdata, chains=2, cores=2, seed=12345, iter_sampling=100
         )
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
 
         data_dict = {'N': 10, 'y': [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
         bern_fit = bern_model.sample(
-            data=data_dict, chains=4, cores=2, seed=12345, iter_sampling=100
+            data=data_dict, chains=2, cores=2, seed=12345, iter_sampling=100
         )
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 4, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
 
     def test_init_types(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
@@ -114,7 +114,7 @@ class SampleTest(unittest.TestCase):
 
         bern_fit = bern_model.sample(
             data=jdata,
-            chains=4,
+            chains=2,
             cores=2,
             seed=12345,
             iter_sampling=100,
@@ -124,7 +124,7 @@ class SampleTest(unittest.TestCase):
 
         bern_fit = bern_model.sample(
             data=jdata,
-            chains=4,
+            chains=2,
             cores=2,
             seed=12345,
             iter_sampling=100,
@@ -135,7 +135,7 @@ class SampleTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             bern_model.sample(
                 data=jdata,
-                chains=4,
+                chains=2,
                 cores=2,
                 seed=12345,
                 iter_sampling=100,
@@ -145,7 +145,7 @@ class SampleTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             bern_model.sample(
                 data=jdata,
-                chains=4,
+                chains=2,
                 cores=2,
                 seed=12345,
                 iter_sampling=100,
@@ -157,12 +157,12 @@ class SampleTest(unittest.TestCase):
         bern_model = CmdStanModel(stan_file=stan)
 
         with self.assertRaisesRegex(RuntimeError, 'variable does not exist'):
-            bern_model.sample(chains=4, cores=2, seed=12345, iter_sampling=100)
+            bern_model.sample(chains=2, cores=2, seed=12345, iter_sampling=100)
 
         with self.assertRaisesRegex(RuntimeError, 'variable does not exist'):
             bern_model.sample(
                 data={'foo': 1},
-                chains=4,
+                chains=2,
                 cores=2,
                 seed=12345,
                 iter_sampling=100,
@@ -174,8 +174,8 @@ class SampleTest(unittest.TestCase):
             dirname2 = 'tmp2' + str(time())
             path = os.path.join(dirname1, dirname2)
             with self.assertRaisesRegex(
-                    ValueError, 'invalid path for output files'
-                    ):
+                ValueError, 'invalid path for output files'
+            ):
                 bern_model.sample(data=jdata, chains=1, output_dir=path)
             os.rmdir(dirname1)
 
@@ -314,7 +314,7 @@ class SampleTest(unittest.TestCase):
             'eta.20',
         ]
         self.assertEqual(datagen_fit.column_names, tuple(column_names))
-        self.assertEqual(datagen_fit.draws, 100)
+        self.assertEqual(datagen_fit.num_draws, 100)
         self.assertEqual(datagen_fit.sample.shape, (100, 1, len(column_names)))
         self.assertEqual(datagen_fit.metric, None)
         self.assertEqual(datagen_fit.metric_type, None)
@@ -360,14 +360,14 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertTrue(runset._check_retcodes())
 
         fit = CmdStanMCMC(runset)
-        self.assertEqual(100, fit.draws)
+        self.assertEqual(100, fit.num_draws)
         self.assertEqual(8, len(fit.column_names))
         self.assertEqual('lp__', fit.column_names[0])
 
         drawset = fit.get_drawset()
         self.assertEqual(
             drawset.shape,
-            (fit.runset.chains * fit.draws, len(fit.column_names)),
+            (fit.runset.chains * fit.num_draws, len(fit.column_names)),
         )
         _ = fit.summary()
         self.assertTrue(True)
@@ -414,7 +414,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         ]
         phis = ['phi.{}'.format(str(x + 1)) for x in range(2095)]
         column_names = sampler_state + phis
-        self.assertEqual(fit.columns, len(column_names))
+        self.assertEqual(fit.num_draws, 1000)
         self.assertEqual(fit.column_names, tuple(column_names))
         self.assertEqual(fit.metric_type, 'diag_e')
         self.assertEqual(fit.stepsize.shape, (2,))
@@ -442,7 +442,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         # just test that it runs without error
         bern_model.sample(
             data=jdata,
-            chains=4,
+            chains=2,
             cores=2,
             seed=12345,
             iter_sampling=200,
@@ -454,9 +454,14 @@ class CmdStanMCMCTest(unittest.TestCase):
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
         bern_model = CmdStanModel(stan_file=stan)
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345,
-            iter_sampling=200, iter_warmup=200,
-            adapt_init_phase=11, adapt_metric_window=12, adapt_step_size=13,
+            data=jdata,
+            chains=1,
+            seed=12345,
+            iter_sampling=200,
+            iter_warmup=200,
+            adapt_init_phase=11,
+            adapt_metric_window=12,
+            adapt_step_size=13,
         )
         txt_file = bern_fit.runset.stdout_files[0]
         with open(txt_file, 'r') as fd:
@@ -471,7 +476,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
         bern_model = CmdStanModel(stan_file=stan)
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=200
+            data=jdata, chains=2, cores=2, seed=12345, iter_sampling=200
         )
         for i in range(bern_fit.runset.chains):
             csv_file = bern_fit.runset.csv_files[i]
@@ -503,7 +508,7 @@ class CmdStanMCMCTest(unittest.TestCase):
 
         # regenerate to tmpdir, save to good dir
         bern_fit = bern_model.sample(
-            data=jdata, chains=4, cores=2, seed=12345, iter_sampling=200
+            data=jdata, chains=2, cores=2, seed=12345, iter_sampling=200
         )
         bern_fit.save_csvfiles()  # default dir
         for i in range(bern_fit.runset.chains):
@@ -610,8 +615,99 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-cols-bern-4.csv'),
         ]
-        with self.assertRaisesRegex(ValueError, 'bad draw'):
+        with self.assertRaisesRegex(
+            ValueError, 'bad iteration, expecting 9 items, found 8'
+        ):
             CmdStanMCMC(runset)
+
+    def test_save_warmup(self):
+        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+
+        bern_model = CmdStanModel(stan_file=stan)
+        bern_fit = bern_model.sample(
+            data=jdata,
+            chains=2,
+            seed=12345,
+            iter_warmup=200,
+            iter_sampling=100,
+            save_warmup=True,
+        )
+        column_names = [
+            'lp__',
+            'accept_stat__',
+            'stepsize__',
+            'treedepth__',
+            'n_leapfrog__',
+            'divergent__',
+            'energy__',
+            'theta',
+        ]
+        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.num_draws_warmup, 200)
+        self.assertEqual(bern_fit.warmup.shape, (200, 2, len(column_names)))
+        self.assertEqual(bern_fit.num_draws, 100)
+        self.assertEqual(bern_fit.sample.shape, (100, 2, len(column_names)))
+
+    def test_save_warmup_thin(self):
+        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+
+        bern_model = CmdStanModel(stan_file=stan)
+        bern_fit = bern_model.sample(
+            data=jdata,
+            chains=2,
+            seed=12345,
+            iter_warmup=200,
+            iter_sampling=100,
+            thin=5,
+            save_warmup=True,
+        )
+        column_names = [
+            'lp__',
+            'accept_stat__',
+            'stepsize__',
+            'treedepth__',
+            'n_leapfrog__',
+            'divergent__',
+            'energy__',
+            'theta',
+        ]
+        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.num_draws_warmup, 40)
+        self.assertEqual(bern_fit.warmup.shape, (40, 2, len(column_names)))
+        self.assertEqual(bern_fit.num_draws, 20)
+        self.assertEqual(bern_fit.sample.shape, (20, 2, len(column_names)))
+
+    def test_dont_save_warmup(self):
+        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+
+        bern_model = CmdStanModel(stan_file=stan)
+        bern_fit = bern_model.sample(
+            data=jdata,
+            chains=2,
+            seed=12345,
+            iter_warmup=200,
+            iter_sampling=100,
+            save_warmup=False,
+        )
+        column_names = [
+            'lp__',
+            'accept_stat__',
+            'stepsize__',
+            'treedepth__',
+            'n_leapfrog__',
+            'divergent__',
+            'energy__',
+            'theta',
+        ]
+        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.num_draws_warmup, 0)
+        self.assertEqual(bern_fit.warmup, None)
+        self.assertEqual(bern_fit.num_draws, 100)
+        self.assertEqual(bern_fit.sample.shape, (100, 2, len(column_names)))
 
 
 if __name__ == '__main__':

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -19,6 +19,16 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 DATAFILES_PATH = os.path.join(HERE, 'data')
 GOODFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-good')
 BADFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-bad')
+SAMPLER_STATE = [
+            'lp__',
+            'accept_stat__',
+            'stepsize__',
+            'treedepth__',
+            'n_leapfrog__',
+            'divergent__',
+            'energy__',
+        ]
+BERNOULLI_COLS = SAMPLER_STATE + ['theta']
 
 
 class SampleTest(unittest.TestCase):
@@ -54,20 +64,10 @@ class SampleTest(unittest.TestCase):
 
         self.assertEqual(bern_fit.runset.chains, 2)
         self.assertEqual(bern_fit.num_draws, 100)
-        column_names = [
-            'lp__',
-            'accept_stat__',
-            'stepsize__',
-            'treedepth__',
-            'n_leapfrog__',
-            'divergent__',
-            'energy__',
-            'theta',
-        ]
-        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.column_names, tuple(BERNOULLI_COLS))
 
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(BERNOULLI_COLS)))
         self.assertEqual(bern_fit.metric_type, 'diag_e')
         self.assertEqual(bern_fit.stepsize.shape, (2,))
         self.assertEqual(bern_fit.metric.shape, (2, 1))
@@ -86,7 +86,7 @@ class SampleTest(unittest.TestCase):
             self.assertTrue(os.path.exists(csv_file))
             self.assertTrue(os.path.exists(stdout_file))
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(BERNOULLI_COLS)))
         for i in range(bern_fit.runset.chains):  # cleanup datafile_path dir
             os.remove(bern_fit.runset.csv_files[i])
             if os.path.exists(bern_fit.runset.stdout_files[i]):
@@ -98,14 +98,14 @@ class SampleTest(unittest.TestCase):
             data=rdata, chains=2, cores=2, seed=12345, iter_sampling=100
         )
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(BERNOULLI_COLS)))
 
         data_dict = {'N': 10, 'y': [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
         bern_fit = bern_model.sample(
             data=data_dict, chains=2, cores=2, seed=12345, iter_sampling=100
         )
         bern_sample = bern_fit.sample
-        self.assertEqual(bern_sample.shape, (100, 2, len(column_names)))
+        self.assertEqual(bern_sample.shape, (100, 2, len(BERNOULLI_COLS)))
 
     def test_init_types(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
@@ -361,7 +361,7 @@ class CmdStanMCMCTest(unittest.TestCase):
 
         fit = CmdStanMCMC(runset)
         self.assertEqual(100, fit.num_draws)
-        self.assertEqual(8, len(fit.column_names))
+        self.assertEqual(len(BERNOULLI_COLS), len(fit.column_names))
         self.assertEqual('lp__', fit.column_names[0])
 
         drawset = fit.get_drawset()
@@ -403,17 +403,8 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-big', 'output_icar_nyc-1.csv'),
         ]
         fit = CmdStanMCMC(runset)
-        sampler_state = [
-            'lp__',
-            'accept_stat__',
-            'stepsize__',
-            'treedepth__',
-            'n_leapfrog__',
-            'divergent__',
-            'energy__',
-        ]
         phis = ['phi.{}'.format(str(x + 1)) for x in range(2095)]
-        column_names = sampler_state + phis
+        column_names = SAMPLER_STATE + phis
         self.assertEqual(fit.num_draws, 1000)
         self.assertEqual(fit.column_names, tuple(column_names))
         self.assertEqual(fit.metric_type, 'diag_e')
@@ -633,21 +624,11 @@ class CmdStanMCMCTest(unittest.TestCase):
             iter_sampling=100,
             save_warmup=True,
         )
-        column_names = [
-            'lp__',
-            'accept_stat__',
-            'stepsize__',
-            'treedepth__',
-            'n_leapfrog__',
-            'divergent__',
-            'energy__',
-            'theta',
-        ]
-        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.column_names, tuple(BERNOULLI_COLS))
         self.assertEqual(bern_fit.num_draws_warmup, 200)
-        self.assertEqual(bern_fit.warmup.shape, (200, 2, len(column_names)))
+        self.assertEqual(bern_fit.warmup.shape, (200, 2, len(BERNOULLI_COLS)))
         self.assertEqual(bern_fit.num_draws, 100)
-        self.assertEqual(bern_fit.sample.shape, (100, 2, len(column_names)))
+        self.assertEqual(bern_fit.sample.shape, (100, 2, len(BERNOULLI_COLS)))
 
     def test_save_warmup_thin(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
@@ -663,22 +644,11 @@ class CmdStanMCMCTest(unittest.TestCase):
             thin=5,
             save_warmup=True,
         )
-        column_names = [
-            'lp__',
-            'accept_stat__',
-            'stepsize__',
-            'treedepth__',
-            'n_leapfrog__',
-            'divergent__',
-            'energy__',
-            'theta',
-        ]
-        self.assertEqual(bern_fit.column_names, tuple(column_names))
-        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.column_names, tuple(BERNOULLI_COLS))
         self.assertEqual(bern_fit.num_draws_warmup, 40)
-        self.assertEqual(bern_fit.warmup.shape, (40, 2, len(column_names)))
+        self.assertEqual(bern_fit.warmup.shape, (40, 2, len(BERNOULLI_COLS)))
         self.assertEqual(bern_fit.num_draws, 20)
-        self.assertEqual(bern_fit.sample.shape, (20, 2, len(column_names)))
+        self.assertEqual(bern_fit.sample.shape, (20, 2, len(BERNOULLI_COLS)))
 
     def test_dont_save_warmup(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
@@ -693,21 +663,11 @@ class CmdStanMCMCTest(unittest.TestCase):
             iter_sampling=100,
             save_warmup=False,
         )
-        column_names = [
-            'lp__',
-            'accept_stat__',
-            'stepsize__',
-            'treedepth__',
-            'n_leapfrog__',
-            'divergent__',
-            'energy__',
-            'theta',
-        ]
-        self.assertEqual(bern_fit.column_names, tuple(column_names))
+        self.assertEqual(bern_fit.column_names, tuple(BERNOULLI_COLS))
         self.assertEqual(bern_fit.num_draws_warmup, 0)
         self.assertEqual(bern_fit.warmup, None)
         self.assertEqual(bern_fit.num_draws, 100)
-        self.assertEqual(bern_fit.sample.shape, (100, 2, len(column_names)))
+        self.assertEqual(bern_fit.sample.shape, (100, 2, len(BERNOULLI_COLS)))
 
 
 if __name__ == '__main__':

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -182,11 +182,16 @@ class CmdStanPathTest(unittest.TestCase):
 class ReadStanCsvTest(unittest.TestCase):
     def test_check_sampler_csv_1(self):
         csv_good = os.path.join(DATAFILES_PATH, 'bernoulli_output_1.csv')
-        dict = check_sampler_csv(csv_good)
+        dict = check_sampler_csv(
+            path=csv_good,
+            is_fixed_param=False,
+            iter_warmup=100,
+            iter_sampling=10
+        )
         self.assertEqual('bernoulli_model', dict['model'])
         self.assertEqual(10, dict['num_samples'])
         self.assertFalse('save_warmup' in dict)
-        self.assertEqual(10, dict['draws'])
+        self.assertEqual(10, dict['iter_sampling'])
         self.assertEqual(8, len(dict['column_names']))
 
     def test_check_sampler_csv_2(self):
@@ -245,10 +250,15 @@ class ReadStanCsvTest(unittest.TestCase):
             adapt_delta=0.98,
         )
         csv_file = bern_fit.runset.csv_files[0]
-        dict = check_sampler_csv(csv_file)
+        dict = check_sampler_csv(
+            path=csv_file,
+            is_fixed_param=False,
+            iter_sampling=490,
+            iter_warmup=490,
+        )
         self.assertEqual(dict['num_samples'], 490)
         self.assertEqual(dict['thin'], 7)
-        self.assertEqual(dict['draws'], 70)
+        self.assertEqual(dict['iter_sampling'], 70)
         self.assertEqual(dict['seed'], 12345)
         self.assertEqual(dict['max_depth'], 11)
         self.assertEqual(dict['delta'], 0.98)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -186,13 +186,38 @@ class ReadStanCsvTest(unittest.TestCase):
             path=csv_good,
             is_fixed_param=False,
             iter_warmup=100,
-            iter_sampling=10
+            iter_sampling=10,
+            thin=1,
         )
         self.assertEqual('bernoulli_model', dict['model'])
         self.assertEqual(10, dict['num_samples'])
         self.assertFalse('save_warmup' in dict)
         self.assertEqual(10, dict['draws_sampling'])
         self.assertEqual(8, len(dict['column_names']))
+
+        with self.assertRaisesRegex(
+                ValueError, 'config error, expected thin = 2'
+            ):
+            check_sampler_csv(
+                path=csv_good,
+                iter_warmup=100,
+                iter_sampling=20,
+                thin=2
+            )
+        with self.assertRaisesRegex(
+                ValueError, 'config error, expected save_warmup'
+            ):
+            check_sampler_csv(
+                path=csv_good,
+                iter_warmup=100,
+                iter_sampling=10,
+                save_warmup=True
+            )
+        with self.assertRaisesRegex(ValueError, 'expected 1000 draws'):
+            check_sampler_csv(
+                path=csv_good,
+                iter_warmup=100,
+            )
 
     def test_check_sampler_csv_2(self):
         csv_bad = os.path.join(DATAFILES_PATH, 'no_such_file.csv')
@@ -255,6 +280,7 @@ class ReadStanCsvTest(unittest.TestCase):
             is_fixed_param=False,
             iter_sampling=490,
             iter_warmup=490,
+            thin=7,
         )
         self.assertEqual(dict['num_samples'], 490)
         self.assertEqual(dict['thin'], 7)
@@ -262,6 +288,22 @@ class ReadStanCsvTest(unittest.TestCase):
         self.assertEqual(dict['seed'], 12345)
         self.assertEqual(dict['max_depth'], 11)
         self.assertEqual(dict['delta'], 0.98)
+
+        with self.assertRaisesRegex(ValueError, 'config error'):
+            check_sampler_csv(
+                path=csv_file,
+                is_fixed_param=False,
+                iter_sampling=490,
+                iter_warmup=490,
+                thin=9,
+            )
+        with self.assertRaisesRegex(ValueError, 'expected 490 draws, found 70'):
+            check_sampler_csv(
+                path=csv_file,
+                is_fixed_param=False,
+                iter_sampling=490,
+                iter_warmup=490,
+            )
 
 
 class ReadMetricTest(unittest.TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -191,7 +191,7 @@ class ReadStanCsvTest(unittest.TestCase):
         self.assertEqual('bernoulli_model', dict['model'])
         self.assertEqual(10, dict['num_samples'])
         self.assertFalse('save_warmup' in dict)
-        self.assertEqual(10, dict['iter_sampling'])
+        self.assertEqual(10, dict['draws_sampling'])
         self.assertEqual(8, len(dict['column_names']))
 
     def test_check_sampler_csv_2(self):
@@ -258,7 +258,7 @@ class ReadStanCsvTest(unittest.TestCase):
         )
         self.assertEqual(dict['num_samples'], 490)
         self.assertEqual(dict['thin'], 7)
-        self.assertEqual(dict['iter_sampling'], 70)
+        self.assertEqual(dict['draws_sampling'], 70)
         self.assertEqual(dict['seed'], 12345)
         self.assertEqual(dict['max_depth'], 11)
         self.assertEqual(dict['delta'], 0.98)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -196,28 +196,22 @@ class ReadStanCsvTest(unittest.TestCase):
         self.assertEqual(8, len(dict['column_names']))
 
         with self.assertRaisesRegex(
-                ValueError, 'config error, expected thin = 2'
-            ):
+            ValueError, 'config error, expected thin = 2'
+        ):
             check_sampler_csv(
-                path=csv_good,
-                iter_warmup=100,
-                iter_sampling=20,
-                thin=2
+                path=csv_good, iter_warmup=100, iter_sampling=20, thin=2
             )
         with self.assertRaisesRegex(
-                ValueError, 'config error, expected save_warmup'
-            ):
+            ValueError, 'config error, expected save_warmup'
+        ):
             check_sampler_csv(
                 path=csv_good,
                 iter_warmup=100,
                 iter_sampling=10,
-                save_warmup=True
+                save_warmup=True,
             )
         with self.assertRaisesRegex(ValueError, 'expected 1000 draws'):
-            check_sampler_csv(
-                path=csv_good,
-                iter_warmup=100,
-            )
+            check_sampler_csv(path=csv_good, iter_warmup=100)
 
     def test_check_sampler_csv_2(self):
         csv_bad = os.path.join(DATAFILES_PATH, 'no_such_file.csv')

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -26,7 +26,7 @@ class CmdStanVBTest(unittest.TestCase):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 
-    def test_set_variational_attrs(self):
+    def test_instantiate(self):
         stan = os.path.join(
             DATAFILES_PATH, 'variational', 'eta_should_be_big.stan'
         )
@@ -41,22 +41,14 @@ class CmdStanVBTest(unittest.TestCase):
             method_args=args,
         )
         runset = RunSet(args=cmdstan_args, chains=1)
+        runset._csv_files = [
+            os.path.join(DATAFILES_PATH, 'variational', 'eta_big_output.csv')
+            ]
         variational = CmdStanVB(runset)
         self.assertIn(
             'CmdStanVB: model=eta_should_be_big', variational.__repr__()
         )
         self.assertIn('method=variational', variational.__repr__())
-
-        # check CmdStanVB.__init__ state
-        self.assertEqual(variational._column_names, ())
-        self.assertEqual(variational._variational_mean, {})
-        self.assertEqual(variational._variational_sample, None)
-
-        # process csv file, check attrs
-        output = os.path.join(
-            DATAFILES_PATH, 'variational', 'eta_big_output.csv'
-        )
-        variational._set_variational_attrs(output)
         self.assertEqual(
             variational.column_names,
             ('lp__', 'log_p__', 'log_g__', 'mu.1', 'mu.2'),


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add accessor to CmdStanMCMC for saved warmup draws from sampler runs.
This entailed a redo of the logic around parsing csv file for both sampling and standalone generated quantities.  Also moved validation of csv files for all CmdStan methods into the constructors of CmdStanMCMC, CmdStanMLE, CmdStanVB, and CmdStanQG objects.

#### PR Notes

For sampling, the user specifies non-default arguments to CmdStan including:
 - `iter_sampling` (CmdStan arg "num_samples", default 1000)
 - `iter_warmup` (CmdStan arg "num_warmup", default 1000)
 - `thin` (default 1)
 - `save_warmup` (boolean, default false, i.e "0")

The number of draws in a sample = specified iterations / thin.  The CmdStanMCMC object needs to make a distinction between sampler iterations and output draws; refactored code and accessor method accordingly.

For sampling, validation of the runset csv files has access to the CmdStanArg object which is cross-referenced with stan_csv file header comments during validation.

For generated quantities, if the starting point is a set of saved csv files, the config of the first csv file is used to validate that the set of saved csv files is consistent; then the saved csv files are processed into the drawset that is passed into the call to standalone generate quantities.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

