### PR TITLE
Enable per chain options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ htmlcov
 docsrc/_build
 .idea
 .DS_Store
+*.hpp
+*.exe

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -527,7 +527,15 @@ class CmdStanMCMC:
                 )
                 for key in dzero:
                     if (
-                        key not in ['id', 'diagnostic_file']
+                        key
+                        not in [
+                            'id',
+                            'diagnostic_file',
+                            'metric_file',
+                            'stepsize',
+                            'init',
+                            'seed',
+                        ]
                         and dzero[key] != drest[key]
                     ):
                         raise ValueError(
@@ -715,9 +723,7 @@ class CmdStanMCMC:
                 len(self.column_names),
                 order='A',
             )
-            self._draws_pd = pd.DataFrame(
-                data=data, columns=self.column_names
-            )
+            self._draws_pd = pd.DataFrame(data=data, columns=self.column_names)
         if params is None:
             return self._draws_pd
         mask = []
@@ -759,10 +765,10 @@ class CmdStanMCMC:
                 names.append(column_name)
                 idxs.append(i)
         return pd.DataFrame(
-            self._draws[
-                self._draws_warmup:, :, idxs
-            ].reshape((dim0, dims), order='A'),
-            columns=names
+            self._draws[self._draws_warmup :, :, idxs].reshape(
+                (dim0, dims), order='A'
+            ),
+            columns=names,
         )
 
     def stan_variables(self) -> Dict:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -941,9 +941,10 @@ class MaybeDictToFilePath:
                 for i, obj_item in enumerate(obj):
                     if not isinstance(obj_item, str):
                         err_msgs.append(
-                            'List element {} must be a filename string, found {}'.format(
-                                i, obj_item
-                            )
+                            (
+                                'List element {} must be a filename string,'
+                                ' found {}'
+                            ).format(i, obj_item)
                         )
                     elif not os.path.exists(obj_item):
                         missing_obj_items.append(

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -908,7 +908,9 @@ def install_cmdstan(
 class MaybeDictToFilePath:
     """Context manager for json files."""
 
-    def __init__(self, *objs: Union[str, dict], logger: logging.Logger = None):
+    def __init__(
+        self, *objs: Union[str, dict, list], logger: logging.Logger = None
+    ):
         self._unlink = [False] * len(objs)
         self._paths = [''] * len(objs)
         self._logger = logger or get_logger()
@@ -932,6 +934,20 @@ class MaybeDictToFilePath:
             elif isinstance(obj, str):
                 if not os.path.exists(obj):
                     raise ValueError("File doesn't exist {}".format(obj))
+                self._paths[i] = obj
+            elif isinstance(obj, list):
+                if not all(isinstance(obj_item, str) for obj_item in obj):
+                    raise ValueError("Not all list items are str")
+                missing_obj_items = []
+                for obj_item in obj:
+                    if not os.path.exists(obj_item):
+                        missing_obj_items.append(obj_item)
+                if missing_obj_items:
+                    raise ValueError(
+                        "File doesn't exist: {}".format(
+                            ", ".join(missing_obj_items)
+                        )
+                    )
                 self._paths[i] = obj
             elif obj is None:
                 self._paths[i] = None

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -938,7 +938,7 @@ class MaybeDictToFilePath:
             elif isinstance(obj, list):
                 err_msgs = []
                 missing_obj_items = []
-                for i, obj_item in obj:
+                for i, obj_item in enumerate(obj):
                     if not isinstance(obj_item, str):
                         err_msgs.append(
                             'List element {} must be a filename string, found {}'.format(

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -936,18 +936,23 @@ class MaybeDictToFilePath:
                     raise ValueError("File doesn't exist {}".format(obj))
                 self._paths[i] = obj
             elif isinstance(obj, list):
-                if not all(isinstance(obj_item, str) for obj_item in obj):
-                    raise ValueError("Not all list items are str")
+                err_msgs = []
                 missing_obj_items = []
-                for obj_item in obj:
-                    if not os.path.exists(obj_item):
-                        missing_obj_items.append(obj_item)
-                if missing_obj_items:
-                    raise ValueError(
-                        "File doesn't exist: {}".format(
-                            ", ".join(missing_obj_items)
+                for i, obj_item in obj:
+                    if not isinstance(obj_item, str):
+                        err_msgs.append(
+                            'List element {} must be a filename string, found {}'.format(
+                                i, obj_item
+                            )
                         )
-                    )
+                    elif not os.path.exists(obj_item):
+                        missing_obj_items.append(
+                            "File doesn't exist: {}".format(obj_item)
+                        )
+                if err_msgs:
+                    raise ValueError('\n'.join(err_msgs))
+                if missing_obj_items:
+                    raise ValueError('\n'.join(missing_obj_items))
                 self._paths[i] = obj
             elif obj is None:
                 self._paths[i] = None

--- a/rtd_change_default_version.py
+++ b/rtd_change_default_version.py
@@ -3,8 +3,9 @@ import sys
 
 # This scrip accepts 4 arguments in order:
 # Project name in readthedocs, readthedocs username, readthedocs password and version in readthedocs to set as default.
-# Example: 
+# Example:
 # python3 change_default_version.py cmdstanpy snick secretpassword stable-0.9.66
+
 
 def get_csrf_token(cookies):
     if 'csrftoken' in cookies:
@@ -14,44 +15,59 @@ def get_csrf_token(cookies):
         # older versions
         return cookies['csrf']
 
-def set_version_active_on_rtd(project_slug, rtd_user, rtd_password, default_version, server_addr = "https://readthedocs.org"):
+
+def set_version_active_on_rtd(
+    project_slug,
+    rtd_user,
+    rtd_password,
+    default_version,
+    server_addr="https://readthedocs.org",
+):
 
     with requests.session() as s:
 
         url = server_addr + "/accounts/login/"
-        
+
         # Fetch the login page
         s.get(url)
         # Extract CSRF token
         csrftoken = get_csrf_token(s.cookies)
 
         # Build out login data
-        login_data = dict(login=rtd_user, password=rtd_password, csrfmiddlewaretoken=csrftoken, next='/')
+        login_data = dict(
+            login=rtd_user,
+            password=rtd_password,
+            csrfmiddlewaretoken=csrftoken,
+            next='/',
+        )
         # Post login request
         r = s.post(url, data=login_data, headers=dict(Referer=url))
 
         # Set url for dashboard/advanced
-        url = server_addr+"/dashboard/"+project_slug+"/advanced/"
+        url = server_addr + "/dashboard/" + project_slug + "/advanced/"
         # Extract CSRF token
         csrftoken = get_csrf_token(s.cookies)
 
         # Build out version data
         version_data = {
-            'csrfmiddlewaretoken': csrftoken, 
-            'default_version': default_version, 
-            'default_branch': 'develop', 
-            'analytics_code': '', 
+            'csrfmiddlewaretoken': csrftoken,
+            'default_version': default_version,
+            'default_branch': 'develop',
+            'analytics_code': '',
             'documentation_type': 'sphinx',
             'requirements_file': '',
             'python_interpreter': 'python',
             'conf_py_file': 'docsrc/conf.py',
             'enable_pdf_build': 'on',
             'enable_epub_build': 'on',
-            'save': 'Save'
+            'save': 'Save',
         }
 
         # Post our version data
-        r = s.post(url, data = version_data, headers=dict(Referer=url))
+        r = s.post(url, data=version_data, headers=dict(Referer=url))
+
 
 if __name__ == '__main__':
-    set_version_active_on_rtd(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+    set_version_active_on_rtd(
+        sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+    )

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -116,9 +116,7 @@ class GenerateQuantitiesTest(unittest.TestCase):
             'y_rep[10]',
         ]
         self.assertEqual(bern_gqs.column_names, tuple(column_names))
-        self.assertEqual(
-            bern_fit.draws_pd().shape, bern_gqs.mcmc_sample.shape
-        )
+        self.assertEqual(bern_fit.draws_pd().shape, bern_gqs.mcmc_sample.shape)
         self.assertEqual(
             bern_gqs.sample_plus_quantities.shape[1],
             bern_gqs.mcmc_sample.shape[1]

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -199,7 +199,7 @@ class SampleTest(unittest.TestCase):
             inits=inits_path1,
         )
         self.assertIn(
-            'init={}'.format(inits_path1.replace("\\", "\\\\")),
+            'init={}'.format(inits_path1.replace('\\', '\\\\')),
             bern_fit.runset.__repr__(),
         )
 
@@ -212,7 +212,7 @@ class SampleTest(unittest.TestCase):
             inits=[inits_path1, inits_path2],
         )
         self.assertIn(
-            'init={}'.format(inits_path1.replace("\\", "\\\\")),
+            'init={}'.format(inits_path1.replace('\\', '\\\\')),
             bern_fit.runset.__repr__(),
         )
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -647,7 +647,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             data=jdata,
             chains=2,
             parallel_chains=2,
-            seed=[12345, 12347],
+            seed=[44444, 55555],
             iter_sampling=200,
         )
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR fixes the bug which caused per chain options to fail.

Now user can set these values individually per chain: `stepsize`, `inits`, `metric_file`, `seed`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

