### PR TITLE
Bundle source code as .tar.gz and pushing it with the package to pypi.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create source code archive
+        run: tar -czvf cmdstanpy-${{ github.event.inputs.new_version }}.tar.gz --exclude ../cmdstanpy/.git --exclude ../cmdstanpy/.github --exclude ../cmdstanpy/.gitignore ../cmdstanpy/
+
       - name: Install dependencies (python)
         run: |
           pip install --upgrade pip wheel twine codecov sphinx sphinx_rtd_theme requests
@@ -73,6 +76,9 @@ jobs:
 
       - name: Install bdist_wheel
         run: pip install dist/*.whl
+
+      - name: Copy source code archive to dist
+        run: cp cmdstanpy-${{ github.event.inputs.new_version }}.tar.gz dist/
       
       - name: Upload to pypi
         if: success()


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [ ] Declare copyright holder and open-source license: see below

#### Summary

Modified github workflow to include a bundle of the source code as a .tar.gz archive when publishing the package to pypi.
Paths `.git`,`.github` and `.gitignore` are excluded.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

