### PR TITLE
Feature/345 from csv to cmd stan mcmc et al

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -37,7 +37,13 @@ atexit.register(_cleanup_tmpdir)
 
 from ._version import __version__  # noqa
 from .model import CmdStanModel  # noqa
-from .stanfit import CmdStanGQ, CmdStanMCMC, CmdStanMLE, CmdStanVB  # noqa
+from .stanfit import (
+    from_csv,
+    CmdStanGQ,
+    CmdStanMCMC,
+    CmdStanMLE,
+    CmdStanVB,
+)  # noqa
 from .utils import set_cmdstan_path  # noqa
 from .utils import cmdstan_path, install_cmdstan, set_make_env
 
@@ -51,4 +57,5 @@ __all__ = [
     'CmdStanGQ',
     'CmdStanVB',
     'CmdStanModel',
+    'from_csv',
 ]

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -312,7 +312,7 @@ class SamplerArgs:
 class OptimizeArgs:
     """Container for arguments for the optimizer."""
 
-    OPTIMIZE_ALGOS = {'BFGS', 'LBFGS', 'Newton'}
+    OPTIMIZE_ALGOS = {'BFGS', 'bfgs', 'LBFGS', 'lbfgs', 'Newton', 'newton'}
 
     def __init__(
         self,

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -465,8 +465,8 @@ class CmdStanMCMC:
         for file in os.listdir(dir):
             if file.endswith(".csv"):
                 csvfiles.append(os.path.join(dir, file))
-        num_chains = len(csvfiles)
-        if num_chains == 0:
+        chains = len(csvfiles)
+        if chains == 0:
             raise ValueError('No CSV files found in directory {}'.format(dir))
         config_dict = {}
         try:
@@ -494,10 +494,10 @@ class CmdStanMCMC:
         cmdstan_args = CmdStanArgs(
             model_name=config_dict['model'],
             model_exe=config_dict['model'],
-            chain_ids=None,
+            chain_ids = [x + 1 for x in range(chains)],
             method_args=sampler_args,
         )
-        runset = RunSet(args=cmdstan_args)
+        runset = RunSet(args=cmdstan_args, chains=chains)
         runset._csv_files = csvfiles
         for i in range(len(runset._retcodes)):
             runset._set_retcode(i, 0)

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 
 from cmdstanpy import _TMPDIR, _CMDSTAN_WARMUP, _CMDSTAN_SAMPLING, _CMDSTAN_THIN
-from cmdstanpy.cmdstan_args import CmdStanArgs, Method
+from cmdstanpy.cmdstan_args import SamplerArgs, CmdStanArgs, Method
 from cmdstanpy.utils import (
     EXTENSION,
     check_sampler_csv,
@@ -26,6 +26,7 @@ from cmdstanpy.utils import (
     get_logger,
     parse_sampler_vars,
     parse_stan_vars,
+    scan_config,
     scan_generated_quantities_csv,
     scan_optimize_csv,
     scan_variational_csv,
@@ -445,6 +446,63 @@ class CmdStanMCMC:
         )
         # TODO - hamiltonian, profiling files
         return repr
+
+    @classmethod
+    def from_csv(cls, dir: str):
+        """
+        Instantiate CmdStanMCMC from sampler csvfiles
+        :param dir: directory path
+        """
+        if dir is None:
+            raise ValueError('Must specify path to directory with Stan CSV files.')
+        csvfiles = []
+        for file in os.listdir(dir):
+            if file.endswith(".csv"):
+                csvfiles.append(os.path.join(dir, file))
+        num_chains = len(csvfiles)
+        if num_chains == 0:
+            raise ValueError('No CSV files found in directory {}'.format(dir))
+        config_dict = {}
+        try:
+            with open(csvfiles[1], 'r') as fd:
+                scan_config(fd, config_dict, 0)
+        except (IOError, OSError, PermissionError) as e:
+            raise ValueError(
+                'Cannot read CSV file: {}'.format(csvfiles[1])
+            ) from e
+        if not 'model' in config_dict or not 'method' in config_dict:
+            raise ValueError(
+                "File {} is not a Stan CSV file.".format(csvfiles[1])
+                )
+        if config_dict['method'] != 'sample':
+            raise ValueError(
+                "File {} isn't a Stan sampler CSV file, "
+                "found method = {} ".format(csvfiles[1], config_dict['method'])
+                )
+        sampler_args = SamplerArgs(
+            iter_sampling=config_dict['num_samples'],
+            iter_warmup=config_dict['num_warmup'],
+            thin=config_dict['thin'],
+            save_warmup=config_dict['save_warmup']
+        )
+        cmdstan_args = CmdStanArgs(
+            model_name=config_dict['model'],
+            model_exe=config_dict['model'],
+            chain_ids=list(range(1,num_chains+1)),
+            method_args=sampler_args,
+        )
+        runset = RunSet(args=cmdstan_args)
+        runset._csv_files = csvfiles
+        for i in range(len(runset._retcodes)):
+            runset._set_retcode(i, 0)
+        fit = CmdStanMCMC(runset)
+        try:
+            fit.draws()
+        except (IOError, OSError, PermissionError) as e:
+            raise ValueError(
+                'An error occured processing the CSV files:\n\t{}'.format(str(e))
+            ) from e
+        return fit
 
     @property
     def chains(self) -> int:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1450,8 +1450,8 @@ def from_csv(
             for i in range(len(runset._retcodes)):
                 runset._set_retcode(i, 0)
             fit = CmdStanVB(runset)
-        return fit
     except (IOError, OSError, PermissionError) as e:
         raise ValueError(
             'An error occured processing the CSV files:\n\t{}'.format(str(e))
         ) from e
+    return fit

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -32,7 +32,6 @@ from cmdstanpy.utils import (
     get_logger,
     parse_sampler_vars,
     parse_stan_vars,
-    scan_config,
     scan_generated_quantities_csv,
     scan_optimize_csv,
     scan_variational_csv,
@@ -1142,7 +1141,7 @@ class CmdStanMLE:
         :param dir: directory path
         """
         csvfiles, config_dict = validate_csvfiles(dir, 'optimize')
-        if not 'algorithm' in config_dict:
+        if 'algorithm' not in config_dict:
             raise ValueError(
                 "Cannot find optimization algorithm"
                 " in file {}.".format(csvfiles[0])
@@ -1376,7 +1375,7 @@ class CmdStanVB:
         :param dir: directory path
         """
         csvfiles, config_dict = validate_csvfiles(dir, 'variational')
-        if not 'algorithm' in config_dict:
+        if 'algorithm' not in config_dict:
             raise ValueError(
                 "Cannot find variational algorithm"
                 " in file {}.".format(csvfiles[0])

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1372,7 +1372,7 @@ def from_csv(
 
     csvfiles = []
     if isinstance(path, list):
-        csvfiles = list
+        csvfiles = path
     elif isinstance(path, str):
         if '*' in path:
             splits = os.path.split(path)
@@ -1399,8 +1399,8 @@ def from_csv(
     for file in csvfiles:
         if not (os.path.exists(file) and file.endswith('.csv')):
             raise ValueError(
-                'Bad CSV file path spec {},'
-                ' matched non-csv file: {}'.format(path, file)
+                'Bad CSV file path spec,'
+                ' includes non-csv file: {}'.format(file)
             )
 
     config_dict = {}

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1046,7 +1046,7 @@ def validate_csvfiles(dir: str = None, method: str = None) -> (List[str], Dict):
             scan_config(fd, config_dict, 0)
     except (IOError, OSError, PermissionError) as e:
         raise ValueError('Cannot read CSV file: {}'.format(csvfiles[0])) from e
-    if not 'model' in config_dict or not 'method' in config_dict:
+    if 'model' not in config_dict or 'method' not in config_dict:
         raise ValueError("File {} is not a Stan CSV file.".format(csvfiles[0]))
     if config_dict['method'] != method:
         raise ValueError(

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1017,47 +1017,6 @@ def install_cmdstan(
     return True
 
 
-def validate_csvfiles(dir: str = None, method: str = None) -> (List[str], Dict):
-    """
-    Given a directory of saved Stan CSV files and a method specification,
-    find the CSV files in the directory and validate that they are
-    Stan CSV files created by the specified method.
-
-    :param dir: directory path
-    :param method: CmdStan method name
-
-    :return: List of CSV filenames, Dict of config info
-    """
-    config_dict = {}
-    if dir is None:
-        raise ValueError('Must specify directory of Stan CSV files.')
-    if method is None:
-        raise ValueError('Must specify CmdStan method.')
-    if not os.path.exists(dir):
-        raise ValueError('Directory {} not found.'.format(dir))
-    csvfiles = []
-    for file in os.listdir(dir):
-        if file.endswith(".csv"):
-            csvfiles.append(os.path.join(dir, file))
-    if len(csvfiles) == 0:
-        raise ValueError('No CSV files found in directory {}'.format(dir))
-    try:
-        with open(csvfiles[0], 'r') as fd:
-            scan_config(fd, config_dict, 0)
-    except (IOError, OSError, PermissionError) as e:
-        raise ValueError('Cannot read CSV file: {}'.format(csvfiles[0])) from e
-    if 'model' not in config_dict or 'method' not in config_dict:
-        raise ValueError("File {} is not a Stan CSV file.".format(csvfiles[0]))
-    if config_dict['method'] != method:
-        raise ValueError(
-            "File {} isn't result of method {}, "
-            "found method = {} ".format(
-                csvfiles[0], method, config_dict['method']
-            )
-        )
-    return (csvfiles, config_dict)
-
-
 class MaybeDictToFilePath:
     """Context manager for json files."""
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -390,7 +390,7 @@ def rdump(path: str, data: Dict) -> None:
             print(line, file=fd)
 
 
-def rload(fname: str) -> dict:
+def rload(fname: str) -> Dict:
     """Parse data and parameter variable values from an R dump format file.
     This parser only supports the subset of R dump data as described
     in the "Dump Data Format" section of the CmdStan manual, i.e.,
@@ -644,7 +644,7 @@ def scan_column_names(fd: TextIO, config_dict: Dict, lineno: int) -> int:
     return lineno
 
 
-def munge_varnames(names: List) -> List:
+def munge_varnames(names: List[str]) -> List[str]:
     """
     Change formatting for indices of container var elements
     from use of dot separator to array-like notation, e.g.,
@@ -1015,6 +1015,47 @@ def install_cmdstan(
             logger.warning(stderr.decode('utf-8').strip())
         return False
     return True
+
+
+def validate_csvfiles(dir: str = None, method: str = None) -> (List[str], Dict):
+    """
+    Given a directory of saved Stan CSV files and a method specification,
+    find the CSV files in the directory and validate that they are
+    Stan CSV files created by the specified method.
+
+    :param dir: directory path
+    :param method: CmdStan method name
+
+    :return: List of CSV filenames, Dict of config info
+    """
+    config_dict = {}
+    if dir is None:
+        raise ValueError('Must specify directory of Stan CSV files.')
+    if method is None:
+        raise ValueError('Must specify CmdStan method.')
+    if not os.path.exists(dir):
+        raise ValueError('Directory {} not found.'.format(dir))
+    csvfiles = []
+    for file in os.listdir(dir):
+        if file.endswith(".csv"):
+            csvfiles.append(os.path.join(dir, file))
+    if len(csvfiles) == 0:
+        raise ValueError('No CSV files found in directory {}'.format(dir))
+    try:
+        with open(csvfiles[0], 'r') as fd:
+            scan_config(fd, config_dict, 0)
+    except (IOError, OSError, PermissionError) as e:
+        raise ValueError('Cannot read CSV file: {}'.format(csvfiles[0])) from e
+    if not 'model' in config_dict or not 'method' in config_dict:
+        raise ValueError("File {} is not a Stan CSV file.".format(csvfiles[0]))
+    if config_dict['method'] != method:
+        raise ValueError(
+            "File {} isn't result of method {}, "
+            "found method = {} ".format(
+                csvfiles[0], method, config_dict['method']
+            )
+        )
+    return (csvfiles, config_dict)
 
 
 class MaybeDictToFilePath:

--- a/test/data/from_csv/wrong_header_method.csv
+++ b/test/data/from_csv/wrong_header_method.csv
@@ -1,0 +1,27 @@
+# stan_version_major = 2
+# stan_version_minor = 25
+# stan_version_patch = 0
+# model = logistic_model
+# method = diagnose
+# id = 1
+# data
+#   file = logistic.data.R
+# init = 2 (Default)
+# random
+#   seed = 12345
+# output
+#   file = logistic_output_1.csv
+#   diagnostic_file =  (Default)
+#   refresh = 100 (Default)
+#   sig_figs = 17
+lp__,accept_stat__,stepsize__,treedepth__,n_leapfrog__,divergent__,energy__,beta.1,beta.2
+# Adaptation terminated
+# Step size = 0.867157
+# Diagonal elements of inverse mass matrix:
+# 0.0574982, 0.0750306
+-65.512400286053165,1,0.86715739477627263,2,3,0,66.280862231993666,1.4566622706449768,-0.4342590644812877
+# 
+#  Elapsed Time: 0.066 seconds (Warm-up)
+#                0.006 seconds (Sampling)
+#                0.072 seconds (Total)
+# 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -14,6 +14,7 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 GOODFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-good')
 BADFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-bad')
 
+
 class InferenceMetadataTest(unittest.TestCase):
     def test_good(self):
         # construct fit using existing sampler output

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -13,17 +13,6 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 DATAFILES_PATH = os.path.join(HERE, 'data')
 GOODFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-good')
 BADFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-bad')
-SAMPLER_STATE = [
-    'lp__',
-    'accept_stat__',
-    'stepsize__',
-    'treedepth__',
-    'n_leapfrog__',
-    'divergent__',
-    'energy__',
-]
-BERNOULLI_COLS = SAMPLER_STATE + ['theta']
-
 
 class InferenceMetadataTest(unittest.TestCase):
     def test_good(self):

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -52,6 +52,16 @@ class CmdStanMLETest(unittest.TestCase):
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
 
 
+    def test_instantiate_from_csvfiles(self):
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'optimize')
+        mle = CmdStanMLE.from_csv(dir=csvfiles_path)
+        self.assertIn('CmdStanMLE: model=rosenbrock', mle.__repr__())
+        self.assertIn('method=optimize', mle.__repr__())
+        self.assertEqual(mle.column_names, ('lp__', 'x', 'y'))
+        self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
+        self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
+
+
 class OptimizeTest(unittest.TestCase):
     def test_optimize_good(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -53,7 +53,7 @@ class CmdStanMLETest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'optimize')
-        mle = from_csv(dir=csvfiles_path)
+        mle = from_csv(path=csvfiles_path)
         self.assertIn('CmdStanMLE: model=rosenbrock', mle.__repr__())
         self.assertIn('method=optimize', mle.__repr__())
         self.assertEqual(mle.column_names, ('lp__', 'x', 'y'))

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -51,7 +51,6 @@ class CmdStanMLETest(unittest.TestCase):
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
 
-
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'optimize')
         mle = CmdStanMLE.from_csv(dir=csvfiles_path)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -53,7 +53,7 @@ class CmdStanMLETest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'optimize')
-        mle = from_csv(dir=csvfiles_path, method='optimize')
+        mle = from_csv(dir=csvfiles_path)
         self.assertIn('CmdStanMLE: model=rosenbrock', mle.__repr__())
         self.assertIn('method=optimize', mle.__repr__())
         self.assertEqual(mle.column_names, ('lp__', 'x', 'y'))

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import unittest
 
 import numpy as np
@@ -59,6 +60,31 @@ class CmdStanMLETest(unittest.TestCase):
         self.assertEqual(mle.column_names, ('lp__', 'x', 'y'))
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
+
+    def test_instantiate_from_csvfiles_fail(self):
+        # use sampler dataset
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-good')
+        with self.assertRaisesRegex(ValueError, r'result of method optimize'):
+            CmdStanMLE.from_csv(dir=csvfiles_path)
+        # use missing dir
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'no-such-directory')
+        with self.assertRaisesRegex(ValueError, r'not found'):
+            CmdStanMLE.from_csv(dir=csvfiles_path)
+        # use none
+        with self.assertRaisesRegex(ValueError, r'Must specify directory'):
+            CmdStanMLE.from_csv(None)
+        # no csv files
+        no_csvfiles_path = os.path.join(
+            DATAFILES_PATH, 'test-fail-empty-directory'
+        )
+        if os.path.exists(no_csvfiles_path):
+            shutil.rmtree(no_csvfiles_path, ignore_errors=True)
+        os.mkdir(no_csvfiles_path)
+        with self.assertRaisesRegex(ValueError, r'No CSV files found'):
+            CmdStanMLE.from_csv(dir=no_csvfiles_path)
+        if os.path.exists(no_csvfiles_path):
+            shutil.rmtree(no_csvfiles_path, ignore_errors=True)
+        # method optimize, no algorithm specified - shouldn't happen
 
 
 class OptimizeTest(unittest.TestCase):

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import shutil
 import unittest
 
 import numpy as np
@@ -10,7 +9,7 @@ import pytest
 
 from cmdstanpy.cmdstan_args import CmdStanArgs, OptimizeArgs
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.stanfit import CmdStanMLE, RunSet
+from cmdstanpy.stanfit import from_csv, CmdStanMLE, RunSet
 from cmdstanpy.utils import EXTENSION
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -54,37 +53,12 @@ class CmdStanMLETest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'optimize')
-        mle = CmdStanMLE.from_csv(dir=csvfiles_path)
+        mle = from_csv(dir=csvfiles_path, method='optimize')
         self.assertIn('CmdStanMLE: model=rosenbrock', mle.__repr__())
         self.assertIn('method=optimize', mle.__repr__())
         self.assertEqual(mle.column_names, ('lp__', 'x', 'y'))
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
-
-    def test_instantiate_from_csvfiles_fail(self):
-        # use sampler dataset
-        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-good')
-        with self.assertRaisesRegex(ValueError, r'result of method optimize'):
-            CmdStanMLE.from_csv(dir=csvfiles_path)
-        # use missing dir
-        csvfiles_path = os.path.join(DATAFILES_PATH, 'no-such-directory')
-        with self.assertRaisesRegex(ValueError, r'not found'):
-            CmdStanMLE.from_csv(dir=csvfiles_path)
-        # use none
-        with self.assertRaisesRegex(ValueError, r'Must specify directory'):
-            CmdStanMLE.from_csv(None)
-        # no csv files
-        no_csvfiles_path = os.path.join(
-            DATAFILES_PATH, 'test-fail-empty-directory'
-        )
-        if os.path.exists(no_csvfiles_path):
-            shutil.rmtree(no_csvfiles_path, ignore_errors=True)
-        os.mkdir(no_csvfiles_path)
-        with self.assertRaisesRegex(ValueError, r'No CSV files found'):
-            CmdStanMLE.from_csv(dir=no_csvfiles_path)
-        if os.path.exists(no_csvfiles_path):
-            shutil.rmtree(no_csvfiles_path, ignore_errors=True)
-        # method optimize, no algorithm specified - shouldn't happen
 
 
 class OptimizeTest(unittest.TestCase):

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -609,7 +609,7 @@ class CmdStanMCMCTest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-good')
-        bern_fit = from_csv(dir=csvfiles_path, method='sample')
+        bern_fit = from_csv(dir=csvfiles_path)
         draws_pd = bern_fit.draws_pd()
         self.assertEqual(
             draws_pd.shape,
@@ -619,7 +619,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             ),
         )
         csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-big')
-        big_fit = from_csv(dir=csvfiles_path, method='sample')
+        big_fit = from_csv(dir=csvfiles_path)
         draws_pd = big_fit.draws_pd()
         self.assertEqual(
             draws_pd.shape,
@@ -630,21 +630,25 @@ class CmdStanMCMCTest(unittest.TestCase):
         )
 
     def test_instantiate_from_csvfiles_fail(self):
-        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-big')
-        with self.assertRaisesRegex(ValueError, r'argument'):
-            from_csv(dir=csvfiles_path)
-        with self.assertRaisesRegex(ValueError, r'argument'):
-            from_csv(dir=csvfiles_path, method='no-such-method')
-        with self.assertRaisesRegex(ValueError, r"isn't result of method"):
-            from_csv(dir=csvfiles_path, method='optimize')
-        # use missing dir
+        with self.assertRaisesRegex(ValueError, r'Must specify directory'):
+            from_csv(None)
+
         csvfiles_path = os.path.join(DATAFILES_PATH, 'no-such-directory')
         with self.assertRaisesRegex(ValueError, r'not found'):
-            from_csv(dir=csvfiles_path, method='sample')
-        # use none
-        with self.assertRaisesRegex(ValueError, r'Must specify directory'):
-            from_csv(None, method='sample')
-        # no csv files
+            from_csv(dir=csvfiles_path)
+
+        wrong_method_path = os.path.join(DATAFILES_PATH, 'from_csv')
+        with LogCapture() as log:
+            logging.getLogger()
+            from_csv(dir=wrong_method_path)
+        log.check_present(
+            (
+                'cmdstanpy',
+                'INFO',
+                'Unable to process CSV output files from method diagnose.',
+            ),
+        )
+
         no_csvfiles_path = os.path.join(
             DATAFILES_PATH, 'test-fail-empty-directory'
         )
@@ -652,7 +656,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             shutil.rmtree(no_csvfiles_path, ignore_errors=True)
         os.mkdir(no_csvfiles_path)
         with self.assertRaisesRegex(ValueError, r'No CSV files found'):
-            from_csv(dir=no_csvfiles_path, method='sample')
+            from_csv(dir=no_csvfiles_path)
         if os.path.exists(no_csvfiles_path):
             shutil.rmtree(no_csvfiles_path, ignore_errors=True)
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -22,7 +22,7 @@ except ImportError:
 from cmdstanpy import _TMPDIR
 from cmdstanpy.cmdstan_args import CmdStanArgs, Method, SamplerArgs
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.stanfit import CmdStanMCMC, RunSet
+from cmdstanpy.stanfit import from_csv, CmdStanMCMC, RunSet
 from cmdstanpy.utils import EXTENSION, cmdstan_version_at
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -609,7 +609,7 @@ class CmdStanMCMCTest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-good')
-        bern_fit = CmdStanMCMC.from_csv(dir=csvfiles_path)
+        bern_fit = from_csv(dir=csvfiles_path, method='sample')
         draws_pd = bern_fit.draws_pd()
         self.assertEqual(
             draws_pd.shape,
@@ -619,7 +619,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             ),
         )
         csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-big')
-        big_fit = CmdStanMCMC.from_csv(dir=csvfiles_path)
+        big_fit = from_csv(dir=csvfiles_path, method='sample')
         draws_pd = big_fit.draws_pd()
         self.assertEqual(
             draws_pd.shape,
@@ -630,17 +630,20 @@ class CmdStanMCMCTest(unittest.TestCase):
         )
 
     def test_instantiate_from_csvfiles_fail(self):
-        # use optimize dataset
-        csvfiles_path = os.path.join(DATAFILES_PATH, 'optimize')
-        with self.assertRaisesRegex(ValueError, r'result of method sample'):
-            CmdStanMCMC.from_csv(dir=csvfiles_path)
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-big')
+        with self.assertRaisesRegex(ValueError, r'argument'):
+            from_csv(dir=csvfiles_path)
+        with self.assertRaisesRegex(ValueError, r'argument'):
+            from_csv(dir=csvfiles_path, method='no-such-method')
+        with self.assertRaisesRegex(ValueError, r"isn't result of method"):
+            from_csv(dir=csvfiles_path, method='optimize')
         # use missing dir
         csvfiles_path = os.path.join(DATAFILES_PATH, 'no-such-directory')
         with self.assertRaisesRegex(ValueError, r'not found'):
-            CmdStanMCMC.from_csv(dir=csvfiles_path)
+            from_csv(dir=csvfiles_path, method='sample')
         # use none
         with self.assertRaisesRegex(ValueError, r'Must specify directory'):
-            CmdStanMCMC.from_csv(None)
+            from_csv(None, method='sample')
         # no csv files
         no_csvfiles_path = os.path.join(
             DATAFILES_PATH, 'test-fail-empty-directory'
@@ -649,7 +652,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             shutil.rmtree(no_csvfiles_path, ignore_errors=True)
         os.mkdir(no_csvfiles_path)
         with self.assertRaisesRegex(ValueError, r'No CSV files found'):
-            CmdStanMCMC.from_csv(dir=no_csvfiles_path)
+            from_csv(dir=no_csvfiles_path, method='sample')
         if os.path.exists(no_csvfiles_path):
             shutil.rmtree(no_csvfiles_path, ignore_errors=True)
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -633,6 +633,15 @@ class CmdStanMCMCTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r'Must specify directory'):
             from_csv(None)
 
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-good')
+        with self.assertRaisesRegex(ValueError, r'Bad method argument'):
+            from_csv(csvfiles_path, 'not-a-method')
+
+        with self.assertRaisesRegex(
+            ValueError, r'Expecting Stan CSV output files from method optimize'
+        ):
+            from_csv(csvfiles_path, 'optimize')
+
         csvfiles_path = os.path.join(DATAFILES_PATH, 'no-such-directory')
         with self.assertRaisesRegex(ValueError, r'not found'):
             from_csv(dir=csvfiles_path)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -634,7 +634,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         for file in os.listdir(csvfiles_path):
             if file.endswith(".csv"):
                 csvfiles.append(os.path.join(csvfiles_path, file))
-        bern_fit = from_csv(path=csvfiles_path)
+        bern_fit = from_csv(path=csvfiles)
         draws_pd = bern_fit.draws_pd()
         self.assertEqual(
             draws_pd.shape,
@@ -677,6 +677,23 @@ class CmdStanMCMCTest(unittest.TestCase):
             ValueError, r'Expecting Stan CSV output files from method optimize'
         ):
             from_csv(csvfiles_path, 'optimize')
+
+        csvfiles = []
+        with self.assertRaisesRegex(ValueError, r'No CSV files found'):
+            from_csv(csvfiles, 'sample')
+
+        for file in os.listdir(csvfiles_path):
+            csvfiles.append(os.path.join(csvfiles_path, file))
+        with self.assertRaisesRegex(ValueError, r'Bad CSV file path spec'):
+            from_csv(csvfiles, 'sample')
+
+        csvfiles_path = os.path.join(csvfiles_path, '*')
+        with self.assertRaisesRegex(ValueError, r'Bad CSV file path spec'):
+            from_csv(csvfiles_path, 'sample')
+
+        csvfiles_path = os.path.join(csvfiles_path, '*')
+        with self.assertRaisesRegex(ValueError, r'Invalid path specification'):
+            from_csv(csvfiles_path, 'sample')
 
         csvfiles_path = os.path.join(DATAFILES_PATH, 'no-such-directory')
         with self.assertRaisesRegex(ValueError, r'Invalid path specification'):

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -29,6 +29,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 DATAFILES_PATH = os.path.join(HERE, 'data')
 GOODFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-good')
 BADFILES_PATH = os.path.join(DATAFILES_PATH, 'runset-bad')
+
+# metadata should make this unnecessary
 SAMPLER_STATE = [
     'lp__',
     'accept_stat__',
@@ -38,8 +40,8 @@ SAMPLER_STATE = [
     'divergent__',
     'energy__',
 ]
+# metadata should make this unnecessary
 BERNOULLI_COLS = SAMPLER_STATE + ['theta']
-
 
 class SampleTest(unittest.TestCase):
 
@@ -592,7 +594,7 @@ class CmdStanMCMCTest(unittest.TestCase):
         ]
         fit = CmdStanMCMC(runset)
         phis = ['phi[{}]'.format(str(x + 1)) for x in range(2095)]
-        column_names = SAMPLER_STATE + phis
+        column_names = list(fit.sampler_vars_cols.keys()) + phis
         self.assertEqual(fit.num_draws_sampling, 1000)
         self.assertEqual(fit.column_names, tuple(column_names))
         self.assertEqual(fit.metric_type, 'diag_e')
@@ -603,6 +605,24 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertEqual((2000, 2095), phis.shape)
         with self.assertRaisesRegex(ValueError, r'unknown parameter: gamma'):
             fit.draws_pd(params=['gamma'])
+
+    def test_instantiate_from_csvfiles(self):
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-good')
+        bern_fit = CmdStanMCMC.from_csv(dir=csvfiles_path)
+        draws_pd = bern_fit.draws_pd()
+        self.assertEqual(
+            draws_pd.shape,
+            (bern_fit.runset.chains * bern_fit.num_draws_sampling, len(bern_fit.column_names)),
+        )
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-big')
+        big_fit = CmdStanMCMC.from_csv(dir=csvfiles_path)
+        draws_pd = big_fit.draws_pd()
+        self.assertEqual(
+            draws_pd.shape,
+            (big_fit.runset.chains * big_fit.num_draws_sampling, len(big_fit.column_names)),
+        )
+
+
 
     # pylint: disable=no-self-use
     def test_custom_metric(self):
@@ -1027,17 +1047,14 @@ class CmdStanMCMCTest(unittest.TestCase):
         self.assertEqual(SAMPLER_STATE, list(diags))
         for diag in diags.values():
             self.assertEqual(diag.shape, (100, 2))
-            self.assertEqual(
-                bern_fit.sample.shape, (100, 2, len(BERNOULLI_COLS))
-            )
-
+            
         with LogCapture() as log:
             diags = bern_fit.sampler_diagnostics()
             self.assertEqual(SAMPLER_STATE, list(diags))
             for diag in diags.values():
                 self.assertEqual(diag.shape, (100, 2))
-                self.assertEqual(
-                    bern_fit.sample.shape, (100, 2, len(BERNOULLI_COLS))
+            self.assertEqual(
+                bern_fit.sample.shape, (100, 2, len(BERNOULLI_COLS))
                 )
         log.check_present(
             (

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -65,7 +65,7 @@ class CmdStanVBTest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'variational')
-        variational = from_csv(dir=csvfiles_path)
+        variational = from_csv(path=csvfiles_path)
         self.assertIn(
             'CmdStanVB: model=eta_should_be_big', variational.__repr__()
         )

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -65,7 +65,7 @@ class CmdStanVBTest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'variational')
-        variational = from_csv(dir=csvfiles_path, method='variational')
+        variational = from_csv(dir=csvfiles_path)
         self.assertIn(
             'CmdStanVB: model=eta_should_be_big', variational.__repr__()
         )

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -1,7 +1,6 @@
 """CmdStan method variational tests"""
 
 import os
-import shutil
 import unittest
 from math import fabs
 
@@ -9,7 +8,7 @@ import pytest
 
 from cmdstanpy.cmdstan_args import CmdStanArgs, VariationalArgs
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.stanfit import CmdStanVB, RunSet
+from cmdstanpy.stanfit import from_csv, CmdStanVB, RunSet
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DATAFILES_PATH = os.path.join(HERE, 'data')
@@ -66,7 +65,7 @@ class CmdStanVBTest(unittest.TestCase):
 
     def test_instantiate_from_csvfiles(self):
         csvfiles_path = os.path.join(DATAFILES_PATH, 'variational')
-        variational = CmdStanVB.from_csv(dir=csvfiles_path)
+        variational = from_csv(dir=csvfiles_path, method='variational')
         self.assertIn(
             'CmdStanVB: model=eta_should_be_big', variational.__repr__()
         )
@@ -82,33 +81,6 @@ class CmdStanVBTest(unittest.TestCase):
             variational.variational_params_dict['mu[2]'], 28.8141, places=2
         )
         self.assertEqual(variational.variational_sample.shape, (1000, 5))
-
-    def test_instantiate_from_csvfiles_fail(self):
-        # use sampler dataset
-        csvfiles_path = os.path.join(DATAFILES_PATH, 'runset-good')
-        with self.assertRaisesRegex(
-            ValueError, r'result of method variational'
-        ):
-            CmdStanVB.from_csv(dir=csvfiles_path)
-        # use missing dir
-        csvfiles_path = os.path.join(DATAFILES_PATH, 'no-such-directory')
-        with self.assertRaisesRegex(ValueError, r'not found'):
-            CmdStanVB.from_csv(dir=csvfiles_path)
-        # use none
-        with self.assertRaisesRegex(ValueError, r'Must specify directory'):
-            CmdStanVB.from_csv(None)
-        # no csv files
-        no_csvfiles_path = os.path.join(
-            DATAFILES_PATH, 'test-fail-empty-directory'
-        )
-        if os.path.exists(no_csvfiles_path):
-            shutil.rmtree(no_csvfiles_path, ignore_errors=True)
-        os.mkdir(no_csvfiles_path)
-        with self.assertRaisesRegex(ValueError, r'No CSV files found'):
-            CmdStanVB.from_csv(dir=no_csvfiles_path)
-        if os.path.exists(no_csvfiles_path):
-            shutil.rmtree(no_csvfiles_path, ignore_errors=True)
-        # method variational, no algorithm specified - shouldn't happen
 
 
 class VariationalTest(unittest.TestCase):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Created class method `from_csv` for CmdStanMCMC, CmdStanMLE, and CmdStanVB objects to reconstitute inference object from saved CSV files.  Utility function `validate_csvfiles` generalizes the step of finding the (list of) csvfiles and doing a quick parse of the header of the first file.  The list of files and config information is then used by the class methods to create the object itself.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):   Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

