### PR TITLE
added percentiles arg to summary command, unit tests

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -458,7 +458,7 @@ class CmdStanModel:
         :param parallel_chains: Number of processes to run in parallel. Must be
             a positive integer.  Defaults to ``multiprocessing.cpu_count()``.
 
-        :param threads_per_chain: the number of threads to use in parallelized
+        :param threads_per_chain: The number of threads to use in parallelized
             sections within an MCMC chain (e.g., when using the Stan functions
             ``reduce_sum()``  or ``map_rect()``).  This will only have an effect
             if the model was compiled with threading support. The total number

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -458,12 +458,11 @@ class CmdStanModel:
         :param parallel_chains: Number of processes to run in parallel. Must be
             a positive integer.  Defaults to ``multiprocessing.cpu_count()``.
 
-        :param threads_per_chain: If the model was compiled with threading support,
-            the number of threads to use in parallelized sections within an
-            MCMC chain (e.g., when using the Stan functions ``reduce_sum()``
-            or ``map_rect()``).  The total number of threads used will be
-            ``parallel_chains * threads_per_chain``.  If a model wasn't
-            compiled with threading support, has no effect.
+        :param threads_per_chain: the number of threads to use in parallelized
+            sections within an MCMC chain (e.g., when using the Stan functions
+            ``reduce_sum()``  or ``map_rect()``).  This will only have an effect
+            if the model was compiled with threading support. The total number
+            of threads used will be ``parallel_chains * threads_per_chain``.
 
         :param seed: The seed for random number generator. Must be an integer
             between 0 and 2^32 - 1. If unspecified,

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -525,8 +525,7 @@ class CmdStanMCMC:
                     )
                 cur_pct = pct
             percentiles_str = '='.join(
-                '--percentiles', 
-                ','.join(str(x) for x in percentiles)
+                ['--percentiles', ','.join([str(x) for x in percentiles])]
             )
         cmd_path = os.path.join(
             cmdstan_path(), 'bin', 'stansummary' + EXTENSION


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Added argument to CmdStanMCMC `summary` method allowing user to specify percentiles to report.
Added unit tests, while doing, made `diagnose` unit test a little less brittle.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

