### PR TITLE
Fix space in path issue for checking exe file

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -300,7 +300,9 @@ class CmdStanModel:
                     exe_time = os.path.getmtime(exe_file)
                     if exe_time > src_time and not force:
                         do_compile = False
-                        self._logger.info('found newer exe file, not recompiling')
+                        self._logger.info(
+                            'found newer exe file, not recompiling'
+                        )
 
                 if do_compile:
                     self._logger.info(
@@ -335,7 +337,9 @@ class CmdStanModel:
                             os.path.abspath(self._stan_file)
                         )
                         new_exec_name = (
-                            os.path.basename(os.path.splitext(self._stan_file)[0])
+                            os.path.basename(
+                                os.path.splitext(self._stan_file)[0]
+                            )
                             + EXTENSION
                         )
                         self._exe_file = os.path.join(

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -276,7 +276,7 @@ class RunSet:
                     )
             # pre 2.27, all msgs sent to stdout, including errors
             if (
-                not cmdstan_version_at(2,27)
+                not cmdstan_version_at(2, 27)
                 and os.path.exists(self._stdout_files[i])
                 and os.stat(self._stdout_files[i]).st_size > 0
             ):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import tempfile
 import unittest
 from unittest.mock import Mock
 
@@ -226,6 +227,27 @@ class CmdStanModelTest(unittest.TestCase):
         exe_time = os.path.getmtime(model.exe_file)
         model2 = CmdStanModel(stan_file=BERN_STAN)
         self.assertEqual(exe_time, os.path.getmtime(model2.exe_file))
+        
+    def test_model_compile_space(self):
+        with tempfile.TemporaryDirectory(prefix="cmdstanpy_testfolder_") as tmp_path:
+            path_with_space = os.path.join(tmp_path, "space in path")
+            os.makedirs(path_with_space, exist_ok=True)
+            shutil.copyfile(BERN_STAN, path_with_space)
+            BERN_STAN_NEW = os.path.join(path_with_space, os.path.split(BERN_STAN)[1])
+            BERN_EXE_NEW = os.path.join(path_with_space, os.path.split(BERN_EXE)[1])
+
+            model = CmdStanModel(stan_file=BERN_STAN_NEW)
+            self.assertTrue(model.exe_file.endswith(BERN_EXE_NEW.replace('\\', '/')))
+            old_exe_time = os.path.getmtime(model.exe_file)
+            os.remove(BERN_EXE_NEW)
+            model.compile()
+            new_exe_time = os.path.getmtime(model.exe_file)
+            self.assertTrue(new_exe_time > old_exe_time)
+
+            # test compile with existing exe - timestamp on exe unchanged
+            exe_time = os.path.getmtime(model.exe_file)
+            model2 = CmdStanModel(stan_file=BERN_STAN_NEW)
+            self.assertEqual(exe_time, os.path.getmtime(model2.exe_file))
 
     def test_model_includes_explicit(self):
         if os.path.exists(BERN_EXE):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -235,26 +235,26 @@ class CmdStanModelTest(unittest.TestCase):
             path_with_space = os.path.join(tmp_path, "space in path")
             os.makedirs(path_with_space, exist_ok=True)
             shutil.copyfile(BERN_STAN, path_with_space)
-            BERN_STAN_NEW = os.path.join(
+            bern_stan_new = os.path.join(
                 path_with_space, os.path.split(BERN_STAN)[1]
             )
-            BERN_EXE_NEW = os.path.join(
+            bern_exe_new = os.path.join(
                 path_with_space, os.path.split(BERN_EXE)[1]
             )
 
-            model = CmdStanModel(stan_file=BERN_STAN_NEW)
+            model = CmdStanModel(stan_file=bern_stan_new)
             self.assertTrue(
-                model.exe_file.endswith(BERN_EXE_NEW.replace('\\', '/'))
+                model.exe_file.endswith(bern_exe_new.replace('\\', '/'))
             )
             old_exe_time = os.path.getmtime(model.exe_file)
-            os.remove(BERN_EXE_NEW)
+            os.remove(bern_exe_new)
             model.compile()
             new_exe_time = os.path.getmtime(model.exe_file)
             self.assertTrue(new_exe_time > old_exe_time)
 
             # test compile with existing exe - timestamp on exe unchanged
             exe_time = os.path.getmtime(model.exe_file)
-            model2 = CmdStanModel(stan_file=BERN_STAN_NEW)
+            model2 = CmdStanModel(stan_file=bern_stan_new)
             self.assertEqual(exe_time, os.path.getmtime(model2.exe_file))
 
     def test_model_includes_explicit(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -242,9 +242,7 @@ class CmdStanModelTest(unittest.TestCase):
             )
             shutil.copyfile(BERN_STAN, bern_stan_new)
             model = CmdStanModel(stan_file=bern_stan_new)
-            self.assertTrue(
-                model.exe_file.endswith(bern_exe_new.replace('\\', '/'))
-            )
+
             old_exe_time = os.path.getmtime(model.exe_file)
             os.remove(bern_exe_new)
             model.compile()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -234,14 +234,13 @@ class CmdStanModelTest(unittest.TestCase):
         ) as tmp_path:
             path_with_space = os.path.join(tmp_path, "space in path")
             os.makedirs(path_with_space, exist_ok=True)
-            shutil.copyfile(BERN_STAN, path_with_space)
             bern_stan_new = os.path.join(
                 path_with_space, os.path.split(BERN_STAN)[1]
             )
             bern_exe_new = os.path.join(
                 path_with_space, os.path.split(BERN_EXE)[1]
             )
-
+            shutil.copyfile(BERN_STAN, bern_stan_new)
             model = CmdStanModel(stan_file=bern_stan_new)
             self.assertTrue(
                 model.exe_file.endswith(bern_exe_new.replace('\\', '/'))

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -227,17 +227,25 @@ class CmdStanModelTest(unittest.TestCase):
         exe_time = os.path.getmtime(model.exe_file)
         model2 = CmdStanModel(stan_file=BERN_STAN)
         self.assertEqual(exe_time, os.path.getmtime(model2.exe_file))
-        
+
     def test_model_compile_space(self):
-        with tempfile.TemporaryDirectory(prefix="cmdstanpy_testfolder_") as tmp_path:
+        with tempfile.TemporaryDirectory(
+            prefix="cmdstanpy_testfolder_"
+        ) as tmp_path:
             path_with_space = os.path.join(tmp_path, "space in path")
             os.makedirs(path_with_space, exist_ok=True)
             shutil.copyfile(BERN_STAN, path_with_space)
-            BERN_STAN_NEW = os.path.join(path_with_space, os.path.split(BERN_STAN)[1])
-            BERN_EXE_NEW = os.path.join(path_with_space, os.path.split(BERN_EXE)[1])
+            BERN_STAN_NEW = os.path.join(
+                path_with_space, os.path.split(BERN_STAN)[1]
+            )
+            BERN_EXE_NEW = os.path.join(
+                path_with_space, os.path.split(BERN_EXE)[1]
+            )
 
             model = CmdStanModel(stan_file=BERN_STAN_NEW)
-            self.assertTrue(model.exe_file.endswith(BERN_EXE_NEW.replace('\\', '/')))
+            self.assertTrue(
+                model.exe_file.endswith(BERN_EXE_NEW.replace('\\', '/'))
+            )
             old_exe_time = os.path.getmtime(model.exe_file)
             os.remove(BERN_EXE_NEW)
             model.compile()

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1392,7 +1392,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             parallel_chains=2,
             seed=12345,
             iter_sampling=200,
-            save_diagnostics=True
+            save_diagnostics=True,
         )
         for i in range(bern_fit.runset.chains):
             diagnostics_file = bern_fit.runset.diagnostic_files[i]
@@ -1406,7 +1406,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             parallel_chains=2,
             seed=12345,
             iter_sampling=200,
-            save_profile=True
+            save_profile=True,
         )
         for i in range(profile_fit.runset.chains):
             profile_file = profile_fit.runset.profile_files[i]


### PR DESCRIPTION
Fixes #377 

This fixes the issue with recompilation caused by the temp-folder hack used for the paths with spaces.

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Check first if exe file exists in the original folder, then check against possible temp file.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

