### PR TITLE
Allow optimize to have no data (Issue #348)

### DIFF
--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -693,10 +693,7 @@ class CmdStanArgs:
         if isinstance(self.data, str):
             if not os.path.exists(self.data):
                 raise ValueError('no such file {}'.format(self.data))
-        elif self.data is None:
-            if isinstance(self.method_args, OptimizeArgs):
-                raise ValueError('data must be set when optimizing')
-        elif not isinstance(self.data, (str, dict)):
+        elif self.data is not None and not isinstance(self.data, (str, dict)):
             raise ValueError('data must be string or dict')
 
         if self.inits is not None:

--- a/test/data/optimize/no_data.stan
+++ b/test/data/optimize/no_data.stan
@@ -1,0 +1,7 @@
+parameters {
+  real a;
+}
+
+model {
+  target += normal_lupdf(a | 0, 1);
+}

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -111,13 +111,17 @@ class OptimizeTest(unittest.TestCase):
     def test_optimize_rosenbrock(self):
         stan = os.path.join(DATAFILES_PATH, 'optimize', 'rosenbrock.stan')
         rose_model = CmdStanModel(stan_file=stan)
-        no_data = {}
-        mle = rose_model.optimize(
-            data=no_data, seed=1239812093, inits=None, algorithm='BFGS'
-        )
+        mle = rose_model.optimize(seed=1239812093, inits=None, algorithm='BFGS')
         self.assertEqual(mle.column_names, ('lp__', 'x', 'y'))
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
+
+    def test_optimize_no_data(self):
+        stan = os.path.join(DATAFILES_PATH, 'optimize', 'no_data.stan')
+        rose_model = CmdStanModel(stan_file=stan)
+        mle = rose_model.optimize(seed = 1239812093)
+        self.assertEqual(mle.column_names, ('lp__', 'a'))
+        self.assertAlmostEqual(mle.optimized_params_dict['a'], 0, places=3)
 
     def test_optimize_bad(self):
         stan = os.path.join(

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -119,7 +119,7 @@ class OptimizeTest(unittest.TestCase):
     def test_optimize_no_data(self):
         stan = os.path.join(DATAFILES_PATH, 'optimize', 'no_data.stan')
         rose_model = CmdStanModel(stan_file=stan)
-        mle = rose_model.optimize(seed = 1239812093)
+        mle = rose_model.optimize(seed=1239812093)
         self.assertEqual(mle.column_names, ('lp__', 'a'))
         self.assertAlmostEqual(mle.optimized_params_dict['a'], 0, places=3)
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #348 with @nourfahmy 

It's now okay to run the optimize function with no data supplied (so the behavior is the same as with sampling now)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

