### PR TITLE
define empty stdin for Popen calls

### DIFF
--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -98,6 +98,7 @@ def install_version(
             proc = subprocess.Popen(
                 cmd,
                 cwd=None,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 env=os.environ,
@@ -117,6 +118,7 @@ def install_version(
         proc = subprocess.Popen(
             cmd,
             cwd=None,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=os.environ,
@@ -153,6 +155,7 @@ def install_version(
         proc = subprocess.Popen(
             cmd,
             cwd=None,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=os.environ,

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -89,6 +89,7 @@ def install_version(
         proc = subprocess.Popen(
             cmd,
             cwd=None,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=os.environ,
@@ -139,6 +140,7 @@ def install_mingw32_make(toolchain_loc, verbose=False):
         proc = subprocess.Popen(
             cmd,
             cwd=None,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=os.environ,

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1101,7 +1101,11 @@ class CmdStanModel:
         )
         self._logger.debug('sampling: %s', cmd)
         proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ,
         )
         if pbar:
             stdout_pbar = self._read_progress(proc, pbar, idx)

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -839,6 +839,7 @@ def do_command(cmd: str, cwd: str = None, logger: logging.Logger = None) -> str:
     proc = subprocess.Popen(
         cmd,
         cwd=cwd,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=os.environ,
@@ -969,7 +970,11 @@ def install_cmdstan(
     if verbose:
         cmd.extend(['--verbose', 'TRUE'])
     proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ,
     )
     while proc.poll() is None:
         print(proc.stdout.readline().decode('utf-8').strip())


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

We don't use stdin so we can use `subprocess.DEVNULL`. This enables CmdStanPy to execute on a RStudio (and similar) environments.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

