### PR TITLE
broaden type check to include numpy scalars (in addition to `ndarray`)

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -370,7 +370,7 @@ def jsondump(path: str, data: Dict) -> None:
     """Dump a dict of data to a JSON file."""
     data = data.copy()
     for key, val in data.items():
-        if isinstance(val, np.ndarray):
+        if type(val).__module__ == 'numpy':
             val = val.tolist()
             data[key] = val
     with open(path, 'w') as fd:

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -10,6 +10,8 @@ import unittest
 from multiprocessing import cpu_count
 from time import time
 
+import numpy as np
+
 import pytest
 from testfixtures import LogCapture
 
@@ -151,6 +153,17 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(bern_fit.draws().shape, (100, 2, len(BERNOULLI_COLS)))
 
         data_dict = {'N': 10, 'y': [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
+        bern_fit = bern_model.sample(
+            data=data_dict,
+            chains=2,
+            parallel_chains=2,
+            seed=12345,
+            iter_sampling=100,
+        )
+        self.assertEqual(bern_fit.draws().shape, (100, 2, len(BERNOULLI_COLS)))
+
+        np_scalr_10 = np.int32(10)
+        data_dict = {'N': np_scalr_10, 'y': [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
         bern_fit = bern_model.sample(
             data=data_dict,
             chains=2,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -186,6 +186,8 @@ class CmdStanPathTest(unittest.TestCase):
         cmdstan_path()  # sets os.environ['CMDSTAN']
         self.assertFalse(cmdstan_version_at(99, 99))
 
+
+class DataFilesTest(unittest.TestCase):
     def test_dict_to_file(self):
         file_good = os.path.join(DATAFILES_PATH, 'bernoulli_output_1.csv')
         dict_good = {'a': 0.5}
@@ -253,6 +255,14 @@ class CmdStanPathTest(unittest.TestCase):
         jsondump(file_3d_matrix, dict_3d_matrix)
         with open(file_3d_matrix) as fd:
             cmp(json.load(fd), dict_3d_matrix)
+
+        scalr = np.int32(1)
+        self.assertTrue(type(scalr).__module__ == 'numpy')
+        dict_scalr = {'a': scalr}
+        file_scalr = os.path.join(_TMPDIR, 'scalr.json')
+        jsondump(file_scalr, dict_scalr)
+        with open(file_scalr) as fd:
+            cmp(json.load(fd), dict_scalr)
 
 
 class ReadStanCsvTest(unittest.TestCase):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

JSON serialization currently falls down if the `data` dictionary values include numpy scalars (with `TypeError: $SCALAR is not JSON serializable`). Fix type-check to catch these, in addition to arrays (the `tolist()` conversion still works as expected to convert to builtin `int`/`float`).

#### Copyright and Licensing

I am the copyright holder of this work and agree to the terms of the license.
