### PR TITLE
cleanup/290-draws_as_dataframe

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -804,7 +804,7 @@ class CmdStanModel:
 
         if isinstance(mcmc_sample, CmdStanMCMC):
             sample_csv_files = mcmc_sample.runset.csv_files
-            sample_drawset = mcmc_sample.draws_as_dataframe()
+            sample_drawset = mcmc_sample.draws_pd()
             chains = mcmc_sample.chains
             chain_ids = mcmc_sample.chain_ids
         elif isinstance(mcmc_sample, list):
@@ -849,7 +849,7 @@ class CmdStanModel:
                 runset = RunSet(args=args, chains=chains, chain_ids=chain_ids)
                 runset._csv_files = sample_csv_files
                 sample_fit = CmdStanMCMC(runset)
-                sample_drawset = sample_fit.draws_as_dataframe()
+                sample_drawset = sample_fit.draws_pd()
         except ValueError as exc:
             raise ValueError(
                 'Invalid mcmc_sample, error:\n\t{}\n\t'

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -329,7 +329,7 @@ class CmdStanMCMC:
         self._metric = None
         self._stepsize = None
         self._draws = None
-        self._draws_as_df = None
+        self._draws_pd = None
         self._stan_variable_dims = {}
         self._validate_csv = validate_csv
         if validate_csv:
@@ -689,7 +689,7 @@ class CmdStanMCMC:
             self.runset._logger.info(result)
         return result
 
-    def draws_as_dataframe(
+    def draws_pd(
         self, params: List[str] = None, inc_warmup: bool = False
     ) -> pd.DataFrame:
         """
@@ -708,24 +708,24 @@ class CmdStanMCMC:
                 if not (param in self._column_names or param in pnames_base):
                     raise ValueError('unknown parameter: {}'.format(param))
         self._assemble_draws()
-        if self._draws_as_df is None:
+        if self._draws_pd is None:
             # pylint: disable=redundant-keyword-arg
             data = self.draws(inc_warmup=inc_warmup).reshape(
                 (self.num_draws * self.runset.chains),
                 len(self.column_names),
                 order='A',
             )
-            self._draws_as_df = pd.DataFrame(
+            self._draws_pd = pd.DataFrame(
                 data=data, columns=self.column_names
             )
         if params is None:
-            return self._draws_as_df
+            return self._draws_pd
         mask = []
         params = set(params)
         for name in self.column_names:
             if any(item in params for item in (name, name.split('[')[0])):
                 mask.append(name)
-        return self._draws_as_df[mask]
+        return self._draws_pd[mask]
 
     def stan_variable(self, name: str) -> pd.DataFrame:
         """

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -117,7 +117,7 @@ class GenerateQuantitiesTest(unittest.TestCase):
         ]
         self.assertEqual(bern_gqs.column_names, tuple(column_names))
         self.assertEqual(
-            bern_fit.draws_as_dataframe().shape, bern_gqs.mcmc_sample.shape
+            bern_fit.draws_pd().shape, bern_gqs.mcmc_sample.shape
         )
         self.assertEqual(
             bern_gqs.sample_plus_quantities.shape[1],

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -475,9 +475,9 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertEqual(len(BERNOULLI_COLS), len(fit.column_names))
         self.assertEqual('lp__', fit.column_names[0])
 
-        draws_df = fit.draws_as_dataframe()
+        draws_pd = fit.draws_pd()
         self.assertEqual(
-            draws_df.shape,
+            draws_pd.shape,
             (fit.runset.chains * fit.num_draws, len(fit.column_names)),
         )
 
@@ -535,22 +535,22 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertEqual(fit.stepsize.shape, (2,))
         self.assertEqual(fit.metric.shape, (2, 2095))
         self.assertEqual((1000, 2, 2102), fit.draws().shape)
-        phis = fit.draws_as_dataframe(params=['phi'])
+        phis = fit.draws_pd(params=['phi'])
         self.assertEqual((2000, 2095), phis.shape)
-        phi1 = fit.draws_as_dataframe(params=['phi[1]'])
+        phi1 = fit.draws_pd(params=['phi[1]'])
         self.assertEqual((2000, 1), phi1.shape)
-        mo_phis = fit.draws_as_dataframe(
+        mo_phis = fit.draws_pd(
             params=['phi[1]', 'phi[10]', 'phi[100]']
         )
         self.assertEqual((2000, 3), mo_phis.shape)
-        phi2095 = fit.draws_as_dataframe(params=['phi[2095]'])
+        phi2095 = fit.draws_pd(params=['phi[2095]'])
         self.assertEqual((2000, 1), phi2095.shape)
         with self.assertRaisesRegex(
             ValueError, r'unknown parameter: phi\[2096\]'
         ):
-            fit.draws_as_dataframe(params=['phi[2096]'])
+            fit.draws_pd(params=['phi[2096]'])
         with self.assertRaisesRegex(ValueError, 'unknown parameter: ph'):
-            fit.draws_as_dataframe(params=['ph'])
+            fit.draws_pd(params=['ph'])
 
     # pylint: disable=no-self-use
     def test_custom_metric(self):


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Resolves issue #290 by renaming `draws_as_dataframe` to `draws_pd` and `_draws_as_df` to `_draws_pd`. Locally, the test `test_multi_proc` fails in this branch, but also in develop.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Imad Ali



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

