### PR TITLE
Feature/405 extend stan variables

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -690,7 +690,7 @@ class CmdStanModel:
             and consistency.
 
         :param refresh: Specify the number of iterations cmdstan will take
-        between progress messages. Default value is 100.
+            between progress messages. Default value is 100.
 
         :return: CmdStanMCMC object
         """

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -526,7 +526,6 @@ class CmdStanModel:
         save_diagnostics: bool = False,
         save_profile: bool = False,
         show_progress: Union[bool, str] = False,
-        validate_csv: bool = True,
         refresh: int = None,
     ) -> CmdStanMCMC:
         """
@@ -683,11 +682,6 @@ class CmdStanModel:
         :param show_progress: Use tqdm progress bar to show sampling progress.
             If show_progress=='notebook' use tqdm_notebook
             (needs nodejs for jupyter).
-
-        :param validate_csv: If ``False``, skip scan of sample csv output file.
-            When sample is large or disk i/o is slow, will speed up processing.
-            Default is ``True`` - sample csv files are scanned for completeness
-            and consistency.
 
         :param refresh: Specify the number of iterations cmdstan will take
             between progress messages. Default value is 100.
@@ -863,7 +857,7 @@ class CmdStanModel:
                 )
                 raise RuntimeError(msg)
 
-            mcmc = CmdStanMCMC(runset, validate_csv, logger=self._logger)
+            mcmc = CmdStanMCMC(runset, logger=self._logger)
         return mcmc
 
     def generate_quantities(

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -394,7 +394,6 @@ class InferenceMetadata:
         """
         return copy.deepcopy(self._stan_vars_cols)
 
-
     @property
     def stan_vars_dims(self) -> Dict[str, Tuple[int]]:
         """
@@ -492,7 +491,6 @@ class CmdStanMCMC:
         thinned sampling iterations.
         """
         return int(math.ceil((self._iter_sampling) / self._thin))
-
 
     @property
     def metadata(self) -> InferenceMetadata:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1132,9 +1132,6 @@ class CmdStanMLE:
         shape = ()
         if len(col_idxs) > 0:
             shape = self._metadata.stan_vars_dims[name]
-        print('xs: {}'.format(xs))
-        print('len xs: {}'.format(len(xs)))
-        print('shape: {}'.format(shape))
         return np.array(xs).reshape(shape)
 
     def stan_variables(self) -> Dict[str, np.ndarray]:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1135,7 +1135,7 @@ class CmdStanMLE:
         if len(col_idxs) > 0:
             shape = self._metadata.stan_vars_dims[name]
         return np.ndarray(
-            shape=shape, buffer=np.array(xs)
+            np.array(xs).reshape(shape)
         )
 
     def stan_variables(self) -> Dict[str, np.ndarray]:
@@ -1384,7 +1384,7 @@ class CmdStanVB:
         if len(col_idxs) > 0:
             shape = self._metadata.stan_vars_dims[name]
         return np.ndarray(
-            shape=shape, buffer=np.array(xs)
+            np.array(xs).reshape(shape)
         )
 
     def stan_variables(self) -> Dict[str, np.ndarray]:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -504,6 +504,39 @@ class CmdStanMCMC:
         return self._metadata
 
     @property
+    def sampler_vars_cols(self) -> Dict:
+        """
+        Deprecated - use "metadata.method_vars_cols" instead
+        """
+        self._logger.warning(
+            'property "sampler_vars_cols" has been deprecated, '
+            'use "metadata.method_vars_cols" instead.'
+        )
+        return self.metadata.method_vars_cols
+
+    @property
+    def stan_vars_cols(self) -> Dict:
+        """
+        Deprecated - use "metadata.stan_vars_cols" instead
+        """
+        self._logger.warning(
+            'property "stan_vars_cols" has been deprecated, '
+            'use "metadata.stan_vars_cols" instead.'
+        )
+        return self.metadata.method_vars_cols
+
+    @property
+    def stan_vars_dims(self) -> Dict:
+        """
+        Deprecated - use "metadata.stan_vars_dims" instead
+        """
+        self._logger.warning(
+            'property "stan_vars_dims" has been deprecated, '
+            'use "metadata.stan_vars_dims" instead.'
+        )
+        return self.metadata.stan_vars_dims
+
+    @property
     def column_names(self) -> Tuple[str]:
         """
         Names of all outputs from the sampler, comprising sampler parameters
@@ -621,7 +654,7 @@ class CmdStanMCMC:
         Deprecated - use method "draws()" instead.
         """
         self._logger.warning(
-            'method "sample" will be deprecated, use method "draws" instead.'
+            'method "sample" has been deprecated, use method "draws" instead.'
         )
         return self.draws()
 
@@ -961,9 +994,10 @@ class CmdStanMCMC:
         # pylint: disable=redundant-keyword-arg
         return self._draws[draw1:, :, col_idxs].reshape(dims, order='F')
 
-    def stan_variables(self) -> Dict:
+    def stan_variables(self) -> Dict[str, np.ndarray]:
         """
-        Return a dictionary of all Stan program variables.
+        Return a dictionary mapping Stan program variables names
+        to the corresponding numpy.ndarray containing the inferred values.
         """
         result = {}
         for name in self._metadata.stan_vars_dims.keys():
@@ -985,9 +1019,22 @@ class CmdStanMCMC:
                 result[self.column_names[idx]] = self._draws[:, :, idx]
         return result
 
-    def sampler_diagnostics(self) -> Dict:
+    def sampler_variables(self) -> Dict:
+        """
+        Deprecated, use "method_variables" instead
+        """
         self._logger.warning(
-            'method "sampler_diagnostics" will be deprecated, '
+            'method "sampler_variables" has been deprecated, '
+            'use method "method_variables" instead.'
+        )
+        return self.method_variables()
+
+    def sampler_diagnostics(self) -> Dict:
+        """
+        Deprecated, use "method_variables" instead
+        """
+        self._logger.warning(
+            'method "sampler_diagnostics" has been deprecated, '
             'use method "method_variables" instead.'
         )
         return self.method_variables()
@@ -1073,6 +1120,13 @@ class CmdStanMLE:
         return OrderedDict(zip(self.column_names, self._mle))
 
     def stan_variable(self, name: str) -> np.ndarray:
+        """
+        Return a numpy.ndarray which contains the estimates for the
+        for the named Stan program variable where the dimensions of the
+        numpy.ndarray match the shape of the Stan program variable.
+
+        :param name: variable name
+        """
         if name not in self._metadata.stan_vars_dims:
             raise ValueError('unknown name: {}'.format(name))
         col_idxs = list(self._metadata.stan_vars_cols[name])
@@ -1085,9 +1139,10 @@ class CmdStanMLE:
             shape=shape, buffer=np.array(xs)
         )
 
-    def stan_variables(self) -> Dict:
+    def stan_variables(self) -> Dict[str, np.ndarray]:
         """
-        Return a dictionary of all Stan program variables.
+        Return a dictionary mapping Stan program variables names
+        to the corresponding numpy.ndarray containing the inferred values.
         """
         result = {}
         for name in self._metadata.stan_vars_dims.keys():
@@ -1314,6 +1369,13 @@ class CmdStanVB:
         return self._metadata
 
     def stan_variable(self, name: str) -> np.ndarray:
+        """
+        Return a numpy.ndarray which contains the estimates for the
+        for the named Stan program variable where the dimensions of the
+        numpy.ndarray match the shape of the Stan program variable.
+
+        :param name: variable name
+        """
         if name not in self._metadata.stan_vars_dims:
             raise ValueError('unknown name: {}'.format(name))
         col_idxs = list(self._metadata.stan_vars_cols[name])
@@ -1326,9 +1388,10 @@ class CmdStanVB:
             shape=shape, buffer=np.array(xs)
         )
 
-    def stan_variables(self) -> Dict:
+    def stan_variables(self) -> Dict[str, np.ndarray]:
         """
-        Return a dictionary of all Stan program variables.
+        Return a dictionary mapping Stan program variables names
+        to the corresponding numpy.ndarray containing the inferred values.
         """
         result = {}
         for name in self._metadata.stan_vars_dims.keys():

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -358,9 +358,7 @@ class InferenceMetadata:
     def __init__(self, config: Dict) -> None:
         """Initialize object from CSV headers"""
         self._cmdstan_config = config
-        self._method_vars_cols = parse_method_vars(
-            names=config['column_names']
-        )
+        self._method_vars_cols = parse_method_vars(names=config['column_names'])
         stan_vars_dims, stan_vars_cols = parse_stan_vars(
             names=config['column_names']
         )
@@ -1134,9 +1132,10 @@ class CmdStanMLE:
         shape = ()
         if len(col_idxs) > 0:
             shape = self._metadata.stan_vars_dims[name]
-        return np.ndarray(
-            np.array(xs).reshape(shape)
-        )
+        print('xs: {}'.format(xs))
+        print('len xs: {}'.format(len(xs)))
+        print('shape: {}'.format(shape))
+        return np.array(xs).reshape(shape)
 
     def stan_variables(self) -> Dict[str, np.ndarray]:
         """
@@ -1383,9 +1382,7 @@ class CmdStanVB:
         shape = ()
         if len(col_idxs) > 0:
             shape = self._metadata.stan_vars_dims[name]
-        return np.ndarray(
-            np.array(xs).reshape(shape)
-        )
+        return np.array(xs).reshape(shape)
 
     def stan_variables(self) -> Dict[str, np.ndarray]:
         """

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -543,7 +543,7 @@ class CmdStanMCMC:
         Returns map from Stan program variable names to variable dimensions.
         Scalar types are mapped to the empty tuple, e.g.,
         program variable ``int foo`` has dimesion ``()`` and
-        program variable ``vector[10] bar`` has dimension ``(10,)``.
+        program variable ``vector[10] bar`` has single dimension ``(10)``.
         """
         if self._metadata is None:
             self.validate_csv_files()
@@ -1125,7 +1125,7 @@ class CmdStanMLE:
         if len(col_idxs) > 0:
             shape = self._metadata.stan_vars_dims[name]
         return np.ndarray(
-            shape = shape, buffer = np.array(xs)
+            shape=shape, buffer=np.array(xs)
         )
 
     def stan_variables(self) -> Dict:
@@ -1136,8 +1136,6 @@ class CmdStanMLE:
         for name in self.stan_vars_dims.keys():
             result[name] = self.stan_variable(name)
         return result
-
-
 
     def save_csvfiles(self, dir: str = None) -> None:
         """
@@ -1354,7 +1352,7 @@ class CmdStanVB:
         Returns map from Stan program variable names to variable dimensions.
         Scalar types are mapped to the empty tuple, e.g.,
         program variable ``int foo`` has dimesion ``()`` and
-        program variable ``vector[10] bar`` has dimension ``(10,)``.
+        program variable ``vector[10] bar`` has single dimension ``(10)``.
         """
         return self._metadata.stan_vars_dims
 
@@ -1374,12 +1372,16 @@ class CmdStanVB:
         return OrderedDict(zip(self.column_names, self._variational_mean))
 
     def stan_variable(self, name: str) -> np.ndarray:
-        col_idxs = self._metadata.stan_vars_cols[name]
+        if name not in self.stan_vars_dims:
+            raise ValueError('unknown name: {}'.format(name))
+        col_idxs = list(self._metadata.stan_vars_cols[name])
+        vals = list(self._variational_mean)
+        xs = [vals[x] for x in col_idxs]
         shape = ()
         if len(col_idxs) > 0:
             shape = self._metadata.stan_vars_dims[name]
         return np.ndarray(
-            shape = shape, buffer = np.array(self._variational_mean[col_idxs])
+            shape=shape, buffer=np.array(xs)
         )
 
     def stan_variables(self) -> Dict:

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -711,7 +711,7 @@ class CmdStanMCMC:
                         and dzero[key] != drest[key]
                     ):
                         raise ValueError(
-                            'Stan CSV file {} found CmdStan config mismatch, '
+                            'CmdStan config mismatch in Stan CSV file {}: '
                             'arg {} is {}, expected {}'.format(
                                 self.runset.csv_files[i],
                                 key,

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1116,6 +1116,8 @@ class CmdStanMLE:
         return OrderedDict(zip(self.column_names, self._mle))
 
     def stan_variable(self, name: str) -> np.ndarray:
+        if name not in self.stan_vars_dims:
+            raise ValueError('unknown name: {}'.format(name))
         col_idxs = list(self._metadata.stan_vars_cols[name])
         vals = list(self._mle)
         xs = [vals[x] for x in col_idxs]

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -451,7 +451,7 @@ class CmdStanMCMC:
         # info from CSV initial comments and header
         self._metadata = InferenceMetadata(self._validate_csv_files())
         # info from CSV values, instantiated lazily
-        self._metric = None 
+        self._metric = None
         self._step_size = None
         self._draws = None
         self._draws_pd = None
@@ -563,7 +563,6 @@ class CmdStanMCMC:
         has 4 constrained and 3 unconstrained parameters.
         """
         return self._metadata.cmdstan_config['num_unconstrained_params']
-    
 
     @property
     def metric_type(self) -> str:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -658,20 +658,21 @@ def munge_varnames(names: List[str]) -> List[str]:
     ]
 
 
-def parse_sampler_vars(names: Tuple[str, ...]) -> Dict:
+def parse_method_vars(names: Tuple[str]) -> Dict[str, Tuple[int]]:
     """
     Parses out names ending in `__` from list of CSV file column names.
     Return a dict mapping sampler variable name to Stan CSV file column, using
     zero-based column indexing.
+    Currently, (Stan 2.X) all CmdStan inference method vars are scalar,
+    the map entries are tuples of int to allow for structured variables.
     """
     if names is None:
         raise ValueError('missing argument "names"')
-    # note: value as tuple allows structured sampler vars
-    # currently, all sampler vars a scalar, not checking for structure
+    # note: method vars are currently all scalar so not checking for structure
     return {v: tuple([k]) for (k, v) in enumerate(names) if v.endswith('__')}
 
 
-def parse_stan_vars(names: Tuple[str, ...]) -> (Dict, Dict):
+def parse_stan_vars(names: Tuple[str]) -> (Dict[str, Tuple[int]], Dict[str, Tuple[int]]):
     """
     Parses out Stan variable names (i.e., names not ending in `__`)
     from list of CSV file column names.

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -203,7 +203,7 @@ def cmdstan_version_at(maj: int, min: int) -> bool:
     return False
 
 
-def cxx_toolchain_path(version: str = None) -> Tuple[str]:
+def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
     """
     Validate, then activate C++ toolchain directory path.
     """
@@ -469,12 +469,12 @@ def check_sampler_csv(
     elif thin > _CMDSTAN_THIN:
         if 'thin' not in meta:
             raise ValueError(
-                'bad csv file {}, '
+                'bad Stan CSV file {}, '
                 'config error, expected thin = {}'.format(path, thin)
             )
         if meta['thin'] != thin:
             raise ValueError(
-                'bad csv file {}, '
+                'bad Stan CSV file {}, '
                 'config error, expected thin = {}, found {}'.format(
                     path, thin, meta['thin']
                 )
@@ -489,19 +489,19 @@ def check_sampler_csv(
     draws_sampling = int(math.ceil(draws_sampling / thin))
     if meta['draws_sampling'] != draws_sampling:
         raise ValueError(
-            'bad csv file {}, expected {} draws, found {}'.format(
+            'bad Stan CSV file {}, expected {} draws, found {}'.format(
                 path, draws_sampling, meta['draws_sampling']
             )
         )
     if save_warmup:
         if not ('save_warmup' in meta and meta['save_warmup'] == 1):
             raise ValueError(
-                'bad csv file {}, '
+                'bad Stan CSV file {}, '
                 'config error, expected save_warmup = 1'.format(path)
             )
         if meta['draws_warmup'] != draws_warmup:
             raise ValueError(
-                'bad csv file {}, '
+                'bad Stan CSV file {}, '
                 'expected {} warmup draws, found {}'.format(
                     path, draws_warmup, meta['draws_warmup']
                 )
@@ -658,7 +658,7 @@ def munge_varnames(names: List[str]) -> List[str]:
     ]
 
 
-def parse_method_vars(names: Tuple[str]) -> Dict[str, Tuple[int]]:
+def parse_method_vars(names: Tuple[str, ...]) -> Dict[str, Tuple[int, ...]]:
     """
     Parses out names ending in `__` from list of CSV file column names.
     Return a dict mapping sampler variable name to Stan CSV file column, using
@@ -673,8 +673,8 @@ def parse_method_vars(names: Tuple[str]) -> Dict[str, Tuple[int]]:
 
 
 def parse_stan_vars(
-    names: Tuple[str],
-) -> (Dict[str, Tuple[int]], Dict[str, Tuple[int]]):
+    names: Tuple[str, ...]
+) -> Tuple[Dict[str, Tuple[int, ...]], Dict[str, Tuple[int, ...]]]:
     """
     Parses out Stan variable names (i.e., names not ending in `__`)
     from list of CSV file column names.

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -672,7 +672,8 @@ def parse_method_vars(names: Tuple[str]) -> Dict[str, Tuple[int]]:
     return {v: tuple([k]) for (k, v) in enumerate(names) if v.endswith('__')}
 
 
-def parse_stan_vars(names: Tuple[str]) -> (Dict[str, Tuple[int]], Dict[str, Tuple[int]]):
+def parse_stan_vars(names: Tuple[str]) ->
+    (Dict[str, Tuple[int]], Dict[str, Tuple[int]]):
     """
     Parses out Stan variable names (i.e., names not ending in `__`)
     from list of CSV file column names.

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -672,8 +672,9 @@ def parse_method_vars(names: Tuple[str]) -> Dict[str, Tuple[int]]:
     return {v: tuple([k]) for (k, v) in enumerate(names) if v.endswith('__')}
 
 
-def parse_stan_vars(names: Tuple[str]) ->
-    (Dict[str, Tuple[int]], Dict[str, Tuple[int]]):
+def parse_stan_vars(
+    names: Tuple[str],
+) -> (Dict[str, Tuple[int]], Dict[str, Tuple[int]]):
     """
     Parses out Stan variable names (i.e., names not ending in `__`)
     from list of CSV file column names.

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -66,8 +66,8 @@ class InferenceMetadataTest(unittest.TestCase):
             'energy__',
         }
 
-        sampler_vars_cols = metadata.sampler_vars_cols
-        self.assertEqual(hmc_vars, sampler_vars_cols.keys())
+        method_vars_cols = metadata.method_vars_cols
+        self.assertEqual(hmc_vars, method_vars_cols.keys())
         bern_model_vars = {'theta'}
         self.assertEqual(bern_model_vars, metadata.stan_vars_dims.keys())
         self.assertEqual((), metadata.stan_vars_dims['theta'])

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -81,7 +81,7 @@ class CmdStanMLETest(unittest.TestCase):
         self.assertTrue('theta' in bern_mle.stan_vars_dims)
         self.assertEqual(bern_mle.stan_vars_dims['theta'], ())
         theta = bern_mle.stan_variable(name='theta')
-        self.assertFalse(isinstane(theta, np.ndarray))
+        self.assertEqual(theta.shape, ())
         with self.assertRaises(ValueError):
             bern_mle.stan_variable(name='eta')
         with self.assertRaises(ValueError):

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -60,6 +60,69 @@ class CmdStanMLETest(unittest.TestCase):
         self.assertAlmostEqual(mle.optimized_params_dict['x'], 1, places=3)
         self.assertAlmostEqual(mle.optimized_params_dict['y'], 1, places=3)
 
+    def test_variable_bern(self):
+        stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+        bern_model = CmdStanModel(stan_file=stan)
+        bern_mle = bern_model.optimize(
+            data=jdata,
+            seed=1239812093,
+            algorithm='LBFGS',
+            init_alpha=0.001,
+            iter=100,
+            tol_obj=1e-12,
+            tol_rel_obj=1e4,
+            tol_grad=1e-8,
+            tol_rel_grad=1e7,
+            tol_param=1e-8,
+            history_size=5,
+        )
+        self.assertEqual(1, len(bern_mle.stan_vars_dims))
+        self.assertTrue('theta' in bern_mle.stan_vars_dims)
+        self.assertEqual(bern_mle.stan_vars_dims['theta'], ())
+        theta = bern_mle.stan_variable(name='theta')
+        self.assertFalse(isinstane(theta, np.ndarray))
+        with self.assertRaises(ValueError):
+            bern_mle.stan_variable(name='eta')
+        with self.assertRaises(ValueError):
+            bern_mle.stan_variable(name='lp__')
+
+    def test_variables_3d(self):
+        # construct fit using existing sampler output
+        stan = os.path.join(DATAFILES_PATH, 'multidim_vars.stan')
+        jdata = os.path.join(DATAFILES_PATH, 'logistic.data.R')
+        multidim_model = CmdStanModel(stan_file=stan)
+        multidim_mle = multidim_model.optimize(
+            data=jdata,
+            seed=1239812093,
+            algorithm='LBFGS',
+            init_alpha=0.001,
+            iter=100,
+            tol_obj=1e-12,
+            tol_rel_obj=1e4,
+            tol_grad=1e-8,
+            tol_rel_grad=1e7,
+            tol_param=1e-8,
+            history_size=5,
+        )
+        self.assertEqual(3, len(multidim_mle.stan_vars_dims))
+        self.assertTrue('y_rep' in multidim_mle.stan_vars_dims)
+        self.assertEqual(multidim_mle.stan_vars_dims['y_rep'], (5, 4, 3))
+        var_y_rep = multidim_mle.stan_variable(name='y_rep')
+        self.assertEqual(var_y_rep.shape, (5, 4, 3))
+        var_beta = multidim_mle.stan_variable(name='beta')
+        self.assertEqual(var_beta.shape, (2,))  # 1-element tuple
+        var_frac_60 = multidim_mle.stan_variable(name='frac_60')
+        self.assertEqual(var_frac_60.shape, ())
+        vars = multidim_mle.stan_variables()
+        self.assertEqual(len(vars), len(multidim_mle.stan_vars_dims))
+        self.assertTrue('y_rep' in vars)
+        self.assertEqual(vars['y_rep'].shape, (5, 4, 3))
+        self.assertTrue('beta' in vars)
+        self.assertEqual(vars['beta'].shape, (2,))
+        self.assertTrue('frac_60' in vars)
+        self.assertEqual(vars['frac_60'].shape, ())
+
 
 class OptimizeTest(unittest.TestCase):
     def test_optimize_good(self):

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -77,9 +77,9 @@ class CmdStanMLETest(unittest.TestCase):
             tol_param=1e-8,
             history_size=5,
         )
-        self.assertEqual(1, len(bern_mle.stan_vars_dims))
-        self.assertTrue('theta' in bern_mle.stan_vars_dims)
-        self.assertEqual(bern_mle.stan_vars_dims['theta'], ())
+        self.assertEqual(1, len(bern_mle.metadata.stan_vars_dims))
+        self.assertTrue('theta' in bern_mle.metadata.stan_vars_dims)
+        self.assertEqual(bern_mle.metadata.stan_vars_dims['theta'], ())
         theta = bern_mle.stan_variable(name='theta')
         self.assertEqual(theta.shape, ())
         with self.assertRaises(ValueError):
@@ -105,9 +105,9 @@ class CmdStanMLETest(unittest.TestCase):
             tol_param=1e-8,
             history_size=5,
         )
-        self.assertEqual(3, len(multidim_mle.stan_vars_dims))
-        self.assertTrue('y_rep' in multidim_mle.stan_vars_dims)
-        self.assertEqual(multidim_mle.stan_vars_dims['y_rep'], (5, 4, 3))
+        self.assertEqual(3, len(multidim_mle.metadata.stan_vars_dims))
+        self.assertTrue('y_rep' in multidim_mle.metadata.stan_vars_dims)
+        self.assertEqual(multidim_mle.metadata.stan_vars_dims['y_rep'], (5, 4, 3))
         var_y_rep = multidim_mle.stan_variable(name='y_rep')
         self.assertEqual(var_y_rep.shape, (5, 4, 3))
         var_beta = multidim_mle.stan_variable(name='beta')
@@ -115,7 +115,7 @@ class CmdStanMLETest(unittest.TestCase):
         var_frac_60 = multidim_mle.stan_variable(name='frac_60')
         self.assertEqual(var_frac_60.shape, ())
         vars = multidim_mle.stan_variables()
-        self.assertEqual(len(vars), len(multidim_mle.stan_vars_dims))
+        self.assertEqual(len(vars), len(multidim_mle.metadata.stan_vars_dims))
         self.assertTrue('y_rep' in vars)
         self.assertEqual(vars['y_rep'].shape, (5, 4, 3))
         self.assertTrue('beta' in vars)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -107,7 +107,9 @@ class CmdStanMLETest(unittest.TestCase):
         )
         self.assertEqual(3, len(multidim_mle.metadata.stan_vars_dims))
         self.assertTrue('y_rep' in multidim_mle.metadata.stan_vars_dims)
-        self.assertEqual(multidim_mle.metadata.stan_vars_dims['y_rep'], (5, 4, 3))
+        self.assertEqual(
+            multidim_mle.metadata.stan_vars_dims['y_rep'], (5, 4, 3)
+        )
         var_y_rep = multidim_mle.stan_variable(name='y_rep')
         self.assertEqual(var_y_rep.shape, (5, 4, 3))
         var_beta = multidim_mle.stan_variable(name='beta')

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1182,23 +1182,8 @@ class CmdStanMCMCTest(unittest.TestCase):
 
     def test_variables_2d(self):
         # pylint: disable=C0103
-        # construct fit using existing sampler output
-        exe = os.path.join(DATAFILES_PATH, 'lotka-volterra' + EXTENSION)
-        jdata = os.path.join(DATAFILES_PATH, 'lotka-volterra.data.json')
-        sampler_args = SamplerArgs(iter_sampling=20)
-        cmdstan_args = CmdStanArgs(
-            model_name='lotka-volterra',
-            model_exe=exe,
-            chain_ids=[1],
-            seed=12345,
-            data=jdata,
-            output_dir=DATAFILES_PATH,
-            method_args=sampler_args,
-        )
-        runset = RunSet(args=cmdstan_args, chains=1)
-        runset._csv_files = [os.path.join(DATAFILES_PATH, 'lotka-volterra.csv')]
-        runset._set_retcode(0, 0)
-        fit = CmdStanMCMC(runset)
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'lotka-volterra.csv')
+        fit = from_csv(path=csvfiles_path)
         self.assertEqual(20, fit.num_draws_sampling)
         self.assertEqual(8, len(fit.stan_vars_dims))
         self.assertTrue('z' in fit.stan_vars_dims)
@@ -1212,22 +1197,8 @@ class CmdStanMCMCTest(unittest.TestCase):
 
     def test_variables_3d(self):
         # construct fit using existing sampler output
-        exe = os.path.join(DATAFILES_PATH, 'multidim_vars' + EXTENSION)
-        jdata = os.path.join(DATAFILES_PATH, 'logistic.data.R')
-        sampler_args = SamplerArgs(iter_sampling=20)
-        cmdstan_args = CmdStanArgs(
-            model_name='multidim_vars',
-            model_exe=exe,
-            chain_ids=[1],
-            seed=12345,
-            data=jdata,
-            output_dir=DATAFILES_PATH,
-            method_args=sampler_args,
-        )
-        runset = RunSet(args=cmdstan_args, chains=1)
-        runset._csv_files = [os.path.join(DATAFILES_PATH, 'multidim_vars.csv')]
-        runset._set_retcode(0, 0)
-        fit = CmdStanMCMC(runset)
+        csvfiles_path = os.path.join(DATAFILES_PATH, 'multidim_vars.csv')
+        fit = from_csv(path=csvfiles_path)
         self.assertEqual(20, fit.num_draws_sampling)
         self.assertEqual(3, len(fit.stan_vars_dims))
         self.assertTrue('y_rep' in fit.stan_vars_dims)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1095,6 +1095,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             )
         )
 
+    # pylint: disable=pointless-statement
     def test_deprecated(self):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
@@ -1136,7 +1137,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 'cmdstanpy',
                 'WARNING',
                 'method "sampler_diagnostics" has been deprecated, '
-                'use method "method_variables" instead.'
+                'use method "method_variables" instead.',
             )
         )
         with LogCapture() as log:
@@ -1146,7 +1147,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 'cmdstanpy',
                 'WARNING',
                 'method "sampler_variables" has been deprecated, '
-                'use method "method_variables" instead.'
+                'use method "method_variables" instead.',
             )
         )
         with LogCapture() as log:
@@ -1156,7 +1157,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 'cmdstanpy',
                 'WARNING',
                 'property "sampler_vars_cols" has been deprecated, '
-                'use "metadata.method_vars_cols" instead.'
+                'use "metadata.method_vars_cols" instead.',
             )
         )
         with LogCapture() as log:
@@ -1166,7 +1167,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 'cmdstanpy',
                 'WARNING',
                 'property "stan_vars_cols" has been deprecated, '
-                'use "metadata.stan_vars_cols" instead.'
+                'use "metadata.stan_vars_cols" instead.',
             )
         )
         with LogCapture() as log:
@@ -1176,7 +1177,7 @@ class CmdStanMCMCTest(unittest.TestCase):
                 'cmdstanpy',
                 'WARNING',
                 'property "stan_vars_dims" has been deprecated, '
-                'use "metadata.stan_vars_dims" instead.'
+                'use "metadata.stan_vars_dims" instead.',
             )
         )
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1181,7 +1181,6 @@ class CmdStanMCMCTest(unittest.TestCase):
             bern_fit.stan_variable(name='lp__')
 
     def test_variables_2d(self):
-        # pylint: disable=C0103
         csvfiles_path = os.path.join(DATAFILES_PATH, 'lotka-volterra.csv')
         fit = from_csv(path=csvfiles_path)
         self.assertEqual(20, fit.num_draws_sampling)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1109,21 +1109,17 @@ class CmdStanMCMCTest(unittest.TestCase):
             save_warmup=True,
         )
         with LogCapture() as log:
-            self.assertEqual(
-                bern_fit.sample.shape, (100, 2, len(BERNOULLI_COLS))
-            )
+            bern_fit.sample
         log.check_present(
             (
                 'cmdstanpy',
                 'WARNING',
-                'method "sample" will be deprecated,'
+                'method "sample" has been deprecated,'
                 ' use method "draws" instead.',
             )
         )
         with LogCapture() as log:
-            self.assertEqual(
-                bern_fit.warmup.shape, (300, 2, len(BERNOULLI_COLS))
-            )
+            bern_fit.warmup
         log.check_present(
             (
                 'cmdstanpy',
@@ -1131,6 +1127,56 @@ class CmdStanMCMCTest(unittest.TestCase):
                 'method "warmup" has been deprecated, instead use method'
                 ' "draws(inc_warmup=True)", returning draws from both'
                 ' warmup and sampling iterations.',
+            )
+        )
+        with LogCapture() as log:
+            bern_fit.sampler_diagnostics()
+        log.check_present(
+            (
+                'cmdstanpy',
+                'WARNING',
+                'method "sampler_diagnostics" has been deprecated, '
+                'use method "method_variables" instead.'
+            )
+        )
+        with LogCapture() as log:
+            bern_fit.sampler_variables()
+        log.check_present(
+            (
+                'cmdstanpy',
+                'WARNING',
+                'method "sampler_variables" has been deprecated, '
+                'use method "method_variables" instead.'
+            )
+        )
+        with LogCapture() as log:
+            bern_fit.sampler_vars_cols
+        log.check_present(
+            (
+                'cmdstanpy',
+                'WARNING',
+                'property "sampler_vars_cols" has been deprecated, '
+                'use "metadata.method_vars_cols" instead.'
+            )
+        )
+        with LogCapture() as log:
+            bern_fit.stan_vars_cols
+        log.check_present(
+            (
+                'cmdstanpy',
+                'WARNING',
+                'property "stan_vars_cols" has been deprecated, '
+                'use "metadata.stan_vars_cols" instead.'
+            )
+        )
+        with LogCapture() as log:
+            bern_fit.stan_vars_dims
+        log.check_present(
+            (
+                'cmdstanpy',
+                'WARNING',
+                'property "stan_vars_dims" has been deprecated, '
+                'use "metadata.stan_vars_dims" instead.'
             )
         )
 
@@ -1158,7 +1204,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             (
                 'cmdstanpy',
                 'WARNING',
-                'method "sample" will be deprecated,'
+                'method "sample" has been deprecated,'
                 ' use method "draws" instead.',
             )
         )

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1284,56 +1284,6 @@ class CmdStanMCMCTest(unittest.TestCase):
             save_warmup=True,
             validate_csv=False,
         )
-        # check error messages
-        with LogCapture() as log:
-            logging.getLogger()
-            self.assertIsNone(bern_fit.column_names)
-        expect = 'csv files not yet validated'
-        msg = log.actual()[-1][-1]
-        self.assertTrue(msg.startswith(expect))
-
-        with LogCapture() as log:
-            logging.getLogger()
-            self.assertIsNone(bern_fit.num_unconstrained_params)
-        expect = 'csv files not yet validated'
-        msg = log.actual()[-1][-1]
-        self.assertTrue(msg.startswith(expect))
-
-        with LogCapture() as log:
-            logging.getLogger()
-            self.assertIsNone(bern_fit.stan_vars_dims)
-        expect = 'csv files not yet validated'
-        msg = log.actual()[-1][-1]
-        self.assertTrue(msg.startswith(expect))
-
-        with LogCapture() as log:
-            logging.getLogger()
-            self.assertIsNone(bern_fit.stan_vars_cols)
-        expect = 'csv files not yet validated'
-        msg = log.actual()[-1][-1]
-        self.assertTrue(msg.startswith(expect))
-
-        with LogCapture() as log:
-            logging.getLogger()
-            self.assertIsNone(bern_fit.metric_type)
-        expect = 'csv files not yet validated'
-        msg = log.actual()[-1][-1]
-        self.assertTrue(msg.startswith(expect))
-
-        with LogCapture() as log:
-            logging.getLogger()
-            self.assertIsNone(bern_fit.metric)
-        expect = 'csv files not yet validated'
-        msg = log.actual()[-1][-1]
-        self.assertTrue(msg.startswith(expect))
-
-        with LogCapture() as log:
-            logging.getLogger()
-            self.assertIsNone(bern_fit.step_size)
-        expect = 'csv files not yet validated'
-        msg = log.actual()[-1][-1]
-        self.assertTrue(msg.startswith(expect))
-
         # check computations match
         self.assertEqual(bern_fit.num_draws_warmup, 100)
         self.assertEqual(bern_fit.num_draws_sampling, 50)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -949,7 +949,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-3.csv'),
             os.path.join(DATAFILES_PATH, 'runset-bad', 'bad-hdr-bern-4.csv'),
         ]
-        with self.assertRaisesRegex(ValueError, 'header mismatch'):
+        with self.assertRaisesRegex(ValueError, 'CmdStan config mismatch'):
             CmdStanMCMC(runset)
 
         # bad draws

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -26,7 +26,7 @@ from cmdstanpy.utils import (
     get_latest_cmdstan,
     jsondump,
     parse_rdump_value,
-    parse_sampler_vars,
+    parse_method_vars,
     parse_stan_vars,
     rdump,
     read_metric,
@@ -589,7 +589,7 @@ class RloadTest(unittest.TestCase):
 class ParseVarsTest(unittest.TestCase):
     def test_parse_empty(self):
         x = []
-        sampler_vars = parse_sampler_vars(x)
+        sampler_vars = parse_method_vars(x)
         self.assertEqual(len(sampler_vars), 0)
         stan_vars_dims, stan_vars_cols = parse_stan_vars(x)
         self.assertEqual(len(stan_vars_dims), 0)
@@ -597,11 +597,11 @@ class ParseVarsTest(unittest.TestCase):
 
     def test_parse_missing(self):
         with self.assertRaises(ValueError):
-            parse_sampler_vars(None)
+            parse_method_vars(None)
         with self.assertRaises(ValueError):
             parse_stan_vars(None)
 
-    def test_parse_sampler_vars(self):
+    def test_parse_method_vars(self):
         x = [
             'lp__',
             'accept_stat__',
@@ -617,7 +617,7 @@ class ParseVarsTest(unittest.TestCase):
             'z_init[1]',
             'z_init[2]',
         ]
-        vars_dict = parse_sampler_vars(x)
+        vars_dict = parse_method_vars(x)
         self.assertEqual(len(vars_dict), 7)
         self.assertEqual(vars_dict['lp__'], (0,))
         self.assertEqual(vars_dict['stepsize__'], (2,))

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -93,9 +93,9 @@ class CmdStanVBTest(unittest.TestCase):
             variational.column_names,
             ('lp__', 'log_p__', 'log_g__', 'mu[1]', 'mu[2]'),
         )
-        self.assertEqual(1, len(variational.stan_vars_dims))
-        self.assertTrue('mu' in variational.stan_vars_dims)
-        self.assertEqual(variational.stan_vars_dims['mu'], (2,))
+        self.assertEqual(1, len(variational.metadata.stan_vars_dims))
+        self.assertTrue('mu' in variational.metadata.stan_vars_dims)
+        self.assertEqual(variational.metadata.stan_vars_dims['mu'], (2,))
         mu = variational.stan_variable(name='mu')
         self.assertEqual(mu.shape, (2,))
         with self.assertRaises(ValueError):
@@ -113,10 +113,10 @@ class CmdStanVBTest(unittest.TestCase):
             seed=1239812093,
             algorithm='meanfield',
         )
-        self.assertEqual(3, len(multidim_variational.stan_vars_dims))
-        self.assertTrue('y_rep' in multidim_variational.stan_vars_dims)
+        self.assertEqual(3, len(multidim_variational.metadata.stan_vars_dims))
+        self.assertTrue('y_rep' in multidim_variational.metadata.stan_vars_dims)
         self.assertEqual(
-            multidim_variational.stan_vars_dims['y_rep'], (5, 4, 3)
+            multidim_variational.metadata.stan_vars_dims['y_rep'], (5, 4, 3)
         )
         var_y_rep = multidim_variational.stan_variable(name='y_rep')
         self.assertEqual(var_y_rep.shape, (5, 4, 3))
@@ -125,7 +125,7 @@ class CmdStanVBTest(unittest.TestCase):
         var_frac_60 = multidim_variational.stan_variable(name='frac_60')
         self.assertEqual(var_frac_60.shape, ())
         vars = multidim_variational.stan_variables()
-        self.assertEqual(len(vars), len(multidim_variational.stan_vars_dims))
+        self.assertEqual(len(vars), len(multidim_variational.metadata.stan_vars_dims))
         self.assertTrue('y_rep' in vars)
         self.assertEqual(vars['y_rep'].shape, (5, 4, 3))
         self.assertTrue('beta' in vars)

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -82,6 +82,57 @@ class CmdStanVBTest(unittest.TestCase):
         )
         self.assertEqual(variational.variational_sample.shape, (1000, 5))
 
+    def test_variables(self):
+        # pylint: disable=C0103
+        stan = os.path.join(
+            DATAFILES_PATH, 'variational', 'eta_should_be_big.stan'
+        )
+        model = CmdStanModel(stan_file=stan)
+        variational = model.variational(algorithm='meanfield', seed=12345)
+        self.assertEqual(
+            variational.column_names,
+            ('lp__', 'log_p__', 'log_g__', 'mu[1]', 'mu[2]'),
+        )
+        self.assertEqual(1, len(variational.stan_vars_dims))
+        self.assertTrue('mu' in variational.stan_vars_dims)
+        self.assertEqual(variational.stan_vars_dims['mu'], (2,))
+        mu = variational.stan_variable(name='mu')
+        self.assertEqual(mu.shape, (2,))
+        with self.assertRaises(ValueError):
+            variational.stan_variable(name='eta')
+        with self.assertRaises(ValueError):
+            variational.stan_variable(name='lp__')
+
+    def test_variables_3d(self):
+        # construct fit using existing sampler output
+        stan = os.path.join(DATAFILES_PATH, 'multidim_vars.stan')
+        jdata = os.path.join(DATAFILES_PATH, 'logistic.data.R')
+        multidim_model = CmdStanModel(stan_file=stan)
+        multidim_variational = multidim_model.variational(
+            data=jdata,
+            seed=1239812093,
+            algorithm='meanfield',
+        )
+        self.assertEqual(3, len(multidim_variational.stan_vars_dims))
+        self.assertTrue('y_rep' in multidim_variational.stan_vars_dims)
+        self.assertEqual(
+            multidim_variational.stan_vars_dims['y_rep'], (5, 4, 3)
+        )
+        var_y_rep = multidim_variational.stan_variable(name='y_rep')
+        self.assertEqual(var_y_rep.shape, (5, 4, 3))
+        var_beta = multidim_variational.stan_variable(name='beta')
+        self.assertEqual(var_beta.shape, (2,))  # 1-element tuple
+        var_frac_60 = multidim_variational.stan_variable(name='frac_60')
+        self.assertEqual(var_frac_60.shape, ())
+        vars = multidim_variational.stan_variables()
+        self.assertEqual(len(vars), len(multidim_variational.stan_vars_dims))
+        self.assertTrue('y_rep' in vars)
+        self.assertEqual(vars['y_rep'].shape, (5, 4, 3))
+        self.assertTrue('beta' in vars)
+        self.assertEqual(vars['beta'].shape, (2,))
+        self.assertTrue('frac_60' in vars)
+        self.assertEqual(vars['frac_60'].shape, ())
+
 
 class VariationalTest(unittest.TestCase):
 

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -125,7 +125,9 @@ class CmdStanVBTest(unittest.TestCase):
         var_frac_60 = multidim_variational.stan_variable(name='frac_60')
         self.assertEqual(var_frac_60.shape, ())
         vars = multidim_variational.stan_variables()
-        self.assertEqual(len(vars), len(multidim_variational.metadata.stan_vars_dims))
+        self.assertEqual(
+            len(vars), len(multidim_variational.metadata.stan_vars_dims)
+        )
         self.assertTrue('y_rep' in vars)
         self.assertEqual(vars['y_rep'].shape, (5, 4, 3))
         self.assertTrue('beta' in vars)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR generalizes the `stan_variables` function to optimize and variational methods, which requires the following:

- expose the `InferenceMedatadata` class
- populate CmdStanMCMC, CmdStanMLE, and CmdStanVB objects attribute `_metadata` during object initialization
- expose attr `_metadata` as property `metadata`
- generalize the term `sampler` to `method` when referring to output columns which end in `__`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

