### PR TITLE
Support xarray draws object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,5 @@ htmlcov
 docsrc/_build
 .idea
 .DS_Store
-*.hpp
-*.exe
 .mypy_cache
 *.dll

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1011,10 +1011,18 @@ class CmdStanMCMC:
             if not inc_warmup and self._save_warmup:
                 draw1 = self.num_draws_warmup
             col_idxs = self._metadata.stan_vars_cols[var]
+
             var_dims = dims + tuple(
                 f"{var}_dim_{i}" for i in range(len(self.stan_vars_dims[var]))
             )
-            data[var] = (var_dims, np.squeeze(self._draws[draw1:, :, col_idxs]))
+
+            if self.stan_vars_dims[var] == ():
+                data[var] = (
+                    var_dims,
+                    np.squeeze(self._draws[draw1:, :, col_idxs], axis=2),
+                )
+            else:
+                data[var] = (var_dims, self._draws[draw1:, :, col_idxs])
 
         return xr.Dataset(data, coords=coordinates, attrs=attrs).transpose(
             'chain', 'draw', ...

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1004,8 +1004,8 @@ class CmdStanMCMC:
             attrs["num_draws_warmup"] = self.num_draws_warmup
 
         data = {}
-        coordinates = {"chains": self.chain_ids, "draws": np.arange(num_draws)}
-        dims = ("draws", "chains")
+        coordinates = {"chain": self.chain_ids, "draw": np.arange(num_draws)}
+        dims = ("draw", "chain")
         for var in vars:
             draw1 = 0
             if not inc_warmup and self._save_warmup:
@@ -1017,7 +1017,7 @@ class CmdStanMCMC:
             data[var] = (var_dims, np.squeeze(self._draws[draw1:, :, col_idxs]))
 
         return xr.Dataset(data, coords=coordinates, attrs=attrs).transpose(
-            'chains', 'draws', ...
+            'chain', 'draw', ...
         )
 
     def stan_variable(self, name: str, inc_warmup: bool = False) -> np.ndarray:

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,1 +1,2 @@
 tqdm
+xarray

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ pytest
 pytest-cov
 testfixtures
 tqdm
+xarray

--- a/test/data/.gitignore
+++ b/test/data/.gitignore
@@ -1,0 +1,8 @@
+# this line ignores everything
+*
+!/**/
+# and then this 'unignores' anything with an extension
+!*.*
+# and we re-ignore hpp and exe files
+*.hpp
+*.exe

--- a/test/data/bernoulli_array.stan
+++ b/test/data/bernoulli_array.stan
@@ -1,0 +1,11 @@
+data {
+  int<lower=0> N;
+  int<lower=0,upper=1> y[N];
+}
+parameters {
+  real<lower=0,upper=1> theta[1];
+}
+model {
+  theta[1] ~ beta(1,1);  // uniform prior on interval 0,1
+  y ~ bernoulli(theta[1]);
+}

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -43,7 +43,9 @@ class CmdStanModelTest(unittest.TestCase):
         for root, _, files in os.walk(DATAFILES_PATH):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.d', '.hpp', '.exe', ''):
+                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
+                    filename != ".gitignore"
+                ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -9,7 +9,7 @@ import pytest
 
 from cmdstanpy.cmdstan_args import CmdStanArgs, OptimizeArgs
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.stanfit import from_csv, CmdStanMLE, RunSet
+from cmdstanpy.stanfit import CmdStanMLE, RunSet, from_csv
 from cmdstanpy.utils import EXTENSION
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -24,7 +24,9 @@ class CmdStanMLETest(unittest.TestCase):
         for root, _, files in os.walk(DATAFILES_PATH):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.hpp', '.exe', ''):
+                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
+                    filename != ".gitignore"
+                ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -52,7 +52,9 @@ class SampleTest(unittest.TestCase):
         for root, _, files in os.walk(DATAFILES_PATH):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.hpp', '.exe', ''):
+                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
+                    filename != ".gitignore"
+                ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -8,7 +8,7 @@ import pytest
 
 from cmdstanpy.cmdstan_args import CmdStanArgs, VariationalArgs
 from cmdstanpy.model import CmdStanModel
-from cmdstanpy.stanfit import from_csv, CmdStanVB, RunSet
+from cmdstanpy.stanfit import CmdStanVB, RunSet, from_csv
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DATAFILES_PATH = os.path.join(HERE, 'data')
@@ -24,7 +24,9 @@ class CmdStanVBTest(unittest.TestCase):
         ):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.hpp', '.exe', ''):
+                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
+                    filename != ".gitignore"
+                ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 
@@ -93,7 +95,9 @@ class VariationalTest(unittest.TestCase):
         ):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.hpp', '.exe', ''):
+                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
+                    filename != ".gitignore"
+                ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Add an optional dependency on [xarray](https://xarray.pydata.org/en/stable/index.html) and add the ability to call `.draws_xr()` on a CmdStanMCMC object. Modeled after `.draws_pd()`

![screenshot](https://i.imgur.com/rifAwta.png)

This allows more natural processing of multi-dimensional quantities, and should interop slightly easier with packages like arviz which use xarray extensively. 

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

