### PR TITLE
Add refresh argument to CmdStanModel.sample

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -628,6 +628,12 @@ class CmdStanArgs:
                     'invalid path for output files,'
                     ' cannot write to dir: {}'.format(self.output_dir)
                 ) from exc
+        if self.refresh is not None:
+            if not isinstance(self.refresh, int) or self.refresh < 1:
+                raise ValueError(
+                    'Argument refresh must be a positive integer value, '
+                    'found {}.'.format(self.refresh)
+                )
 
         if self.sig_figs is not None:
             if (

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -548,7 +548,7 @@ class CmdStanArgs:
         sig_figs: str = None,
         save_diagnostics: bool = False,
         save_profile: bool = False,
-        refresh: str = None,
+        refresh: int = None,
         logger: logging.Logger = None,
     ) -> None:
         """Initialize object."""
@@ -734,7 +734,10 @@ class CmdStanArgs:
                         )
 
     def compose_command(
-        self, idx: int, csv_file: str, *,
+        self,
+        idx: int,
+        csv_file: str,
+        *,
         diagnostic_file: str = None,
         profile_file: str = None
     ) -> str:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -346,6 +346,7 @@ class CmdStanModel:
         algorithm: str = None,
         init_alpha: float = None,
         iter: int = None,
+        refresh: int = None,
     ) -> CmdStanMLE:
         """
         Run the specified CmdStan optimize algorithm to produce a
@@ -412,6 +413,9 @@ class CmdStanModel:
 
         :param iter: Total number of iterations
 
+        :param refresh: Specify the number of iterations cmdstan will take
+        between progress messages. Default value is 100.
+
         :return: CmdStanMLE object
         """
         optimize_args = OptimizeArgs(
@@ -430,6 +434,7 @@ class CmdStanModel:
                 sig_figs=sig_figs,
                 save_profile=save_profile,
                 method_args=optimize_args,
+                refresh=refresh,
             )
 
             dummy_chain_id = 0
@@ -815,6 +820,7 @@ class CmdStanModel:
         seed: int = None,
         gq_output_dir: str = None,
         sig_figs: int = None,
+        refresh: int = None,
     ) -> CmdStanGQ:
         """
         Run CmdStan's generate_quantities method which runs the generated
@@ -862,6 +868,9 @@ class CmdStanModel:
             Must be an integer between 1 and 18.  If unspecified, the default
             precision for the system file I/O is used; the usual value is 6.
             Introduced in CmdStan-2.25.
+
+        :param refresh: Specify the number of iterations cmdstan will take
+            between progress messages. Default value is 100.
 
         :return: CmdStanGQ object
         """
@@ -939,6 +948,7 @@ class CmdStanModel:
                 output_dir=gq_output_dir,
                 sig_figs=sig_figs,
                 method_args=generate_quantities_args,
+                refresh=refresh,
             )
             runset = RunSet(args=args, chains=chains, chain_ids=chain_ids)
 
@@ -976,6 +986,7 @@ class CmdStanModel:
         eval_elbo: int = None,
         output_samples: int = None,
         require_converged: bool = True,
+        refresh: int = None,
     ) -> CmdStanVB:
         """
         Run CmdStan's variational inference algorithm to approximate
@@ -1057,6 +1068,9 @@ class CmdStanModel:
         :param require_converged: Whether or not to raise an error if stan
             reports that "The algorithm may not have converged".
 
+        :param refresh: Specify the number of iterations cmdstan will take
+            between progress messages. Default value is 100.
+
         :return: CmdStanVB object
         """
         variational_args = VariationalArgs(
@@ -1085,6 +1099,7 @@ class CmdStanModel:
                 save_diagnostics=save_diagnostics,
                 save_profile=save_profile,
                 method_args=variational_args,
+                refresh=refresh,
             )
 
             dummy_chain_id = 0

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -699,11 +699,6 @@ class CmdStanModel:
             'total threads: %u', parallel_chains * threads_per_chain
         )
         os.environ['STAN_NUM_THREADS'] = str(threads_per_chain)
-        if refresh is not None and refresh < 1:
-            raise ValueError(
-                'Argument refresh must be a positive integer value, '
-                'found {}.'.format(refresh)
-            )
 
         if show_progress:
             try:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -471,6 +471,7 @@ class CmdStanModel:
         save_profile: bool = False,
         show_progress: Union[bool, str] = False,
         validate_csv: bool = True,
+        refresh: int = None,
     ) -> CmdStanMCMC:
         """
         Run or more chains of the NUTS sampler to produce a set of draws
@@ -632,6 +633,9 @@ class CmdStanModel:
             Default is ``True`` - sample csv files are scanned for completeness
             and consistency.
 
+        :param refresh: Specify the number of iterations cmdstan will take
+        between progress messages. Default value is 100.
+
         :return: CmdStanMCMC object
         """
         if chains is None:
@@ -695,8 +699,12 @@ class CmdStanModel:
             'total threads: %u', parallel_chains * threads_per_chain
         )
         os.environ['STAN_NUM_THREADS'] = str(threads_per_chain)
+        if refresh is not None and refresh < 1:
+            raise ValueError(
+                'Argument refresh must be a positive integer value, '
+                'found {}.'.format(refresh)
+            )
 
-        refresh = None
         if show_progress:
             try:
                 import tqdm

--- a/test/test_cmdstan_args.py
+++ b/test/test_cmdstan_args.py
@@ -343,6 +343,7 @@ class CmdStanArgsTest(unittest.TestCase):
             chain_ids=[1, 2, 3, 4],
             data=jdata,
             method_args=sampler_args,
+            refresh=10,
         )
         self.assertEqual(cmdstan_args.method, Method.SAMPLE)
         cmd = cmdstan_args.compose_command(idx=0, csv_file='bern-output-1.csv')
@@ -350,6 +351,7 @@ class CmdStanArgsTest(unittest.TestCase):
         self.assertIn('data file=', ' '.join(cmd))
         self.assertIn('output file=', ' '.join(cmd))
         self.assertIn('method=sample algorithm=hmc', ' '.join(cmd))
+        self.assertIn('refresh=10', ' '.join(cmd))
 
         cmdstan_args = CmdStanArgs(
             model_name='bernoulli',
@@ -574,6 +576,28 @@ class CmdStanArgsTest(unittest.TestCase):
                     output_dir=read_only,
                     method_args=sampler_args,
                 )
+
+        with self.assertRaisesRegex(
+            ValueError, 'Argument refresh must be a positive integer value'
+        ):
+            CmdStanArgs(
+                model_name='bernoulli',
+                model_exe='bernoulli.exe',
+                chain_ids=[1, 2, 3, 4],
+                method_args=sampler_args,
+                refresh="a",
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, 'Argument refresh must be a positive integer value'
+        ):
+            CmdStanArgs(
+                model_name='bernoulli',
+                model_exe='bernoulli.exe',
+                chain_ids=[1, 2, 3, 4],
+                method_args=sampler_args,
+                refresh=0,
+            )
 
     def test_args_sig_figs(self):
         sampler_args = SamplerArgs()


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This change allows the user to set the `CmdStanArgs` argument `refresh` by adding a matching argument to the method `CmdStanModel.sample`. 

The main reason for doing this is to control the tqdm progress bar's granularity: for example setting `refresh` to 1 makes the progress bar update every iteration. Someone also might want to do this in order to tell from the `stdout.txt` file exactly at what iteration a message was printed.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Teddy Groves

