### PR TITLE
Feature/227 cmdstan install

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -21,6 +21,8 @@ _TMPDIR = tempfile.mkdtemp()
 _CMDSTAN_WARMUP = 1000
 _CMDSTAN_SAMPLING = 1000
 _CMDSTAN_THIN = 1
+_DOT_CMDSTANPY = '.cmdstanpy'
+_DOT_CMDSTAN = '.cmdstan'
 
 
 def _cleanup_tmpdir():

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from time import sleep
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
-from cmdstanpy.utils import cmdstan_path, validate_dir
+from cmdstanpy.utils import validate_dir
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -14,7 +14,8 @@ import platform
 import subprocess
 import sys
 import tarfile
-import urllib.request, urllib.error
+import urllib.request
+import urllib.error
 from pathlib import Path
 from time import sleep
 
@@ -53,9 +54,8 @@ def install_version(cmdstan_version, overwrite):
         print('Building version {}'.format(cmdstan_version))
         if overwrite:
             print(
-                'Overwrite requested, remove existing build of version {}'.format(
-                    cmdstan_version
-                )
+                'Overwrite requested, remove existing build of version '
+                '{}'.format(cmdstan_version)
             )
             cmd = [make, 'clean-all']
             proc = subprocess.Popen(
@@ -110,17 +110,17 @@ def install_version(cmdstan_version, overwrite):
 
 
 def is_version_available(version):
-    is_OK = True
+    is_available = True
     url = (
         'https://github.com/stan-dev/cmdstan/releases/download/'
         'v{0}/cmdstan-{0}.tar.gz'.format(version)
     )
     for i in range(6):
         try:
-            conn = urllib.request.urlopen(url)
+            urllib.request.urlopen(url)
         except urllib.error.HTTPError as err:
             print('HTTPError: {}'.format(err.code))
-            is_OK = False
+            is_available = False
             break
         except urllib.error.URLError as err:
             print('URLError: {}'.format(err.reason))
@@ -132,8 +132,8 @@ def is_version_available(version):
                 )
                 sleep(1)
                 continue
-            is_OK = False
-    return is_OK
+            is_available = False
+    return is_available
 
 
 def latest_version():

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -62,7 +62,9 @@ def usage():
     )
 
 
-def install_version(cmdstan_version: str, overwrite: bool = False, verbose: bool = False):
+def install_version(
+    cmdstan_version: str, overwrite: bool = False, verbose: bool = False
+):
     """
     Build specified CmdStan version by spawning subprocesses to
     run the Make utility on the downloaded CmdStan release src files.
@@ -273,9 +275,7 @@ def main():
 
     cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
     if not os.path.exists(cmdstan_dir):
-        cmdstanpy_dir = os.path.expanduser(
-            os.path.join('~', _DOT_CMDSTANPY)
-        )
+        cmdstanpy_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
         if os.path.exists(cmdstanpy_dir):
             cmdstan_dir = cmdstanpy_dir
 

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -174,7 +174,9 @@ def latest_version():
                 print('retry ({}/5)'.format(i + 1))
                 sleep(1)
                 continue
-            raise CmdStanRetrieveError('Cannot connect to CmdStan github repo.')
+            raise CmdStanRetrieveError(
+                'Cannot connect to CmdStan github repo.'
+            ) from err
     with open(file_tmp, 'r') as fd:
         response = fd.read()
         start_idx = response.find('\"tag_name\":\"v') + len('"tag_name":"v')
@@ -199,7 +201,7 @@ def retrieve_version(version):
                 'Version {} not available from github.com.'.format(
                     err.code, version
                 )
-            )
+            ) from err
         except urllib.error.URLError as err:
             print(
                 'Failed to download CmdStan version {} from github.com'.format(
@@ -214,7 +216,7 @@ def retrieve_version(version):
             print('Version {} not available from github.com.'.format(version))
             raise CmdStanRetrieveError(
                 'Version {} not available from github.com.'.format(version)
-            )
+            ) from err
     print('Download successful, file: {}'.format(file_tmp))
     try:
         tar = tarfile.open(file_tmp)
@@ -224,7 +226,9 @@ def retrieve_version(version):
             target = r'\\?\{}'.format(target)
         tar.extractall(target)
     except Exception as err:  # pylint: disable=broad-except
-        raise CmdStanInstallError('Failed to unpack file {}'.format(file_tmp))
+        raise CmdStanInstallError(
+            'Failed to unpack file {}'.format(file_tmp)
+        ) from err
     finally:
         tar.close()
     print('Unpacked download as cmdstan-{}'.format(version))
@@ -235,10 +239,10 @@ def validate_dir(install_dir):
     if not os.path.exists(install_dir):
         try:
             os.makedirs(install_dir)
-        except (IOError, OSError, PermissionError) as e:
+        except (IOError, OSError, PermissionError) as err:
             raise ValueError(
                 'Cannot create directory: {}'.format(install_dir)
-            ) from e
+            ) from err
     else:
         if not os.path.isdir(install_dir):
             raise ValueError(
@@ -248,10 +252,10 @@ def validate_dir(install_dir):
             with open('tmp_test_w', 'w'):
                 pass
             os.remove('tmp_test_w')  # cleanup
-        except (IOError, OSError, PermissionError) as e:
+        except (IOError, OSError, PermissionError) as err:
             raise ValueError(
                 'Cannot write files to directory {}'.format(install_dir)
-            ) from e
+            ) from err
 
 
 def main():

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -3,7 +3,7 @@
 Download and install a CmdStan release from GitHub.
 Optional command line arguments:
    -v, --version : version, defaults to latest
-   -d, --dir : install directory, defaults to '~/.cmdstanpy
+   -d, --dir : install directory, defaults to '~/.cmdstan(py)
    -c --compiler : add C++ compiler to path (Windows only)
 """
 import argparse
@@ -16,6 +16,8 @@ import tarfile
 import urllib.request
 from pathlib import Path
 from time import sleep
+
+from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
@@ -201,9 +203,13 @@ def main():
         version = latest_version()
     print('CmdStan version: {}'.format(version))
 
+    cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+    if not os.path.exists(cmdstan_dir):
+        cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
+
     install_dir = vars(args)['dir']
     if install_dir is None:
-        install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
+        install_dir = cmdstan_dir
     validate_dir(install_dir)
     print('Install directory: {}'.format(install_dir))
 
@@ -214,7 +220,7 @@ def main():
         )
         from .utils import cxx_toolchain_path
 
-        cxx_loc = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
+        cxx_loc = cmdstan_dir
         compiler_found = False
         for cxx_version in ['40', '35']:
             if _is_installed_cxx(cxx_loc, cxx_version):
@@ -242,4 +248,5 @@ def main():
 
 
 if __name__ == '__main__':
+    print(sys.argv[:1])
     main()

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -41,7 +41,7 @@ class CmdStanInstallError(RuntimeError):
 
 
 @contextlib.contextmanager
-def pushd(new_dir):
+def pushd(new_dir: str):
     """Acts like pushd/popd."""
     previous_dir = os.getcwd()
     os.chdir(new_dir)
@@ -56,13 +56,22 @@ def usage():
         -v (--version) :CmdStan version
         -d (--dir) : install directory
         --overwrite : replace installed version
+        --verbose : show CmdStan build messages
         -h (--help) : this message
         """
     )
 
 
-def install_version(cmdstan_version, overwrite, verbose):
-    """Build specified CmdStan version."""
+def install_version(cmdstan_version: str, overwrite: bool = False, verbose: bool = False):
+    """
+    Build specified CmdStan version by spawning subprocesses to
+    run the Make utility on the downloaded CmdStan release src files.
+    Assumes that current working directory is parent of release dir.
+
+    :param cmdstan_version: CmdStan release, corresponds to release dirname.
+    :param overwrite: when ``True``, run ``make clean-all`` before building.
+    :param verbose: when ``True``, print build msgs to stdout.
+    """
     with pushd(cmdstan_version):
         make = os.getenv(
             'MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make'
@@ -131,7 +140,7 @@ def install_version(cmdstan_version, overwrite, verbose):
     print('Installed {}'.format(cmdstan_version))
 
 
-def is_version_available(version):
+def is_version_available(version: str):
     is_available = True
     url = (
         'https://github.com/stan-dev/cmdstan/releases/download/'
@@ -185,7 +194,7 @@ def latest_version():
     return response[start_idx:end_idx]
 
 
-def retrieve_version(version):
+def retrieve_version(version: str):
     """Download specified CmdStan version."""
     print('Downloading CmdStan version {}'.format(version))
     url = (

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -7,7 +7,7 @@ Currently implemented platforms (platform.system)
     Linux: Not implemented
 Optional command line arguments:
    -v, --version : version, defaults to latest
-   -d, --dir : install directory, defaults to '~/.cmdstanpy
+   -d, --dir : install directory, defaults to '~/.cmdstan(py)
    -s (--silent) : install with /VERYSILENT instead of /SILENT for RTools
    -m --no-make : don't install mingw32-make (Windows RTools 4.0 only)
 """
@@ -21,6 +21,9 @@ import sys
 import urllib.request
 from collections import OrderedDict
 from time import sleep
+
+from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
+
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 IS_64BITS = sys.maxsize > 2 ** 32
@@ -297,7 +300,10 @@ def main():
 
     install_dir = vars(args)['dir']
     if install_dir is None:
-        install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
+        cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+        if not os.path.exists(cmdstan_dir):
+            cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
+        install_dir = cmdstan_dir
     validate_dir(install_dir)
     print('Install directory: {}'.format(install_dir))
 

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from time import sleep
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
-from cmdstanpy.utils import cmdstan_path, validate_dir
+from cmdstanpy.utils import validate_dir
 
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -23,6 +23,7 @@ from collections import OrderedDict
 from time import sleep
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
+from cmdstanpy.utils import cmdstan_path, validate_dir
 
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
@@ -209,30 +210,6 @@ def retrieve_toolchain(filename, url):
     print('Download successful, file: {}'.format(filename))
 
 
-def validate_dir(install_dir):
-    """Check that specified install directory exists, can write."""
-    if not os.path.exists(install_dir):
-        try:
-            os.makedirs(install_dir)
-        except (IOError, OSError, PermissionError) as e:
-            raise ValueError(
-                'Cannot create directory: {}'.format(install_dir)
-            ) from e
-    else:
-        if not os.path.isdir(install_dir):
-            raise ValueError(
-                'File exists, should be a directory: {}'.format(install_dir)
-            )
-        try:
-            with open('tmp_test_w', 'w'):
-                pass
-            os.remove('tmp_test_w')  # cleanup
-        except OSError as e:
-            raise ValueError(
-                'Cannot write files to directory {}'.format(install_dir)
-            ) from e
-
-
 def normalize_version(version):
     """Return maj.min part of version string."""
     if platform.system() == 'Windows':
@@ -302,7 +279,11 @@ def main():
     if install_dir is None:
         cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
         if not os.path.exists(cmdstan_dir):
-            cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
+            cmdstanpy_dir = os.path.expanduser(
+                os.path.join('~', _DOT_CMDSTANPY)
+            )
+            if os.path.exists(cmdstanpy_dir):
+                cmdstan_dir = cmdstanpy_dir
         install_dir = cmdstan_dir
     validate_dir(install_dir)
     print('Install directory: {}'.format(install_dir))

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -44,7 +44,7 @@ def get_logger():
     return logger
 
 
-def get_latest_cmdstan(dot_dir: str) -> str:
+def get_latest_cmdstan(cmdstan_dir: str) -> str:
     """
     Given a valid directory path, find all installed CmdStan versions
     and return highest (i.e., latest) version number.
@@ -52,8 +52,8 @@ def get_latest_cmdstan(dot_dir: str) -> str:
     """
     versions = [
         name.split('-')[1]
-        for name in os.listdir(dot_dir)
-        if os.path.isdir(os.path.join(dot_dir, name))
+        for name in os.listdir(cmdstan_dir)
+        if os.path.isdir(os.path.join(cmdstan_dir, name))
         and name.startswith('cmdstan-')
         and name[8].isdigit()
     ]
@@ -271,19 +271,19 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
                 )
                 toolchain_root = ''
     else:
-        dot_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
-        if not os.path.exists(dot_dir):
-            dot_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+        cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+        if not os.path.exists(cmdstan_dir):
+            cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
         rtools_dir = os.path.expanduser(
-            os.path.join('~', dot_dir, 'RTools40')
+            os.path.join('~', cmdstan_dir, 'RTools40')
         )
         if not os.path.exists(rtools_dir):
             rtools_dir = os.path.expanduser(
-                os.path.join('~', dot_dir, 'RTools35')
+                os.path.join('~', cmdstan_dir, 'RTools35')
             )
             if not os.path.exists(rtools_dir):
                 rtools_dir = os.path.expanduser(
-                    os.path.join('~', dot_dir, 'RTools')
+                    os.path.join('~', cmdstan_dir, 'RTools')
                 )
                 if not os.path.exists(rtools_dir):
                     raise ValueError(
@@ -291,9 +291,9 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str]:
                         'run command line script "install_cxx_toolchain"'
                     )
             else:
-                rtools_dir = os.path.expanduser(os.path.join('~', dot_dir))
+                rtools_dir = os.path.expanduser(os.path.join('~', cmdstan_dir))
         else:
-            rtools_dir = os.path.expanduser(os.path.join('~', dot_dir))
+            rtools_dir = os.path.expanduser(os.path.join('~', cmdstan_dir))
         compiler_path = ''
         tool_path = ''
         if version not in ('35', '3.5', '3') and os.path.exists(

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -44,7 +44,7 @@ def get_logger():
     return logger
 
 
-def validate_dir(install_dir):
+def validate_dir(install_dir: str):
     """Check that specified install directory exists, can write."""
     if not os.path.exists(install_dir):
         try:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -904,7 +904,9 @@ def create_named_text_file(dir: str, prefix: str, suffix: str) -> str:
     return path
 
 
-def install_cmdstan(version: str = None, dir: str = None) -> bool:
+def install_cmdstan(version: str = None,
+                    dir: str = None,
+                    overwrite: bool = False) -> bool:
     """
     Run 'install_cmdstan' -script
     """
@@ -912,20 +914,23 @@ def install_cmdstan(version: str = None, dir: str = None) -> bool:
     python = sys.executable
     here = os.path.dirname(os.path.abspath(__file__))
     path = os.path.join(here, 'install_cmdstan.py')
-    cmd = [python, path]
+    cmd = [python, "-u", path]
     if version is not None:
         cmd.extend(['--version', version])
     if dir is not None:
         cmd.extend(['--dir', dir])
+    if overwrite:
+        cmd.extend(['--overwrite', "TRUE"])
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ
     )
-    # while proc.poll() is None:
-    #     output = proc.stdout.readline().decode('utf-8').strip()
-    #     if output:
-    #        logger.info(output)
-    proc.communicate()
+    while proc.poll() is None:
+        print(proc.stdout.readline().decode('utf-8').strip())
+
+    _, stderr = proc.communicate()
     if proc.returncode:
-        logger.warning('CmdStan installation failed')
+        logger.warning('CmdStan installation failed.')
+        if stderr:
+            logger.warning(stderr.decode('utf-8').strip())
         return False
     return True

--- a/docsrc/api.rst
+++ b/docsrc/api.rst
@@ -57,3 +57,35 @@ RunSet
 
 .. autoclass:: cmdstanpy.stanfit.RunSet
    :members:
+
+*********
+Functions
+*********
+
+.. _function_cmdstan_path:
+
+cmdstan_path
+============
+
+.. autofunction:: cmdstanpy.cmdstan_path
+
+.. _function_install_cmdstan:
+
+install_cmstan
+==============
+
+.. autofunction:: cmdstanpy.install_cmdstan
+
+.. _function_set_cmdstan_path:
+
+set_cmdstan_path
+================
+
+.. autofunction:: cmdstanpy.set_cmdstan_path
+
+.. _function_set_make_env:
+
+set_make_env
+============
+
+.. autofunction:: cmdstanpy.set_make_env

--- a/docsrc/hello_world.rst
+++ b/docsrc/hello_world.rst
@@ -41,7 +41,7 @@ The data file specifies the number of observations and their values.
 Specify a Stan model
 ^^^^^^^^^^^^^^^^^^^^
 
-The: :ref:`class_cmdstanmodel` class manages the Stan program and its corresponding compiled executable.
+The :ref:`class_cmdstanmodel` class manages the Stan program and its corresponding compiled executable.
 It provides properties and functions to inspect the model code and filepaths.
 By default, the Stan program is compiled on instantiation.
 

--- a/docsrc/installation.rst
+++ b/docsrc/installation.rst
@@ -21,6 +21,7 @@ command line using ``pip``:
 The optional packages are
 
   * ``tqdm`` which allows for progress bar display during sampling
+  * ``ujson`` which provides faster IO
 
 To install CmdStanPy with all the optional packages:
 
@@ -57,11 +58,14 @@ consisting of a modern C++ compiler and the GNU-Make utility.
 Function ``install_cmdstan``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CmdStanPy provides the function ``install_cmdstan`` which
+CmdStanPy provides the function :ref:`function_install_cmdstan` which
 downloads CmdStan from GitHub and builds the CmdStan utilities.
 It can be can be called from within Python or from the command line.
-By default it installs the latest version of CmdStan into a directory named
-``.cmdstanpy`` in your ``$HOME`` directory:
+
+The default install location is a hidden directory in the user ``$HOME`` directory
+named ``.cmdstan``.  (In earlier versions, the hidden directory was named ``.cmdstanpy``,
+and if directory ``$HOME/.cmdstanpy`` exists, it will continue to be used as the
+default install dir.)  This directory will be created by the install script.
 
 + From Python
 
@@ -75,14 +79,14 @@ By default it installs the latest version of CmdStan into a directory named
 .. code-block:: bash
 
     install_cmdstan
-    ls -F ~/.cmdstanpy
+    ls -F ~/.cmdstan
 
 + On Windows
 
 .. code-block:: bash
 
     python -m cmdstanpy.install_cmdstan
-    dir "%HOME%/.cmdstanpy"
+    dir "%HOME%/.cmdstan"
 
 The named arguments: `-d <directory>` and  `-v <version>`
 can be used to override these defaults:
@@ -92,17 +96,20 @@ can be used to override these defaults:
     install_cmdstan -d my_local_cmdstan -v 2.20.0
     ls -F my_local_cmdstan
 
-DIY Installion 
-^^^^^^^^^^^^^^
+DIY Installation 
+^^^^^^^^^^^^^^^^
 
 If you with to install CmdStan yourself, follow the instructions
 in the `CmdStan User's Guide <https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html>`__.
 
-Post Installion: Setting Environment Variables
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Post Installation: Setting Environment Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default for the CmdStan installation location
-is a directory named ``.cmdstanpy`` in your ``$HOME`` directory.
+is a directory named ``.cmdstan`` in your ``$HOME`` directory.
+(In earlier versions, the hidden directory was named ``.cmdstanpy``,
+and if directory ``$HOME/.cmdstanpy`` exists, it will continue to be used as the
+default install dir.)
 
 If you have installed CmdStan in a different directory,
 then you can set the environment variable ``CMDSTAN`` to this
@@ -130,5 +137,3 @@ To use custom ``make``-tool use ``set_make_env`` function.
 
     from cmdstanpy import set_make_env
     set_make_env("mingw32-make.exe") # On Windows with mingw32-make
-
-

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,1 +1,2 @@
 tqdm
+ujson

--- a/test/test_install_cmdstan.py
+++ b/test/test_install_cmdstan.py
@@ -5,9 +5,9 @@ import unittest
 from cmdstanpy.install_cmdstan import (
     is_version_available,
     latest_version,
-    validate_dir,
+    retrieve_version,
+    CmdStanRetrieveError,
 )
-from cmdstanpy.utils import cmdstan_path
 
 
 class InstallCmdStanTest(unittest.TestCase):
@@ -17,30 +17,19 @@ class InstallCmdStanTest(unittest.TestCase):
         self.assertFalse(is_version_available('2.222.222-rc222'))
 
     def test_latest_version(self):
-        # parse version into Maj, min, patch
-        # Maj between 1 and 99
-        # min between 1 and 99
-        # p starts with digit
-        # examples of known previous version:  2.24.0-rc1, 2.23.0
+        # examples of known previous version:  2.24-rc1, 2.23.0
         version = latest_version()
         nums = version.split('.')
-        self.assertEqual(len(nums), 3)
-        for num in nums:
-            self.assertTrue(num[0].isdigit())
+        self.assertTrue(len(nums) >= 2)
+        self.assertTrue(nums[0][0].isdigit())
+        self.assertTrue(nums[1][0].isdigit())
 
     def test_retrieve_version(self):
         # check http error for bad version
-        self.assertTrue(True)
-
-    def test_validate_dir(self):
-        # get cmdstan path; should be valid
-        # create directory, chmod to no write
-        # create file
-        # with self.assertRaisesRegex(ValueError, 'Cannot create directory'):
-        #     validate_dir(path_foo)
-        path = cmdstan_path()
-        validate_dir(path)
-        self.assertTrue(True)
+        with self.assertRaisesRegex(
+            CmdStanRetrieveError, 'not available from github.com'
+        ):
+            retrieve_version('no_such_version')
 
 
 if __name__ == '__main__':

--- a/test/test_install_cmdstan.py
+++ b/test/test_install_cmdstan.py
@@ -1,0 +1,48 @@
+"""install_cmdstan test"""
+
+import unittest
+
+from cmdstanpy.install_cmdstan import (
+    is_version_available,
+    latest_version,
+#    retrieve_version,
+    validate_dir,
+)
+from cmdstanpy.utils import cmdstan_path
+
+
+class InstallCmdStanTest(unittest.TestCase):
+    def test_is_version_available(self):
+        # check http error for bad version
+        self.assertTrue(is_version_available('2.24.1'))
+        self.assertFalse(is_version_available('2.222.222-rc222'))
+
+    def test_latest_version(self):
+        # parse version into Maj, min, patch
+        # Maj between 1 and 99
+        # min between 1 and 99
+        # p starts with digit
+        # examples of known previous version:  2.24.0-rc1, 2.23.0
+        version = latest_version()
+        nums = version.split('.')
+        self.assertEqual(len(nums), 3)
+        for num in nums:
+            self.assertTrue(num[0].isdigit())
+
+    def test_retrieve_version(self):
+        # check http error for bad version
+        self.assertTrue(True)
+
+    def test_validate_dir(self):
+        # get cmdstan path; should be valid
+        # create directory, chmod to no write
+        # create file
+        # with self.assertRaisesRegex(ValueError, 'Cannot create directory'):
+        #     validate_dir(path_foo)
+        path = cmdstan_path()
+        validate_dir(path)
+        self.assertTrue(True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_install_cmdstan.py
+++ b/test/test_install_cmdstan.py
@@ -5,7 +5,6 @@ import unittest
 from cmdstanpy.install_cmdstan import (
     is_version_available,
     latest_version,
-#    retrieve_version,
     validate_dir,
 )
 from cmdstanpy.utils import cmdstan_path

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -159,7 +159,6 @@ class CmdStanPathTest(unittest.TestCase):
                 os.chmod(dir, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
                 validate_dir(os.path.join(dir, 'cmdstan-M.m.p'))
 
-
     def test_munge_cmdstan_versions(self):
         tdir = os.path.join(HERE, 'tmpdir_xxx')
         os.mkdir(tdir)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,7 +10,7 @@ import random
 
 import numpy as np
 
-from cmdstanpy import _TMPDIR
+from cmdstanpy import _TMPDIR, _DOT_CMDSTAN, _DOT_CMDSTANPY
 from cmdstanpy.utils import (
     cmdstan_path,
     set_cmdstan_path,
@@ -48,12 +48,10 @@ class CmdStanPathTest(unittest.TestCase):
                 self.assertEqual(cmdstan_path(), path)
                 self.assertTrue('CMDSTAN' in os.environ)
             else:
-                install_dir = os.path.expanduser(
-                    os.path.join('~', '.cmdstanpy')
-                )
-                install_version = os.path.expanduser(
-                    os.path.join(install_dir, get_latest_cmdstan(install_dir))
-                )
+                cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+                if not os.path.exists(cmdstan_dir):
+                    cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
+                install_version = os.path.join(cmdstan_dir, get_latest_cmdstan(cmdstan_dir))
                 self.assertTrue(
                     os.path.samefile(cmdstan_path(), install_version)
                 )
@@ -99,19 +97,19 @@ class CmdStanPathTest(unittest.TestCase):
         if 'CMDSTAN' in os.environ:
             self.assertEqual(cmdstan_path(), os.environ['CMDSTAN'])
         else:
-            install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
-            install_version = os.path.expanduser(
-                os.path.join(install_dir, get_latest_cmdstan(install_dir))
-            )
+            cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+            if not os.path.exists(cmdstan_dir):
+                cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
+            install_version = os.path.join(cmdstan_dir, get_latest_cmdstan(cmdstan_dir))
             set_cmdstan_path(install_version)
             self.assertEqual(install_version, cmdstan_path())
             self.assertEqual(install_version, os.environ['CMDSTAN'])
 
     def test_validate_path(self):
-        install_dir = os.path.expanduser(os.path.join('~', '.cmdstanpy'))
-        install_version = os.path.expanduser(
-            os.path.join(install_dir, get_latest_cmdstan(install_dir))
-        )
+        cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+        if not os.path.exists(cmdstan_dir):
+            cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
+        install_version = os.path.join(cmdstan_dir, get_latest_cmdstan(cmdstan_dir))
         set_cmdstan_path(install_version)
         validate_cmdstan_path(install_version)
         path_foo = os.path.abspath(os.path.join('releases', 'foo'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -140,6 +140,15 @@ class CmdStanPathTest(unittest.TestCase):
             validate_cmdstan_path(path_test)
         shutil.rmtree(folder_name)
 
+    def test_munge_cmdstan_versions(self):
+        tdir = os.path.join(HERE, 'tmpdir_xxx')
+        os.mkdir(tdir)
+        os.mkdir(os.path.join(tdir, 'cmdstan-2.22-rc1'))
+        os.mkdir(os.path.join(tdir, 'cmdstan-2.22-rc2'))
+        os.mkdir(os.path.join(tdir, 'cmdstan-2.22.0'))
+        self.assertEqual(get_latest_cmdstan(tdir), 'cmdstan-2.22.0')
+        shutil.rmtree(tdir, ignore_errors=True)
+
     def test_dict_to_file(self):
         file_good = os.path.join(DATAFILES_PATH, 'bernoulli_output_1.csv')
         dict_good = {'a': 0.5}

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -48,10 +48,16 @@ class CmdStanPathTest(unittest.TestCase):
                 self.assertEqual(cmdstan_path(), path)
                 self.assertTrue('CMDSTAN' in os.environ)
             else:
-                cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+                cmdstan_dir = os.path.expanduser(
+                    os.path.join('~', _DOT_CMDSTAN)
+                )
                 if not os.path.exists(cmdstan_dir):
-                    cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
-                install_version = os.path.join(cmdstan_dir, get_latest_cmdstan(cmdstan_dir))
+                    cmdstan_dir = os.path.expanduser(
+                        os.path.join('~', _DOT_CMDSTANPY)
+                    )
+                install_version = os.path.join(
+                    cmdstan_dir, get_latest_cmdstan(cmdstan_dir)
+                )
                 self.assertTrue(
                     os.path.samefile(cmdstan_path(), install_version)
                 )
@@ -99,8 +105,12 @@ class CmdStanPathTest(unittest.TestCase):
         else:
             cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
             if not os.path.exists(cmdstan_dir):
-                cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
-            install_version = os.path.join(cmdstan_dir, get_latest_cmdstan(cmdstan_dir))
+                cmdstan_dir = os.path.expanduser(
+                    os.path.join('~', _DOT_CMDSTANPY)
+                )
+            install_version = os.path.join(
+                cmdstan_dir, get_latest_cmdstan(cmdstan_dir)
+            )
             set_cmdstan_path(install_version)
             self.assertEqual(install_version, cmdstan_path())
             self.assertEqual(install_version, os.environ['CMDSTAN'])
@@ -109,7 +119,9 @@ class CmdStanPathTest(unittest.TestCase):
         cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
         if not os.path.exists(cmdstan_dir):
             cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
-        install_version = os.path.join(cmdstan_dir, get_latest_cmdstan(cmdstan_dir))
+        install_version = os.path.join(
+            cmdstan_dir, get_latest_cmdstan(cmdstan_dir)
+        )
         set_cmdstan_path(install_version)
         validate_cmdstan_path(install_version)
         path_foo = os.path.abspath(os.path.join('releases', 'foo'))


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Cleanup function `install_cmdstan` (`cmdstanpy/utils.py`) and corresponding script `install_cmdstan.py` per issues #227 and #262 

- Constants, logic, and documentation for directories for local install of CmdStan
- Added arguments "overwrite" and "verbose" to function `install_cmdstan`
- Function `install_cmdstan` now streams output from subprocess (was blocking)
- Added logic so that release candidate names sort properly w/r/t releases
- Added a few unit tests for functions in script `install_cmdstan.py`, (more needed)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

