### PR TITLE
IndexError bugfix for per-chain initialisation

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -990,13 +990,13 @@ class MaybeDictToFilePath:
             elif isinstance(obj, list):
                 err_msgs = []
                 missing_obj_items = []
-                for i, obj_item in enumerate(obj):
+                for j, obj_item in enumerate(obj):
                     if not isinstance(obj_item, str):
                         err_msgs.append(
                             (
                                 'List element {} must be a filename string,'
                                 ' found {}'
-                            ).format(i, obj_item)
+                            ).format(j, obj_item)
                         )
                     elif not os.path.exists(obj_item):
                         missing_obj_items.append(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Reuse of variable `i` inside `MaybeDictToFilePath` causing error when list of strings used to initialise parameters on line 1009. Fixed by renaming to `j`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

I am the copyright holder of this submission and agree to license it under BSD 3-clause

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
