### PR TITLE
stdout/stderr on popen  handling  (for windows)

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -39,7 +39,7 @@ from ._version import __version__  # noqa
 from .model import CmdStanModel  # noqa
 from .stanfit import CmdStanGQ, CmdStanMCMC, CmdStanMLE, CmdStanVB  # noqa
 from .utils import set_cmdstan_path  # noqa
-from .utils import cmdstan_path, install_cmdstan, set_make_env
+from .utils import cmdstan_path, install_cmdstan, set_make_env  # noqa
 
 __all__ = [
     'set_cmdstan_path',

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -117,7 +117,9 @@ def install_version(
             if proc.returncode:
                 msgs = ['Command "make clean-all" failed']
                 if stderr:
-                    msgs.append(stderr.decode(sys.stdin.encoding, errors='ignore').strip())
+                    msgs.append(stderr.
+                                decode(sys.stdin.encoding, errors='ignore')
+                                .strip())
                 raise CmdStanInstallError('\n'.join(msgs))
             print('Rebuilding version {}'.format(cmdstan_version))
         cmd = [make, 'build']
@@ -132,7 +134,9 @@ def install_version(
         while proc.poll() is None:
             if not proc.wait_newline(0.5):
                 continue
-            output = proc.qout.readline().decode(sys.stdin.encoding, errors='ignore').strip()
+            output = proc.qout.readline().\
+                decode(sys.stdin.encoding, errors='ignore').\
+                strip()
             if verbose and len(output) != 0:
                 print(output, flush=True)
         proc.wait_log()

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -29,10 +29,9 @@ import urllib.request
 from collections import OrderedDict
 from pathlib import Path
 from time import sleep
-import sys
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
-from cmdstanpy.utils import validate_dir,proc_readline_ext
+from cmdstanpy.utils import validate_dir, proc_readline_ext
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
@@ -103,12 +102,14 @@ def install_version(
                 stderr=subprocess.PIPE,
                 env=os.environ,
             )
-            proc_readline_ext(proc,stdout_log=False,stderr_readline=False)
+            proc_readline_ext(proc, stdout_log=False, stderr_readline=False)
             while proc.poll() is None:
-                if(not proc.wait_newline(0.5)): continue
+                if not proc.wait_newline(0.5):
+                    continue
                 output = proc.qout.readline()
-                if(len(output)==0):continue
-                output=output.decode(sys.stdin.encoding, errors='ignore').strip()
+                if len(output) == 0:
+                    continue
+                output = output.decode(sys.stdin.encoding, errors='ignore').strip()
                 if verbose and output:
                     print(output, flush=True)
             proc.wait_log()
@@ -127,11 +128,12 @@ def install_version(
             stderr=subprocess.PIPE,
             env=os.environ,
         )
-        proc_readline_ext(proc,stdout_log=False,stderr_readline=False)
+        proc_readline_ext(proc, stdout_log=False, stderr_readline=False)
         while proc.poll() is None:
-            if(not proc.wait_newline(0.5)): continue
-            output=proc.qout.readline().decode(sys.stdin.encoding, errors='ignore').strip()
-            if verbose and len(output)!=0:
+            if not proc.wait_newline(0.5):
+                continue
+            output = proc.qout.readline().decode(sys.stdin.encoding, errors='ignore').strip()
+            if verbose and len(output) != 0:
                 print(output, flush=True)
         proc.wait_log()
         stderr = proc.get_stderr_log()
@@ -166,14 +168,15 @@ def install_version(
             stderr=subprocess.PIPE,
             env=os.environ,
         )
-        proc_readline_ext(proc,stdout_log=False,stderr_readline=False)
+        proc_readline_ext(proc, stdout_log=False, stderr_readline=False)
         while proc.poll() is None:
-            if(not proc.wait_newline(0.5)): continue
-            if(not proc.wait_newline(0.5)): continue
+            if not proc.wait_newline(0.5):
+                continue
             output = proc.qout.readline()
-            if(len(output)==0):continue
-            output=output.decode(sys.stdin.encoding, errors='ignore').strip()
-            if verbose and len(output)!=0:
+            if len(output) == 0:
+                continue
+            output = output.decode(sys.stdin.encoding, errors='ignore').strip()
+            if verbose and len(output) != 0:
                 print(output, flush=True)
         proc.wait_log()
         stderr = proc.get_stderr_log()

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 from time import sleep
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
-from cmdstanpy.utils import validate_dir,proc_readline_ext
+from cmdstanpy.utils import validate_dir, proc_readline_ext
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 IS_64BITS = sys.maxsize > 2 ** 32
@@ -93,11 +93,13 @@ def install_version(
             stderr=subprocess.PIPE,
             env=os.environ,
         )
-        proc_readline_ext(proc,stdout_log=False,stderr_readline=False)
+        proc_readline_ext(proc, stdout_log=False, stderr_readline=False)
         while proc.poll() is None:
-            if(not proc.wait_newline(0.5)): continue
-            o=proc.qout.readline()
-            if(len(o)==0):continue
+            if not proc.wait_newline(0.5):
+                continue
+            o = proc.qout.readline()
+            if len(o) == 0:
+                continue
             output = o.decode(sys.stdin.encoding, errors='ignore').strip()
             if output and verbose:
                 print(output, flush=True)
@@ -148,11 +150,13 @@ def install_mingw32_make(toolchain_loc, verbose=False):
             stderr=subprocess.PIPE,
             env=os.environ,
         )
-        proc_readline_ext(proc,stdout_log=False,stderr_readline=False)
+        proc_readline_ext(proc, stdout_log=False, stderr_readline=False)
         while proc.poll() is None:
-            if(not proc.wait_newline(0.5)): continue
-            o=proc.qout.readline()
-            if(len(o)==0):continue
+            if not proc.wait_newline(0.5):
+                continue
+            o = proc.qout.readline()
+            if len(o) == 0:
+                continue
             output = o.decode(sys.stdin.encoding, errors='ignore').strip()
             if output and verbose:
                 print(output, flush=True)

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1086,7 +1086,7 @@ class CmdStanModel:
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ
         )
-        proc_readline_ext(proc,stderr_readline=False)
+        proc_readline_ext(proc, stderr_readline=False)
         if pbar:
             self._read_progress(proc, pbar, idx)
         proc.wait_log()
@@ -1121,14 +1121,16 @@ class CmdStanModel:
 
         try:
             # iterate while process is sampling
-            running=True
+            running = True
             while running:
                 if(not proc.poll() is None):
                     proc.wait_log()
-                    running=False
-                if(not proc.wait_newline(0.5)): continue
+                    running = False
+                if(not proc.wait_newline(0.5)):
+                    continue
                 output = proc.qout.readline()
-                if(len(output)==0):continue
+                if len(output) == 0:
+                    continue
                 output = output.decode(sys.stdin.encoding, errors='ignore').strip()
                 if output.startswith('Iteration'):
                     match = re.search(pattern_compiled, output)
@@ -1161,4 +1163,3 @@ class CmdStanModel:
                 idx,
                 repr(e),
             )
-

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -484,7 +484,7 @@ class CmdStanMCMC:
             self._assemble_draws()
         if not inc_warmup:
             if self._save_warmup:
-                return self._draws[self._draws_warmup :, :, :]
+                return self._draws[self._draws_warmup:, :, :]
             return self._draws
         else:
             if not self._save_warmup:
@@ -821,7 +821,7 @@ class CmdStanMCMC:
                 names.append(column_name)
                 idxs.append(i)
         return pd.DataFrame(
-            self._draws[self._draws_warmup :, :, idxs].reshape(
+            self._draws[self._draws_warmup:, :, idxs].reshape(
                 (dim0, dims), order='A'
             ),
             columns=names,

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -941,11 +941,13 @@ def install_cmdstan(
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ
     )
-    proc_readline_ext(proc,stdout_log=False,stderr_readline=False)
+    proc_readline_ext(proc, stdout_log=False, stderr_readline=False)
     while proc.poll() is None:
-        if(not proc.wait_newline(0.5)): continue
-        output=proc.qout.readline()
-        if(len(output) == 0):continue
+        if not proc.wait_newline(0.5):
+            continue
+        output = proc.qout.readline()
+        if len(output) == 0:
+            continue
         print(output.decode(sys.stdin.encoding, errors='ignore').strip())
     proc.wait_log()
     stderr = proc.get_stderr_log()
@@ -1068,58 +1070,69 @@ class TemporaryCopiedFile:
             shutil.rmtree(self._tmpdir, ignore_errors=True)
 
 
-def proc_readline_ext(proc,stdout_log=True,stderr_log=True,stdout_readline=True,stderr_readline=True):
-    from threading  import Thread
+def proc_readline_ext(proc, stdout_log=True, stderr_log=True,
+                        stdout_readline=True, stderr_readline=True):
+    from threading import Thread
     from queue import Queue, Empty
     from time import sleep
 
     qout = Queue()
     qerr = Queue()
-    log=[b'',b'']#0:stdout,1:stderr
-    
-    def _enqueue_output(out, queue,log_id):
-        def _r(): 
+    log = [b'', b'']  # 0:stdout,1:stderr
+
+    def _enqueue_output(out, queue, log_id):
+        def _r():
             for line in iter(out.readline, b''):
-                if(not queue is None): queue.put(line)
-                if(0<=log_id):log[log_id]+=line
+                if queue is not None:
+                    queue.put(line)
+                if 0 <= log_id:
+                    log[log_id] += line
             out.close()
         return _r
 
     def _readline_nowait(q):
         def _r():
-            try: 
+            try:
                 return q.get_nowait()
             except Empty:
                 return ''
         return _r
-    
-    to= Thread(target=_enqueue_output(proc.stdout,qout if stdout_readline else None,0 if stdout_log else -1 ) )
-    to.daemon = True # thread dies with the program
+
+    to = Thread(target=_enqueue_output(proc.stdout,
+                qout if stdout_readline else None, 0 if stdout_log else -1))
+    to.daemon = True  # thread dies with the program
     to.start()
-    te= Thread(target=_enqueue_output(proc.stderr, qerr if stderr_readline else None,1 if stderr_log else -1))
-    te.daemon = True 
+    te = Thread(target=_enqueue_output(proc.stderr,
+                qerr if stderr_readline else None, 1 if stderr_log else -1))
+    te.daemon = True
     te.start()
-    
+
     def no_newline():
         return qout.empty() and qerr.empty()
+
     def wait_newline(timeout=0.5):
         if(no_newline()):
             sleep(0.5)
             return False
         return True
-        
-    qout.readline=_readline_nowait(qout)
-    qerr.readline=_readline_nowait(qerr)
-    proc.qout=qout
-    proc.qerr=qerr    
+
+    qout.readline = _readline_nowait(qout)
+    qerr.readline = _readline_nowait(qerr)
+    proc.qout = qout
+    proc.qerr = qerr
+
     def get_stdout_log():
         return log[0]
+
     def get_stderr_log():
         return log[1]
+
     proc.get_stdout_log = get_stdout_log
     proc.get_stderr_log = get_stderr_log
-    proc.wait_newline=wait_newline
+    proc.wait_newline = wait_newline
+
     def wait_log():
         to.join()
         te.join()
+
     proc.wait_log = wait_log

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -822,7 +822,10 @@ def do_command(cmd: str, cwd: str = None, logger: logging.Logger = None) -> str:
     if proc.returncode:
         msg = 'ERROR\n'
         if stderr:
-            msg = '{}{} '.format(msg, stderr.decode(sys.stdin.encoding, errors='ignore').strip())
+            msg = '{}{} '.format(msg,
+                                 stderr.
+                                 decode(sys.stdin.encoding, errors='ignore')
+                                 .strip())
         raise RuntimeError(msg)
     if stdout:
         return stdout.decode(sys.stdin.encoding, errors='ignore').strip()
@@ -955,7 +958,9 @@ def install_cmdstan(
     if proc.returncode:
         logger.warning('CmdStan installation failed.')
         if stderr:
-            logger.warning(stderr.decode(sys.stdin.encoding, errors='ignore').strip())
+            logger.warning(stderr.
+                           decode(sys.stdin.encoding, errors='ignore')
+                           .strip())
         return False
     return True
 
@@ -1071,7 +1076,7 @@ class TemporaryCopiedFile:
 
 
 def proc_readline_ext(proc, stdout_log=True, stderr_log=True,
-                        stdout_readline=True, stderr_readline=True):
+                      stdout_readline=True, stderr_readline=True):
     from threading import Thread
     from queue import Queue, Empty
     from time import sleep

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -11,7 +11,7 @@ import tqdm
 from testfixtures import LogCapture
 
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.utils import EXTENSION, cmdstan_path
+from cmdstanpy.utils import EXTENSION, cmdstan_path, proc_readline_ext
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DATAFILES_PATH = os.path.join(HERE, 'data')
@@ -259,7 +259,9 @@ class CmdStanModelTest(unittest.TestCase):
         ]
 
         with LogCapture() as log:
-            result = model._read_progress(proc=proc_mock, pbar=pbar, idx=0)
+            proc_readline_ext(proc_mock, stderr_readline=False)
+            model._read_progress(proc=proc_mock, pbar=pbar, idx=0)
+            result = proc_mock.get_stdout_log()
             self.assertEqual([], log.actual())
             self.assertEqual(31000, pbar.total)
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests (On Ubuntu)
- [x] Declare copyright holder and open-source license: see below

#### Summary
Fix for windows (I tested it on python 3.8.6 /windows10 Japanese locale )
・Pseudo non-block IO for subprocess.Popen  stdout/stderr
・Use system.stdin.encoding insisted of 'utf-8' for bytes.decode('utf-8')

Some stan model have many warning message (ex. bad initial value of sampling),
In case of that cmdstanpy on windows will hangs up. 
Because Windows have not enough buffer for pipe-stderr, so you have to use non-block IO.
I add Pseudo non-block IO extension function. (Windows have no fnctl funcitons)

In many case,Windows don't use 'utf-8'  for terminal.
But 'utf-8' was hard coded.It's no problem for just sampling(cmdstan outputs ASCII only), 
but it's harmful for install_cmdstan/install_cxx_toolcain . 

Anyway now I can run cmdstanpy on windows and Ubuntu with this patch,


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Akira NODA @ Shimadzu corp.


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

