### PR TITLE
Feature/238 validate csv opt

### DIFF
--- a/cmdstanpy/_version.py
+++ b/cmdstanpy/_version.py
@@ -1,3 +1,3 @@
 """PyPi Version"""
 
-__version__ = '0.9.62'
+__version__ = '0.9.63'

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -620,7 +620,7 @@ class CmdStanModel:
         if parallel_chains is None:
             parallel_chains = max(min(cpu_count(), chains), 1)
         elif parallel_chains > chains:
-            self._logger.warning(
+            self._logger.info(
                 'Requesting %u parallel_chains for %u chains,'
                 ' running all chains in parallel.',
                 parallel_chains,

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -436,6 +436,7 @@ class CmdStanModel:
         output_dir: str = None,
         save_diagnostics: bool = False,
         show_progress: Union[bool, str] = False,
+        validate_csv: bool = True,
     ) -> CmdStanMCMC:
         """
         Run or more chains of the NUTS sampler to produce a set of draws
@@ -579,6 +580,11 @@ class CmdStanModel:
         :param show_progress: Use tqdm progress bar to show sampling progress.
             If show_progress=='notebook' use tqdm_notebook
             (needs nodejs for jupyter).
+
+        :param validate_csv: If ``False``, skip scan of sample csv output file.
+            When sample is large or disk i/o is slow, will speed up processing.
+            Default is ``True`` - sample csv files are scanned for completeness
+            and consistency.
 
         :return: CmdStanMCMC object
         """
@@ -756,7 +762,7 @@ class CmdStanModel:
                     err_msg = '{}{}'.format(err_msg, ''.join(console_errs))
                 raise RuntimeError(err_msg)
 
-            mcmc = CmdStanMCMC(runset)
+            mcmc = CmdStanMCMC(runset, validate_csv, logger=self._logger)
         return mcmc
 
     def generate_quantities(

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import copy
 import logging
+import math
 from typing import List, Tuple, Dict
 from collections import Counter, OrderedDict
 from datetime import datetime
@@ -272,7 +273,13 @@ class CmdStanMCMC:
     Container for outputs from CmdStan sampler run.
     """
 
-    def __init__(self, runset: RunSet, validate_csv: bool = True) -> None:
+    # pylint: disable=too-many-instance-attributes
+    def __init__(
+        self,
+        runset: RunSet,
+        validate_csv: bool = True,
+        logger: logging.Logger = None,
+    ) -> None:
         """Initialize object."""
         if not runset.method == Method.SAMPLE:
             raise ValueError(
@@ -280,6 +287,7 @@ class CmdStanMCMC:
                 'found method {}'.format(runset.method)
             )
         self.runset = runset
+        self._logger = logger or get_logger()
         # copy info from runset
         self._is_fixed_param = runset._args.method_args.fixed_param
         self._iter_sampling = runset._args.method_args.iter_sampling
@@ -301,7 +309,6 @@ class CmdStanMCMC:
         self._validate_csv = validate_csv
         if validate_csv:
             self.validate_csv_files()
-
 
     def __repr__(self) -> str:
         repr = 'CmdStanMCMC: model={} chains={}{}'.format(
@@ -340,7 +347,6 @@ class CmdStanMCMC:
             return int(math.ceil(self._iter_warmup / self._thin))
         return self._draws_warmup
 
-
     @property
     def column_names(self) -> Tuple[str, ...]:
         """
@@ -351,10 +357,9 @@ class CmdStanMCMC:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
                 ' in order to retrieve sample metatdata.'
-                )
+            )
             return None
         return self._column_names
-            
 
     @property
     def stan_variable_dims(self) -> Dict:
@@ -367,7 +372,7 @@ class CmdStanMCMC:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
                 ' in order to retrieve sample metatdata.'
-                )
+            )
             return None
         return copy.deepcopy(self._stan_variable_dims)
 
@@ -383,7 +388,7 @@ class CmdStanMCMC:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
                 ' in order to retrieve sample metatdata.'
-                )
+            )
             return None
         return self._metric_type
 
@@ -399,7 +404,7 @@ class CmdStanMCMC:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
                 ' in order to retrieve sample metatdata.'
-                )
+            )
             return None
         if self._sample is None:
             self._assemble_sample()
@@ -417,7 +422,7 @@ class CmdStanMCMC:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
                 ' in order to retrieve sample metatdata.'
-                )
+            )
             return None
         if self._sample is None:
             self._assemble_sample()

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -356,7 +356,7 @@ class CmdStanMCMC:
         if not self._validate_csv and len(self._column_names) == 0:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
-                ' in order to retrieve sample metatdata.'
+                ' in order to retrieve sample metadata.'
             )
             return None
         return self._column_names
@@ -371,7 +371,7 @@ class CmdStanMCMC:
         if not self._validate_csv and len(self._stan_variable_dims) == 0:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
-                ' in order to retrieve sample metatdata.'
+                ' in order to retrieve sample metadata.'
             )
             return None
         return copy.deepcopy(self._stan_variable_dims)
@@ -387,7 +387,7 @@ class CmdStanMCMC:
         if not self._validate_csv and self._metric_type is None:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
-                ' in order to retrieve sample metatdata.'
+                ' in order to retrieve sample metadata.'
             )
             return None
         return self._metric_type
@@ -403,7 +403,7 @@ class CmdStanMCMC:
         if not self._validate_csv and self._metric is None:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
-                ' in order to retrieve sample metatdata.'
+                ' in order to retrieve sample metadata.'
             )
             return None
         if self._sample is None:
@@ -421,7 +421,7 @@ class CmdStanMCMC:
         if not self._validate_csv and self._stepsize is None:
             self._logger.warning(
                 'csv files not yet validated, run method validate_csv_files()'
-                ' in order to retrieve sample metatdata.'
+                ' in order to retrieve sample metadata.'
             )
             return None
         if self._sample is None:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -272,7 +272,7 @@ class CmdStanMCMC:
     Container for outputs from CmdStan sampler run.
     """
 
-    def __init__(self, runset: RunSet) -> None:
+    def __init__(self, runset: RunSet, validate_csv: bool = True) -> None:
         """Initialize object."""
         if not runset.method == Method.SAMPLE:
             raise ValueError(
@@ -298,7 +298,10 @@ class CmdStanMCMC:
         self._warmup = None
         self._drawset = None
         self._stan_variable_dims = {}
-        self._validate_csv_files()
+        self._validate_csv = validate_csv
+        if validate_csv:
+            self.validate_csv_files()
+
 
     def __repr__(self) -> str:
         repr = 'CmdStanMCMC: model={} chains={}{}'.format(
@@ -326,12 +329,17 @@ class CmdStanMCMC:
     @property
     def num_draws(self) -> int:
         """Number of post-warmup draws per chain."""
+        if not self._validate_csv and self._draws_sampling is None:
+            return int(math.ceil(self._iter_sampling / self._thin))
         return self._draws_sampling
 
     @property
     def num_draws_warmup(self) -> int:
         """Number of warmup draws per chain."""
+        if not self._validate_csv and self._draws_warmup is None:
+            return int(math.ceil(self._iter_warmup / self._thin))
         return self._draws_warmup
+
 
     @property
     def column_names(self) -> Tuple[str, ...]:
@@ -339,7 +347,14 @@ class CmdStanMCMC:
         Names of all per-draw outputs: all
         sampler and model parameters and quantities of interest
         """
+        if not self._validate_csv and len(self._column_names) == 0:
+            self._logger.warning(
+                'csv files not yet validated, run method validate_csv_files()'
+                ' in order to retrieve sample metatdata.'
+                )
+            return None
         return self._column_names
+            
 
     @property
     def stan_variable_dims(self) -> Dict:
@@ -348,6 +363,12 @@ class CmdStanMCMC:
         Scalar types have int value '1'.  Structured types have list of dims,
         e.g.,  program variable ``vector[10] foo`` has entry ``('foo', [10])``.
         """
+        if not self._validate_csv and len(self._stan_variable_dims) == 0:
+            self._logger.warning(
+                'csv files not yet validated, run method validate_csv_files()'
+                ' in order to retrieve sample metatdata.'
+                )
+            return None
         return copy.deepcopy(self._stan_variable_dims)
 
     @property
@@ -356,6 +377,14 @@ class CmdStanMCMC:
         Metric type used for adaptation, either 'diag_e' or 'dense_e'.
         When sampler algorithm 'fixed_param' is specified, metric_type is None.
         """
+        if self._is_fixed_param:
+            return None
+        if not self._validate_csv and self._metric_type is None:
+            self._logger.warning(
+                'csv files not yet validated, run method validate_csv_files()'
+                ' in order to retrieve sample metatdata.'
+                )
+            return None
         return self._metric_type
 
     @property
@@ -364,7 +393,15 @@ class CmdStanMCMC:
         Metric used by sampler for each chain.
         When sampler algorithm 'fixed_param' is specified, metric is None.
         """
-        if not self._is_fixed_param and self._metric is None:
+        if self._is_fixed_param:
+            return None
+        if not self._validate_csv and self._metric is None:
+            self._logger.warning(
+                'csv files not yet validated, run method validate_csv_files()'
+                ' in order to retrieve sample metatdata.'
+                )
+            return None
+        if self._sample is None:
             self._assemble_sample()
         return self._metric
 
@@ -374,7 +411,15 @@ class CmdStanMCMC:
         Stepsize used by sampler for each chain.
         When sampler algorithm 'fixed_param' is specified, stepsize is None.
         """
-        if not self._is_fixed_param and self._stepsize is None:
+        if self._is_fixed_param:
+            return None
+        if not self._validate_csv and self._stepsize is None:
+            self._logger.warning(
+                'csv files not yet validated, run method validate_csv_files()'
+                ' in order to retrieve sample metatdata.'
+                )
+            return None
+        if self._sample is None:
             self._assemble_sample()
         return self._stepsize
 
@@ -386,6 +431,8 @@ class CmdStanMCMC:
         so that the values for each parameter are stored contiguously
         in memory, likewise all draws from a chain are contiguous.
         """
+        if not self._validate_csv and self._sample is None:
+            self.validate_csv_files()
         if self._sample is None:
             self._assemble_sample()
         return self._sample
@@ -400,11 +447,13 @@ class CmdStanMCMC:
         """
         if not self._save_warmup:
             return None
+        if not self._validate_csv and self._sample is None:
+            self.validate_csv_files()
         if self._sample is None:
             self._assemble_sample()
         return self._warmup
 
-    def _validate_csv_files(self) -> None:
+    def validate_csv_files(self) -> None:
         """
         Checks that csv output files for all chains are consistent.
         Populates attributes for draws, column_names, num_params, metric_type.

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -258,7 +258,7 @@ class SampleTest(unittest.TestCase):
         log.check_present(
             (
                 'cmdstanpy',
-                'WARNING',
+                'INFO',
                 'Requesting 7 parallel_chains for 1 chains, '
                 'running all chains in parallel.',
             )


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add argument `validate_csv` to CmdStanModel `sample` method.

Tests locally and on cluster indicates that skipping validation of CSV file
results in a 10% speedup.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

