### PR TITLE
[WIP] Move release from Jenkins to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 jobs:
   cmdstanpy:
-    name: tests and publish
+    name: tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,12 +86,3 @@ jobs:
         run: |
           cd run_tests
           codecov
-
-      - name: Upload to pypi
-        if: success() && startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python -m pip install --no-cache-dir twine
-          python -m twine upload -u ${TWINE_USERNAME} -p ${TWINE_PASSWORD} --skip-existing dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CmdStanPyRelease
+name: ReleaseCmdStanPy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:
       new_version:
         description: 'New version, for example: 0.9.69'     
         required: true
-      old_version:
-        description: 'Old version, for example: 0.9.68'
-        required: true
 
 jobs:
   release-cmdstanpy:
@@ -42,7 +39,7 @@ jobs:
         run: |
           git checkout -b release/v${{ github.event.inputs.new_version }}
 
-          sed -i 's/${{ github.event.inputs.old_version }}/${{ github.event.inputs.new_version }}/g' cmdstanpy/_version.py
+          sed -i 's/^__version__ = .*$/__version__ = '\''${{ github.event.inputs.new_version }}'\''/g' cmdstanpy/_version.py
           
           cd docsrc
           make github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,4 +87,4 @@ jobs:
         env:
           RTD_USERNAME: ${{ secrets.RTD_USERNAME }}
           RTD_PASSWORD: ${{ secrets.RTD_PASSWORD }}
-        run: python3 rtd_change_default_version.py cmdstanpy ${RTD_USERNAME} ${RTD_PASSWORD} v${{ github.event.inputs.new_version }}
+        run: python rtd_change_default_version.py cmdstanpy ${RTD_USERNAME} ${RTD_PASSWORD} v${{ github.event.inputs.new_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: CmdStanPyRelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: 'New version, for example: 0.9.67'     
+        required: true
+      old_version:
+        description: 'Old version, for example: 0.9.66'     
+        required: true
+
+jobs:
+  cmdstanpy:
+    name: publish release and read the docs update
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+      fail-fast: false
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out github
+        uses: actions/checkout@v2
+
+      - name: Create release branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          git checkout -b release/v${{ github.event.inputs.new_version }}
+          sed -i 's/${{ github.event.inputs.old_version }}/${{ github.event.inputs.new_version }}/g' cmdstanpy/_version.py
+          
+          cd docsrc
+          make github
+          cd ..
+          
+          git commit -m "release/v${{ github.event.inputs.new_version }}: updating version numbers" -a
+          git push -u origin release/v${{ github.event.inputs.new_version }}
+          
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-test.txt
           pip install codecov
-          
+          pip install sphinx
+
       - name: Create release branch
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           pip install -r requirements-test.txt
           pip install codecov
           pip install sphinx
+          pip install sphinx_rtd_theme
 
       - name: Create release branch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,19 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
+      
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies (python)
+        run: |
+          pip install --upgrade pip wheel
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+          pip install codecov
+          
       - name: Create release branch
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,14 @@
 name: ReleaseCmdStanPy
 
-env:
-  new_version: '0.9.68'
-  old_version: '0.9.67'
-
 on:
-  push:
-    branches:    
-    - 'move-release-to-gh-actions'
   workflow_dispatch:
     inputs:
       new_version:
-        description: 'New version, for example: 0.9.68'     
+        description: 'New version, for example: 0.9.69'     
         required: true
-        default: '0.9.68'
       old_version:
-        description: 'Old version, for example: 0.9.67'
+        description: 'Old version, for example: 0.9.68'
         required: true
-        default: '0.9.67'
 
 jobs:
   release-cmdstanpy:
@@ -28,8 +19,6 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.9]
       fail-fast: false
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
@@ -41,28 +30,61 @@ jobs:
 
       - name: Install dependencies (python)
         run: |
-          pip install --upgrade pip wheel
+          pip install --upgrade pip wheel twine codecov sphinx sphinx_rtd_theme requests
           pip install -r requirements.txt
-          pip install -r requirements-test.txt
-          pip install codecov
-          pip install sphinx
-          pip install sphinx_rtd_theme
 
-      - name: Create release branch
+      - name: Setup git identity
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git submodule update --init --recursive
-          
-          git checkout -b release/v${{ env.new_version }}
-          sed -i 's/${{ env.old_version }}/${{ env.new_version }}/g' cmdstanpy/_version.py
+      - name: Create release branch
+        run: |
+          git checkout -b release/v${{ github.event.inputs.new_version }}
+
+          sed -i 's/${{ github.event.inputs.old_version }}/${{ github.event.inputs.new_version }}/g' cmdstanpy/_version.py
           
           cd docsrc
           make github
           cd ..
           
-          git commit -m "release/v${{ env.new_version }}: updating version numbers" -a
-          git push -u origin release/v${{ env.new_version }}
+          git commit -m "release/v${{ github.event.inputs.new_version }}: updating version numbers" -a
+          git push -u origin release/v${{ github.event.inputs.new_version }}
           
-          
+      - name: Merge into develop
+        run: |
+          git checkout develop
+          git reset --hard v${{ github.event.inputs.new_version }}
+          git push origin develop
+
+      - name: Tag version
+        run: |
+          git checkout develop
+          git tag -a "v${{ github.event.inputs.new_version }}" -m "Tagging v${{ github.event.inputs.new_version }}"
+          git push origin "v${{ github.event.inputs.new_version }}"
+
+      - name: Update master to new released version
+        run: |
+          git checkout master
+          git reset --hard v${{ github.event.inputs.new_version }}
+          git push origin master
+      
+      - name: Build wheel
+        run: python setup.py bdist_wheel
+
+      - name: Install bdist_wheel
+        run: pip install dist/*.whl
+      
+      - name: Upload to pypi
+        if: success()
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: python -m twine upload -u ${TWINE_USERNAME} -p ${TWINE_PASSWORD} --skip-existing dist/*
+
+      - name: Change default version in readthedocs.io
+        if: success()
+        env:
+          RTD_USERNAME: ${{ secrets.RTD_USERNAME }}
+          RTD_PASSWORD: ${{ secrets.RTD_PASSWORD }}
+        run: python3 rtd_change_default_version.py cmdstanpy ${RTD_USERNAME} ${RTD_PASSWORD} v${{ github.event.inputs.new_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   release-cmdstanpy:
-    name: publish release and read the docs update
+    name: publish release and update read the docs default version
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: ReleaseCmdStanPy
 
 on:
+  push:
+    branches:    
+    - 'move-release-to-gh-actions'
   workflow_dispatch:
     inputs:
       new_version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       new_version:
-        description: 'New version, for example: 0.9.67'     
+        description: 'New version, for example: 0.9.68'     
         required: true
+        default: '0.9.68'
       old_version:
-        description: 'Old version, for example: 0.9.66'     
+        description: 'Old version, for example: 0.9.67'
         required: true
+        default: '0.9.67'
 
 jobs:
   release-cmdstanpy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
 jobs:
-  cmdstanpy:
+  release-cmdstanpy:
     name: publish release and read the docs update
     runs-on: ${{ matrix.os }}
     strategy:
@@ -22,7 +22,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Check out github
+      - name: Check out source code
         uses: actions/checkout@v2
 
       - name: Create release branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: ReleaseCmdStanPy
 
+env:
+  new_version: '0.9.68'
+  old_version: '0.9.67'
+
 on:
   push:
     branches:    
@@ -22,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9]
       fail-fast: false
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -34,15 +38,17 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git submodule update --init --recursive
           
-          git checkout -b release/v${{ github.event.inputs.new_version }}
-          sed -i 's/${{ github.event.inputs.old_version }}/${{ github.event.inputs.new_version }}/g' cmdstanpy/_version.py
+          git checkout -b release/v${{ env.new_version }}
+          sed -i 's/${{ env.old_version }}/${{ env.new_version }}/g' cmdstanpy/_version.py
           
           cd docsrc
           make github
           cd ..
           
-          git commit -m "release/v${{ github.event.inputs.new_version }}: updating version numbers" -a
-          git push -u origin release/v${{ github.event.inputs.new_version }}
+          git commit -m "release/v${{ env.new_version }}: updating version numbers" -a
+          git push -u origin release/v${{ env.new_version }}
           
           


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR will move the release process from a [Jenkins Job](https://github.com/stan-dev/cmdstanpy/blob/develop/Jenkinsfile) to Github Actions.

It's a workflow triggered manually, with two parameters:

* new_version - New version to release, for example: 0.9.68

When triggered it will do the following:
- Create a release branch out of develop
  - Update version in `cmdstanpy/_version.py`
  - Generate docs
  - Push branch
- Merge release branch into develop
- Create a tag out of develop
- Update master to new version
- Build wheels
- Install Wheels
- Upload to pypi
- Update default version in `readthedocs` to the new version released

Note!!! The [main](https://github.com/stan-dev/cmdstanpy/blob/develop/.github/workflows/main.yml) workflow is not pushing the package to pypi anymore, it will just run the tests. The workflow in this PR will handle tagging, releasing and publishing to pypi.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Toptal



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

