### PR TITLE
Additional initialisation options for `CmdStanModel.sample`

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -198,6 +198,23 @@ class CmdStanPathTest(unittest.TestCase):
             with MaybeDictToFilePath(123, dict_good) as (fg1, fg2):
                 pass
 
+    def test_dicts_to_file(self):
+        file_good = os.path.join(DATAFILES_PATH, 'bernoulli_output_1.csv')
+        files_good = [file_good] * 3
+        dicts_good = [{'a': 0.5 + 0.1 * i} for i in range(3)]
+        created_tmp = None
+        with MaybeDictToFilePath(files_good, dicts_good) as (fg1, fg2):
+            for f in fg1:
+                self.assertTrue(os.path.exists(f))
+            for i, f in enumerate(fg2):
+                self.assertTrue(os.path.exists(f))
+                with open(f) as f_d:
+                    self.assertEqual(json.load(f_d), dicts_good[i])
+            created_tmp = fg2
+        self.assertTrue(os.path.exists(file_good))
+        for f in created_tmp:
+            self.assertFalse(os.path.exists(f))
+
     def test_jsondump(self):
         def cmp(d1, d2):
             self.assertEqual(d1.keys(), d2.keys())


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Hi again, thanks for the great package, I'm enjoying playing around with it a lot.

This PR allows more flexible initialisation of parameters when using `CmdStanModel.sample`. In particular it allows initialisation via a function which optionally takes `chain_id` as an argument. I have tried to be faithful to the logic and error reporting present in [the relevant parts of cmdstanr](https://github.com/stan-dev/cmdstanr/blob/c84fab987d48b0ccc2ba635b631b75c5e12b1ea4/R/args.R#L703-L720)

The approach I took was to call the initialisation function if passed inside `sample` to create a list of dictionaries, then allow `MaybeDictToFilePath` to take care of the rest, mainly as `MaybeDictToFilePath` doesn't have visibility on `chain_ids`. This required also making sure that `MaybeDictToFilePath` can handle lists of dictionaries as well as single dictionaries. I have added a test for this new behaviour.

Very happy to take guidance on whether the approach here is right, whether I've added enough input validation and whether more test coverage is needed.

Fixes #49 

#### Copyright and Licensing

I am the copyright holder of this work and agree to the terms of the license.

