### PR TITLE
Feature/22 better error handling

### DIFF
--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -201,13 +201,6 @@ class RunSet:
         return True
 
     @property
-    def retcodes(self) -> List[int]:
-        """
-        List of return codes for all chains.
-        """
-        return self._retcodes
-
-    @property
     def diagnostic_files(self) -> List[str]:
         """
         List of paths to CmdStan diagnostic output files.

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -126,8 +126,19 @@ class RunSet:
     def __repr__(self) -> str:
         repr = 'RunSet: chains={}'.format(self._chains)
         repr = '{}\n cmd:\n\t{}'.format(repr, self._cmds[0])
-        repr = '{}\n csv_files:\n\t{}\n output_files:\n\t{}'.format(
-            repr, '\n\t'.join(self._csv_files), '\n\t'.join(self._stdout_files)
+        repr = '{}\n retcodes={}'.format(repr, self._retcodes)
+        repr = '{}\n csv_files:\n\t{}\n'.format(
+            repr, '\n\t'.join(self._csv_files)
+        )
+        if self._args.save_diagnostics:
+            repr = '{}\n diagnostics_files:\n\t{}\n'.format(
+                repr, '\n\t'.join(self._diagnostic_files)
+            )
+        repr = '{}\n console_msgs:\n\t{}\n'.format(
+            repr, '\n\t'.join(self._stdout_files)
+        )
+        repr = '{}\n error_msgs:\n\t{}\n'.format(
+            repr, '\n\t'.join(self._stderr_files)
         )
         return repr
 
@@ -183,6 +194,13 @@ class RunSet:
             if self._retcodes[i] != 0:
                 return False
         return True
+
+    @property
+    def retcodes(self) -> List[int]:
+        """
+        List of return codes for all chains.
+        """
+        return self._retcodes
 
     @property
     def diagnostic_files(self) -> List[str]:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -132,7 +132,7 @@ class RunSet:
                 repr, '\n\t'.join(self._csv_files)
             )
         if self._args.save_diagnostics and os.path.exists(
-            self._diagnostics_files[0]
+            self._diagnostic_files[0]
         ):
             repr = '{}\n diagnostics_files:\n\t{}'.format(
                 repr, '\n\t'.join(self._diagnostic_files)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -124,9 +124,7 @@ class OptimizeTest(unittest.TestCase):
         )
         exp_bound_model = CmdStanModel(stan_file=stan)
         no_data = {}
-        with self.assertRaisesRegex(
-            Exception, 'Error during optimizing, error code 70'
-        ):
+        with self.assertRaisesRegex(RuntimeError, 'Error during optimization'):
             exp_bound_model.optimize(
                 data=no_data, seed=1239812093, inits=None, algorithm='BFGS'
             )

--- a/test/test_runset.py
+++ b/test/test_runset.py
@@ -13,6 +13,26 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 
 
 class RunSetTest(unittest.TestCase):
+    def test_check_repr(self):
+        exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+        sampler_args = SamplerArgs()
+        chain_ids = [1, 2, 3, 4]  # default
+        cmdstan_args = CmdStanArgs(
+            model_name='bernoulli',
+            model_exe=exe,
+            chain_ids=chain_ids,
+            data=jdata,
+            method_args=sampler_args,
+        )
+        runset = RunSet(args=cmdstan_args)
+
+        self.assertIn('RunSet: chains=4', runset.__repr__())
+        self.assertIn('method=sample', runset.__repr__())
+        self.assertIn('retcodes=[-1, -1, -1, -1]', runset.__repr__())
+        self.assertIn('csv_files:', runset.__repr__())
+        self.assertNotIn('diagnostics_files:', runset.__repr__())
+
     def test_check_retcodes(self):
         exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
@@ -26,8 +46,6 @@ class RunSetTest(unittest.TestCase):
             method_args=sampler_args,
         )
         runset = RunSet(args=cmdstan_args)
-        self.assertIn('RunSet: chains=4', runset.__repr__())
-        self.assertIn('method=sample', runset.__repr__())
 
         retcodes = runset._retcodes
         self.assertEqual(4, len(retcodes))
@@ -60,7 +78,7 @@ class RunSetTest(unittest.TestCase):
             stdout_file = 'chain-' + str(i + 1) + '-missing-data-stdout.txt'
             path = os.path.join(DATAFILES_PATH, stdout_file)
             runset._stdout_files[i] = path
-        errs = '\n\t'.join(runset._get_err_msgs())
+        errs = runset.get_err_msgs()
         self.assertIn('Exception', errs)
 
     def test_output_filenames(self):

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -720,7 +720,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 DATAFILES_PATH, 'runset-bad', 'bad-transcript-bern-4.txt'
             ),
         ]
-        self.assertEqual(len(runset._get_err_msgs()), 4)
+        self.assertIn('Exception', runset.get_err_msgs())
 
         # csv file headers inconsistent
         runset._csv_files = [


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

When CmdStan method returns a non-zero error code, return as much useful information as can be scraped out of the stdout and stderr messages, plus information about the run and locations of resulting output files, if any.

Exposed and expanded `RunSet` method `get_err_msgs`; this function was written a long time ago, but wasn't being called by the CmdStanModel methods.  It attempts to get just the relevant messages from the information spew that's written to stdout, in addtion to all msgs written to stderr.  It seems to do an OK job on the most common and annoying problem - return code 70 which happens when there's a mismatch between the model's data block variable declarations and the input data.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

