### PR TITLE
don't alter users data dict

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -352,6 +352,7 @@ def _rdump_array(key: str, val: np.ndarray) -> str:
 
 def jsondump(path: str, data: Dict) -> None:
     """Dump a dict of data to a JSON file."""
+    data = data.copy()
     for key, val in data.items():
         if isinstance(val, np.ndarray):
             val = val.tolist()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -147,36 +147,45 @@ class CmdStanPathTest(unittest.TestCase):
                 pass
 
     def test_jsondump(self):
+        def cmp(d1, d2):
+            self.assertEqual(d1.keys(), d2.keys())
+            for k in d1:
+                data_1 = d1[k]
+                data_2 = d2[k]
+                if isinstance(data_2, np.ndarray):
+                    data_2 = data_2.tolist()
+                    self.assertEqual(data_1, data_2)
+
         dict_list = {'a': [1.0, 2.0, 3.0]}
         file_list = os.path.join(_TMPDIR, 'list.json')
         jsondump(file_list, dict_list)
         with open(file_list) as fd:
-            self.assertEqual(json.load(fd), dict_list)
+            cmp(json.load(fd), dict_list)
 
         dict_vec = {'a': np.repeat(3, 4)}
         file_vec = os.path.join(_TMPDIR, 'vec.json')
         jsondump(file_vec, dict_vec)
         with open(file_vec) as fd:
-            self.assertEqual(json.load(fd), dict_vec)
+            cmp(json.load(fd), dict_vec)
 
         dict_zero_vec = {'a': []}
         file_zero_vec = os.path.join(_TMPDIR, 'empty_vec.json')
         jsondump(file_zero_vec, dict_zero_vec)
         with open(file_zero_vec) as fd:
-            self.assertEqual(json.load(fd), dict_zero_vec)
+            cmp(json.load(fd), dict_zero_vec)
 
         dict_zero_matrix = {'a': [[], [], []]}
         file_zero_matrix = os.path.join(_TMPDIR, 'empty_matrix.json')
         jsondump(file_zero_matrix, dict_zero_matrix)
         with open(file_zero_matrix) as fd:
-            self.assertEqual(json.load(fd), dict_zero_matrix)
+            cmp(json.load(fd), dict_zero_matrix)
 
         arr = np.zeros(shape=(5, 0))
         dict_zero_matrix = {'a': arr}
         file_zero_matrix = os.path.join(_TMPDIR, 'empty_matrix.json')
         jsondump(file_zero_matrix, dict_zero_matrix)
         with open(file_zero_matrix) as fd:
-            self.assertEqual(json.load(fd), dict_zero_matrix)
+            cmp(json.load(fd), dict_zero_matrix)
 
 
 class ReadStanCsvTest(unittest.TestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -154,7 +154,7 @@ class CmdStanPathTest(unittest.TestCase):
                 data_2 = d2[k]
                 if isinstance(data_2, np.ndarray):
                     data_2 = data_2.tolist()
-                    self.assertEqual(data_1, data_2)
+                self.assertEqual(data_1, data_2)
 
         dict_list = {'a': [1.0, 2.0, 3.0]}
         file_list = os.path.join(_TMPDIR, 'list.json')


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

`utils.jsondump` alters the users dictionary... turning numpy arrays into lists.
This pull request ensures that the users input data dict remains the same after calling
say `sample`.

It's a surpise to find you code failing after calling sample... and then finding
all your numpy arrays are now simple lists.

Also... I ran the tests  with cmdstan 2.22.1 and your `test_model_syntax_error` failed.
Don't know what you what to do with that...

Most of the changes are in the test which also assumes this change has occured.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Copyright is yours now...


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

