### PR TITLE
Fix stepsize → step_size

### DIFF
--- a/cmdstanpy_tutorial.ipynb
+++ b/cmdstanpy_tutorial.ipynb
@@ -201,10 +201,10 @@
     "- `draws`  - all draws from all chains, stored as a 3-D numpy.ndarray.\n",
     "- `num_draws` - total number of warmup and sampling draws\n",
     "- `chains` - number of chains run by sampler\n",
-    "- `metric`, `stepsize` - per-chain HMC tuning parameters\n",
+    "- `metric`, `step_size` - per-chain HMC tuning parameters\n",
     "- `csv_files` - list of Stan csv output files which comprise the sample\n",
     "    \n",
-    "The `draws` array is created only as needed; therefore the first time that this property is accessed, CmdStanPy parses the set of csv output files, at the same time it parses the contain stepsize and metric information.  Depending on the size of the sample and your computing environment, this may take a few seconds or more.\n",
+    "The `draws` array is created only as needed; therefore the first time that this property is accessed, CmdStanPy parses the set of csv output files, at the same time it parses the contain step size and metric information.  Depending on the size of the sample and your computing environment, this may take a few seconds or more.\n",
     "\n",
     "The numpy ndarray is stored column major format so that values for each parameter are stored contiguously in memory, likewise all draws from a chain are contiguous.  Thus the dimensions of the ndarray are arranged as follows:  (draws, chains, columns).  The draws array contains both the sampler variables and the model variables.  Sampler variables report the sampler state.  For the NUTS-HMC sampler, there are 7 reported variables, all of which end in `__`.  The example model contains a single variable `theta`."
    ]
@@ -253,11 +253,11 @@
    "source": [
     "#### Get HMC sampler tuning parameters\n",
     "\n",
-    "##### stepsize\n",
+    "##### step_size\n",
     "\n",
-    "The `CmdStanMCMC` property `stepsize` property is a 1-D numpy ndarray which contains the stepsize used by the sampler for each chain.  This array is created at the same time as the `sample` and `metric` arrays are created.\n",
+    "The `CmdStanMCMC` property `step_size` property is a 1-D numpy ndarray which contains the step size used by the sampler for each chain.  This array is created at the same time as the `sample` and `metric` arrays are created.\n",
     "\n",
-    "At the end of adaptation, the stepsize for the 4 chains in this example is:"
+    "At the end of adaptation, the step size for the 4 chains in this example is:"
    ]
   },
   {
@@ -266,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bern_fit.stepsize"
+    "bern_fit.step_size"
    ]
   },
   {
@@ -275,7 +275,7 @@
    "source": [
     "#### metric_type, metric\n",
     "\n",
-    "The `metric` property is an numpy ndarray which contains the metric used by the sampler for each chain.  This array is created at the same time as the `sample` and `stepsize` arrays are created.\n",
+    "The `metric` property is an numpy ndarray which contains the metric used by the sampler for each chain.  This array is created at the same time as the `sample` and `step_size` arrays are created.\n",
     "\n",
     "At the end of adaptation, the metric for the 4 chains in this example is:"
    ]

--- a/cmdstanpy_tutorial.py
+++ b/cmdstanpy_tutorial.py
@@ -44,7 +44,7 @@ pd.DataFrame(data=thetas).plot.density()
 
 # #### Get HMC sampler tuning parameters
 
-bern_fit.stepsize
+bern_fit.step_size
 bern_fit.metric_type
 bern_fit.metric
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- [X] Declare copyright holder and open-source license: see below

#### Summary

The `stepsize` attribute does not exist on `CmdStanMCMC`. Apparently it should be `step_size` instead.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Myself (Ben Mares)

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

