### PR TITLE
Typing fixes

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -25,7 +25,7 @@ _DOT_CMDSTANPY = '.cmdstanpy'
 _DOT_CMDSTAN = '.cmdstan'
 
 
-def _cleanup_tmpdir():
+def _cleanup_tmpdir() -> None:
     """Force deletion of _TMPDIR."""
     print('deleting tmpfiles dir: {}'.format(_TMPDIR))
     shutil.rmtree(_TMPDIR, ignore_errors=True)
@@ -37,13 +37,13 @@ atexit.register(_cleanup_tmpdir)
 
 from ._version import __version__  # noqa
 from .model import CmdStanModel  # noqa
-from .stanfit import (
-    from_csv,
+from .stanfit import (  # noqa
     CmdStanGQ,
     CmdStanMCMC,
     CmdStanMLE,
     CmdStanVB,
-)  # noqa
+    from_csv,
+)
 from .utils import set_cmdstan_path  # noqa
 from .utils import cmdstan_path, install_cmdstan, set_make_env
 

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -4,9 +4,8 @@ CmdStan arguments
 import logging
 import os
 from enum import Enum, auto
-from numbers import Integral, Real
 from time import time
-from typing import List, Union
+from typing import List, Optional, Union
 
 from numpy.random import RandomState
 
@@ -26,7 +25,7 @@ class Method(Enum):
     GENERATE_QUANTITIES = auto()
     VARIATIONAL = auto()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s.%s>' % (self.__class__.__name__, self.name)
 
 
@@ -66,7 +65,7 @@ class SamplerArgs:
         self.fixed_param = fixed_param
         self.diagnostic_file = None
 
-    def validate(self, chains: int) -> None:
+    def validate(self, chains: Optional[int]) -> None:
         """
         Check arguments correctness and consistency.
 
@@ -74,7 +73,7 @@ class SamplerArgs:
         * if file(s) for metric are supplied, check contents.
         * length of per-chain lists equals specified # of chains
         """
-        if not isinstance(chains, Integral) or chains < 1:
+        if not isinstance(chains, int) or chains < 1:
             raise ValueError(
                 'sampler expects number of chains to be greater than 0'
             )
@@ -103,9 +102,7 @@ class SamplerArgs:
                 raise ValueError(msg)
 
         if self.iter_warmup is not None:
-            if self.iter_warmup < 0 or not isinstance(
-                self.iter_warmup, Integral
-            ):
+            if self.iter_warmup < 0 or not isinstance(self.iter_warmup, int):
                 raise ValueError(
                     'iter_warmup must be a non-negative integer,'
                     ' found {}'.format(self.iter_warmup)
@@ -116,28 +113,28 @@ class SamplerArgs:
                 )
         if self.iter_sampling is not None:
             if self.iter_sampling < 0 or not isinstance(
-                self.iter_sampling, Integral
+                self.iter_sampling, int
             ):
                 raise ValueError(
                     'iter_sampling must be a non-negative integer,'
                     ' found {}'.format(self.iter_sampling)
                 )
         if self.thin is not None:
-            if self.thin < 1 or not isinstance(self.thin, Integral):
+            if self.thin < 1 or not isinstance(self.thin, int):
                 raise ValueError(
                     'thin must be a positive integer,'
                     'found {}'.format(self.thin)
                 )
         if self.max_treedepth is not None:
             if self.max_treedepth < 1 or not isinstance(
-                self.max_treedepth, Integral
+                self.max_treedepth, int
             ):
                 raise ValueError(
                     'max_treedepth must be a positive integer,'
                     ' found {}'.format(self.max_treedepth)
                 )
         if self.step_size is not None:
-            if isinstance(self.step_size, Real):
+            if isinstance(self.step_size, (float, int)):
                 if self.step_size <= 0:
                     raise ValueError(
                         'step_size must be > 0, found {}'.format(self.step_size)
@@ -218,7 +215,7 @@ class SamplerArgs:
                 )
         if self.adapt_init_phase is not None:
             if self.adapt_init_phase < 0 or not isinstance(
-                self.adapt_init_phase, Integral
+                self.adapt_init_phase, int
             ):
                 raise ValueError(
                     'adapt_init_phase must be a non-negative integer,'
@@ -226,7 +223,7 @@ class SamplerArgs:
                 )
         if self.adapt_metric_window is not None:
             if self.adapt_metric_window < 0 or not isinstance(
-                self.adapt_metric_window, Integral
+                self.adapt_metric_window, int
             ):
                 raise ValueError(
                     'adapt_metric_window must be a non-negative integer,'
@@ -234,7 +231,7 @@ class SamplerArgs:
                 )
         if self.adapt_step_size is not None:
             if self.adapt_step_size < 0 or not isinstance(
-                self.adapt_step_size, Integral
+                self.adapt_step_size, int
             ):
                 raise ValueError(
                     'adapt_step_size must be a non-negative integer,'
@@ -259,7 +256,7 @@ class SamplerArgs:
                 ' or adaptation parameters.'
             )
 
-    def compose(self, idx: int, cmd: List) -> str:
+    def compose(self, idx: int, cmd: List[str]) -> List[str]:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -317,13 +314,13 @@ class OptimizeArgs:
     def __init__(
         self,
         algorithm: str = None,
-        init_alpha: Real = None,
+        init_alpha: float = None,
         iter: int = None,
-        tol_obj: Real = None,
-        tol_rel_obj: Real = None,
-        tol_grad: Real = None,
-        tol_rel_grad: Real = None,
-        tol_param: Real = None,
+        tol_obj: float = None,
+        tol_rel_obj: float = None,
+        tol_grad: float = None,
+        tol_rel_grad: float = None,
+        tol_param: float = None,
         history_size: int = None,
     ) -> None:
 
@@ -337,7 +334,9 @@ class OptimizeArgs:
         self.tol_param = tol_param
         self.history_size = history_size
 
-    def validate(self, chains=None) -> None:  # pylint: disable=unused-argument
+    def validate(
+        self, chains: Optional[int] = None  # pylint: disable=unused-argument
+    ) -> None:
         """
         Check arguments correctness and consistency.
         """
@@ -356,14 +355,14 @@ class OptimizeArgs:
                 raise ValueError(
                     'init_alpha must not be set when algorithm is Newton'
                 )
-            if isinstance(self.init_alpha, Real):
+            if isinstance(self.init_alpha, float):
                 if self.init_alpha <= 0:
                     raise ValueError('init_alpha must be greater than 0')
             else:
                 raise ValueError('init_alpha must be type of float')
 
         if self.iter is not None:
-            if isinstance(self.iter, Integral):
+            if isinstance(self.iter, int):
                 if self.iter < 0:
                     raise ValueError('iter must be greater than 0')
             else:
@@ -374,7 +373,7 @@ class OptimizeArgs:
                 raise ValueError(
                     'tol_obj must not be set when algorithm is Newton'
                 )
-            if isinstance(self.tol_obj, Real):
+            if isinstance(self.tol_obj, float):
                 if self.tol_obj <= 0:
                     raise ValueError('tol_obj must be greater than 0')
             else:
@@ -385,7 +384,7 @@ class OptimizeArgs:
                 raise ValueError(
                     'tol_rel_obj must not be set when algorithm is Newton'
                 )
-            if isinstance(self.tol_rel_obj, Real):
+            if isinstance(self.tol_rel_obj, float):
                 if self.tol_rel_obj <= 0:
                     raise ValueError('tol_rel_obj must be greater than 0')
             else:
@@ -396,7 +395,7 @@ class OptimizeArgs:
                 raise ValueError(
                     'tol_grad must not be set when algorithm is Newton'
                 )
-            if isinstance(self.tol_grad, Real):
+            if isinstance(self.tol_grad, float):
                 if self.tol_grad <= 0:
                     raise ValueError('tol_grad must be greater than 0')
             else:
@@ -407,7 +406,7 @@ class OptimizeArgs:
                 raise ValueError(
                     'tol_rel_grad must not be set when algorithm is Newton'
                 )
-            if isinstance(self.tol_rel_grad, Real):
+            if isinstance(self.tol_rel_grad, float):
                 if self.tol_rel_grad <= 0:
                     raise ValueError('tol_rel_grad must be greater than 0')
             else:
@@ -418,7 +417,7 @@ class OptimizeArgs:
                 raise ValueError(
                     'tol_param must not be set when algorithm is Newton'
                 )
-            if isinstance(self.tol_param, Real):
+            if isinstance(self.tol_param, float):
                 if self.tol_param <= 0:
                     raise ValueError('tol_param must be greater than 0')
             else:
@@ -430,14 +429,14 @@ class OptimizeArgs:
                     'history_size must not be set when algorithm is '
                     'Newton or BFGS'
                 )
-            if isinstance(self.history_size, Integral):
+            if isinstance(self.history_size, int):
                 if self.history_size < 0:
                     raise ValueError('history_size must be greater than 0')
             else:
                 raise ValueError('history_size must be type of int')
 
     # pylint: disable=unused-argument
-    def compose(self, idx: int, cmd: List) -> str:
+    def compose(self, idx: int, cmd: List[str]) -> List[str]:
         """compose command string for CmdStan for non-default arg values."""
         cmd.append('method=optimize')
         if self.algorithm:
@@ -469,7 +468,9 @@ class GenerateQuantitiesArgs:
         """Initialize object."""
         self.sample_csv_files = csv_files
 
-    def validate(self, chains: int) -> None:  # pylint: disable=unused-argument
+    def validate(
+        self, chains: Optional[int] = None  # pylint: disable=unused-argument
+    ) -> None:
         """
         Check arguments correctness and consistency.
 
@@ -481,7 +482,7 @@ class GenerateQuantitiesArgs:
                     'Invalid path for sample csv file: {}'.format(csv)
                 )
 
-    def compose(self, idx: int, cmd: List) -> str:
+    def compose(self, idx: int, cmd: List[str]) -> List[str]:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -501,10 +502,10 @@ class VariationalArgs:
         iter: int = None,
         grad_samples: int = None,
         elbo_samples: int = None,
-        eta: Real = None,
+        eta: float = None,
         adapt_iter: int = None,
         adapt_engaged: bool = True,
-        tol_rel_obj: Real = None,
+        tol_rel_obj: float = None,
         eval_elbo: int = None,
         output_samples: int = None,
     ) -> None:
@@ -519,7 +520,9 @@ class VariationalArgs:
         self.eval_elbo = eval_elbo
         self.output_samples = output_samples
 
-    def validate(self, chains=None) -> None:  # pylint: disable=unused-argument
+    def validate(
+        self, chains: Optional[int] = None  # pylint: disable=unused-argument
+    ) -> None:
         """
         Check arguments correctness and consistency.
         """
@@ -533,56 +536,52 @@ class VariationalArgs:
                 )
             )
         if self.iter is not None:
-            if self.iter < 1 or not isinstance(self.iter, Integral):
+            if self.iter < 1 or not isinstance(self.iter, int):
                 raise ValueError(
                     'iter must be a positive integer,'
                     ' found {}'.format(self.iter)
                 )
         if self.grad_samples is not None:
-            if self.grad_samples < 1 or not isinstance(
-                self.grad_samples, Integral
-            ):
+            if self.grad_samples < 1 or not isinstance(self.grad_samples, int):
                 raise ValueError(
                     'grad_samples must be a positive integer,'
                     ' found {}'.format(self.grad_samples)
                 )
         if self.elbo_samples is not None:
-            if self.elbo_samples < 1 or not isinstance(
-                self.elbo_samples, Integral
-            ):
+            if self.elbo_samples < 1 or not isinstance(self.elbo_samples, int):
                 raise ValueError(
                     'elbo_samples must be a positive integer,'
                     ' found {}'.format(self.elbo_samples)
                 )
         if self.eta is not None:
-            if self.eta < 0 or not isinstance(self.eta, (Integral, Real)):
+            if self.eta < 0 or not isinstance(self.eta, (int, float)):
                 raise ValueError(
                     'eta must be a non-negative number,'
                     ' found {}'.format(self.eta)
                 )
         if self.adapt_iter is not None:
-            if self.adapt_iter < 1 or not isinstance(self.adapt_iter, Integral):
+            if self.adapt_iter < 1 or not isinstance(self.adapt_iter, int):
                 raise ValueError(
                     'adapt_iter must be a positive integer,'
                     ' found {}'.format(self.adapt_iter)
                 )
         if self.tol_rel_obj is not None:
             if self.tol_rel_obj <= 0 or not isinstance(
-                self.tol_rel_obj, (Integral, Real)
+                self.tol_rel_obj, (int, float)
             ):
                 raise ValueError(
                     'tol_rel_obj must be a positive number,'
                     ' found {}'.format(self.tol_rel_obj)
                 )
         if self.eval_elbo is not None:
-            if self.eval_elbo < 1 or not isinstance(self.eval_elbo, Integral):
+            if self.eval_elbo < 1 or not isinstance(self.eval_elbo, int):
                 raise ValueError(
                     'eval_elbo must be a positive integer,'
                     ' found {}'.format(self.eval_elbo)
                 )
         if self.output_samples is not None:
             if self.output_samples < 1 or not isinstance(
-                self.output_samples, Integral
+                self.output_samples, int
             ):
                 raise ValueError(
                     'output_samples must be a positive integer,'
@@ -590,7 +589,7 @@ class VariationalArgs:
                 )
 
     # pylint: disable=unused-argument
-    def compose(self, idx: int, cmd: List) -> str:
+    def compose(self, idx: int, cmd: List[str]) -> List[str]:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -631,20 +630,20 @@ class CmdStanArgs:
     def __init__(
         self,
         model_name: str,
-        model_exe: str,
+        model_exe: Optional[str],
         chain_ids: Union[List[int], None],
         method_args: Union[
             SamplerArgs, OptimizeArgs, GenerateQuantitiesArgs, VariationalArgs
         ],
-        data: Union[str, dict] = None,
-        seed: Union[int, List[int]] = None,
-        inits: Union[int, float, str, List[str]] = None,
-        output_dir: str = None,
-        sig_figs: str = None,
+        data: Union[str, dict, None] = None,
+        seed: Union[int, List[int], None] = None,
+        inits: Union[int, float, str, List[str], None] = None,
+        output_dir: Optional[str] = None,
+        sig_figs: Optional[int] = None,
         save_diagnostics: bool = False,
         save_profile: bool = False,
-        refresh: int = None,
-        logger: logging.Logger = None,
+        refresh: Optional[int] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Initialize object."""
         self.model_name = model_name
@@ -790,7 +789,7 @@ class CmdStanArgs:
             raise ValueError('data must be string or dict')
 
         if self.inits is not None:
-            if isinstance(self.inits, (Integral, Real)):
+            if isinstance(self.inits, (float, int)):
                 if self.inits < 0:
                     raise ValueError(
                         'inits must be > 0, found {}'.format(self.inits)
@@ -826,13 +825,13 @@ class CmdStanArgs:
         idx: int,
         csv_file: str,
         *,
-        diagnostic_file: str = None,
-        profile_file: str = None
-    ) -> str:
+        diagnostic_file: Optional[str] = None,
+        profile_file: Optional[str] = None
+    ) -> List[str]:
         """
         Compose CmdStan command for non-default arguments.
         """
-        cmd = []
+        cmd: List[str] = []
         if idx is not None and self.chain_ids is not None:
             if idx < 0 or idx > len(self.chain_ids) - 1:
                 raise ValueError(
@@ -840,10 +839,10 @@ class CmdStanArgs:
                         idx, len(self.chain_ids)
                     )
                 )
-            cmd.append(self.model_exe)
+            cmd.append(self.model_exe)  # type: ignore # guaranteed by validate
             cmd.append('id={}'.format(self.chain_ids[idx]))
         else:
-            cmd.append(self.model_exe)
+            cmd.append(self.model_exe)  # type: ignore # guaranteed by validate
 
         if self.seed is not None:
             if not isinstance(self.seed, list):

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -5,7 +5,7 @@ import logging
 import os
 from enum import Enum, auto
 from time import time
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from numpy.random import RandomState
 
@@ -34,18 +34,18 @@ class SamplerArgs:
 
     def __init__(
         self,
-        iter_warmup: int = None,
-        iter_sampling: int = None,
+        iter_warmup: Optional[int] = None,
+        iter_sampling: Optional[int] = None,
         save_warmup: bool = False,
-        thin: int = None,
-        max_treedepth: int = None,
-        metric: Union[str, List[str]] = None,
-        step_size: Union[float, List[float]] = None,
+        thin: Optional[int] = None,
+        max_treedepth: Optional[int] = None,
+        metric: Union[str, List[str], None] = None,
+        step_size: Union[float, List[float], None] = None,
         adapt_engaged: bool = True,
-        adapt_delta: float = None,
-        adapt_init_phase: int = None,
-        adapt_metric_window: int = None,
-        adapt_step_size: int = None,
+        adapt_delta: Optional[float] = None,
+        adapt_init_phase: Optional[int] = None,
+        adapt_metric_window: Optional[int] = None,
+        adapt_step_size: Optional[int] = None,
         fixed_param: bool = False,
     ) -> None:
         """Initialize object."""
@@ -313,15 +313,15 @@ class OptimizeArgs:
 
     def __init__(
         self,
-        algorithm: str = None,
-        init_alpha: float = None,
-        iter: int = None,
-        tol_obj: float = None,
-        tol_rel_obj: float = None,
-        tol_grad: float = None,
-        tol_rel_grad: float = None,
-        tol_param: float = None,
-        history_size: int = None,
+        algorithm: Optional[str] = None,
+        init_alpha: Optional[float] = None,
+        iter: Optional[int] = None,
+        tol_obj: Optional[float] = None,
+        tol_rel_obj: Optional[float] = None,
+        tol_grad: Optional[float] = None,
+        tol_rel_grad: Optional[float] = None,
+        tol_param: Optional[float] = None,
+        history_size: Optional[int] = None,
     ) -> None:
 
         self.algorithm = algorithm
@@ -333,6 +333,7 @@ class OptimizeArgs:
         self.tol_rel_grad = tol_rel_grad
         self.tol_param = tol_param
         self.history_size = history_size
+        self.thin = None
 
     def validate(
         self, chains: Optional[int] = None  # pylint: disable=unused-argument
@@ -498,16 +499,16 @@ class VariationalArgs:
 
     def __init__(
         self,
-        algorithm: str = None,
-        iter: int = None,
-        grad_samples: int = None,
-        elbo_samples: int = None,
-        eta: float = None,
-        adapt_iter: int = None,
+        algorithm: Optional[str] = None,
+        iter: Optional[int] = None,
+        grad_samples: Optional[int] = None,
+        elbo_samples: Optional[int] = None,
+        eta: Optional[float] = None,
+        adapt_iter: Optional[int] = None,
         adapt_engaged: bool = True,
-        tol_rel_obj: float = None,
-        eval_elbo: int = None,
-        output_samples: int = None,
+        tol_rel_obj: Optional[float] = None,
+        eval_elbo: Optional[int] = None,
+        output_samples: Optional[int] = None,
     ) -> None:
         self.algorithm = algorithm
         self.iter = iter
@@ -635,7 +636,7 @@ class CmdStanArgs:
         method_args: Union[
             SamplerArgs, OptimizeArgs, GenerateQuantitiesArgs, VariationalArgs
         ],
-        data: Union[str, dict, None] = None,
+        data: Union[str, Dict[str, Any], None] = None,
         seed: Union[int, List[int], None] = None,
         inits: Union[int, float, str, List[str], None] = None,
         output_dir: Optional[str] = None,

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -5,7 +5,7 @@ Makefile options for stanc and C++ compilers
 import logging
 import os
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from cmdstanpy.utils import get_logger
 
@@ -60,13 +60,14 @@ class CompilerOptions:
 
     def __init__(
         self,
-        stanc_options: Dict = None,
-        cpp_options: Dict = None,
+        *,
+        stanc_options: Dict[str, Any] = None,
+        cpp_options: Dict[str, Any] = None,
         logger: logging.Logger = None,
     ) -> None:
         """Initialize object."""
-        self._stanc_options = stanc_options
-        self._cpp_options = cpp_options
+        self._stanc_options = stanc_options if stanc_options is not None else {}
+        self._cpp_options = cpp_options if cpp_options is not None else {}
         self._logger = logger or get_logger()
 
     def __repr__(self) -> str:

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -5,7 +5,7 @@ Makefile options for stanc and C++ compilers
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Union
 
 from cmdstanpy.utils import get_logger
 
@@ -16,7 +16,7 @@ STANC_OPTS = [
     'warn-uninitialized',
     'include_paths',
     'name',
-    "warn-pedantic",
+    'warn-pedantic',
 ]
 
 STANC_IGNORE_OPTS = [
@@ -61,9 +61,9 @@ class CompilerOptions:
     def __init__(
         self,
         *,
-        stanc_options: Dict[str, Any] = None,
-        cpp_options: Dict[str, Any] = None,
-        logger: logging.Logger = None,
+        stanc_options: Optional[Dict[str, Any]] = None,
+        cpp_options: Optional[Dict[str, Any]] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Initialize object."""
         self._stanc_options = stanc_options if stanc_options is not None else {}
@@ -76,12 +76,12 @@ class CompilerOptions:
         )
 
     @property
-    def stanc_options(self) -> Dict:
+    def stanc_options(self) -> Dict[str, Union[bool, int, str]]:
         """Stanc compiler options."""
         return self._stanc_options
 
     @property
-    def cpp_options(self) -> Dict:
+    def cpp_options(self) -> Dict[str, Union[bool, int]]:
         """C++ compiler options."""
         return self._cpp_options
 

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -22,6 +22,7 @@ import sys
 import urllib.request
 from collections import OrderedDict
 from time import sleep
+from typing import Callable, Iterator, List, Optional
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
 from cmdstanpy.utils import validate_dir
@@ -31,7 +32,7 @@ IS_64BITS = sys.maxsize > 2 ** 32
 
 
 @contextlib.contextmanager
-def pushd(new_dir):
+def pushd(new_dir: str) -> Iterator[None]:
     """Acts like pushd/popd."""
     previous_dir = os.getcwd()
     os.chdir(new_dir)
@@ -39,7 +40,7 @@ def pushd(new_dir):
     os.chdir(previous_dir)
 
 
-def usage():
+def usage() -> None:
     """Print usage."""
     print(
         """Arguments:
@@ -53,7 +54,7 @@ def usage():
     )
 
 
-def get_config(dir, silent):
+def get_config(dir: str, silent: bool) -> List[str]:
     """Assemble config info."""
     config = []
     if platform.system() == 'Windows':
@@ -74,8 +75,12 @@ def get_config(dir, silent):
 
 
 def install_version(
-    installation_dir, installation_file, version, silent, verbose=False
-):
+    installation_dir: str,
+    installation_file: str,
+    version: str,
+    silent: bool,
+    verbose: bool = False,
+) -> None:
     """Install specified toolchain version."""
     with pushd('.'):
         print(
@@ -95,9 +100,10 @@ def install_version(
             env=os.environ,
         )
         while proc.poll() is None:
-            output = proc.stdout.readline().decode('utf-8').strip()
-            if output and verbose:
-                print(output, flush=True)
+            if proc.stdout:
+                output = proc.stdout.readline().decode('utf-8').strip()
+                if output and verbose:
+                    print(output, flush=True)
         _, stderr = proc.communicate()
         if proc.returncode:
             print('Installation failed: returncode={}'.format(proc.returncode))
@@ -112,7 +118,7 @@ def install_version(
     print('Installed {}'.format(os.path.splitext(installation_file)[0]))
 
 
-def install_mingw32_make(toolchain_loc, verbose=False):
+def install_mingw32_make(toolchain_loc: str, verbose: bool = False) -> None:
     """Install mingw32-make for Windows RTools 4.0."""
     os.environ['PATH'] = ';'.join(
         list(
@@ -146,9 +152,10 @@ def install_mingw32_make(toolchain_loc, verbose=False):
             env=os.environ,
         )
         while proc.poll() is None:
-            output = proc.stdout.readline().decode('utf-8').strip()
-            if output and verbose:
-                print(output, flush=True)
+            if proc.stdout:
+                output = proc.stdout.readline().decode('utf-8').strip()
+                if output and verbose:
+                    print(output, flush=True)
         _, stderr = proc.communicate()
         if proc.returncode:
             print(
@@ -162,7 +169,7 @@ def install_mingw32_make(toolchain_loc, verbose=False):
     print('Installed mingw32-make.exe')
 
 
-def is_installed(toolchain_loc, version):
+def is_installed(toolchain_loc: str, version: str) -> bool:
     """Returns True is toolchain is installed."""
     if platform.system() == 'Windows':
         if version in ['35', '3.5']:
@@ -190,14 +197,14 @@ def is_installed(toolchain_loc, version):
     return False
 
 
-def latest_version():
+def latest_version() -> str:
     """Windows version hardcoded to 4.0."""
     if platform.system() == 'Windows':
         return '4.0'
     return ''
 
 
-def wrap_progress_hook():
+def wrap_progress_hook() -> Optional[Callable[[int, int, int], None]]:
     try:
         from tqdm import tqdm
 
@@ -207,7 +214,9 @@ def wrap_progress_hook():
             unit_divisor=1024,
         )
 
-        def download_progress_hook(count, block_size, total_size):
+        def download_progress_hook(
+            count: int, block_size: int, total_size: int
+        ) -> None:
             if pbar.total is None:
                 pbar.total = total_size
                 pbar.reset()
@@ -218,12 +227,12 @@ def wrap_progress_hook():
 
     except (ImportError, ModuleNotFoundError):
         print("tqdm was not downloaded, progressbar not shown")
-        download_progress_hook = None
+        return None
 
     return download_progress_hook
 
 
-def retrieve_toolchain(filename, url, progress=True):
+def retrieve_toolchain(filename: str, url: str, progress: bool = True) -> None:
     """Download toolchain from URL."""
     print('Downloading C++ toolchain: {}'.format(filename))
     for i in range(6):
@@ -247,7 +256,7 @@ def retrieve_toolchain(filename, url, progress=True):
     print('Download successful, file: {}'.format(filename))
 
 
-def normalize_version(version):
+def normalize_version(version: str) -> str:
     """Return maj.min part of version string."""
     if platform.system() == 'Windows':
         if version in ['4', '40']:
@@ -257,14 +266,14 @@ def normalize_version(version):
     return version
 
 
-def get_toolchain_name():
+def get_toolchain_name() -> str:
     """Return toolchain name."""
     if platform.system() == 'Windows':
         return 'RTools'
     return ''
 
 
-def get_url(version):
+def get_url(version: str) -> str:
     """Return URL for toolchain."""
     if platform.system() == 'Windows':
         if version == '4.0':
@@ -278,16 +287,16 @@ def get_url(version):
     return url
 
 
-def get_toolchain_version(name, version):
+def get_toolchain_version(name: str, version: str) -> str:
     """Toolchain version."""
-    toolchain_folder = None
+    toolchain_folder = ''
     if platform.system() == 'Windows':
         toolchain_folder = '{}{}'.format(name, version.replace('.', ''))
 
     return toolchain_folder
 
 
-def main():
+def main() -> None:
     """Main."""
     if platform.system() not in {'Windows'}:
         msg = (

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -209,16 +209,16 @@ class CmdStanModel:
         return self._exe_file
 
     @property
-    def stanc_options(self) -> Dict:
+    def stanc_options(self) -> Dict[str, Union[bool, int, str]]:
         """Options to stanc compilers."""
         return self._compiler_options._stanc_options
 
     @property
-    def cpp_options(self) -> Dict:
+    def cpp_options(self) -> Dict[str, Union[bool, int]]:
         """Options to C++ compilers."""
         return self._compiler_options._cpp_options
 
-    def code(self) -> str:
+    def code(self) -> Optional[str]:
         """Return Stan program as a string."""
         if not self._stan_file:
             raise RuntimeError('Please specify source file')
@@ -236,8 +236,8 @@ class CmdStanModel:
     def compile(
         self,
         force: bool = False,
-        stanc_options: Dict[str, Any] = None,
-        cpp_options: Dict[str, Any] = None,
+        stanc_options: Optional[Dict[str, Any]] = None,
+        cpp_options: Optional[Dict[str, Any]] = None,
         override_options: bool = False,
     ) -> None:
         """
@@ -360,22 +360,22 @@ class CmdStanModel:
 
     def optimize(
         self,
-        data: Union[Dict, str] = None,
-        seed: int = None,
-        inits: Union[Dict, float, str] = None,
-        output_dir: str = None,
-        sig_figs: int = None,
+        data: Union[Dict[str, Any], str, None] = None,
+        seed: Optional[int] = None,
+        inits: Union[Dict[str, float], float, str, None] = None,
+        output_dir: Optional[str] = None,
+        sig_figs: Optional[int] = None,
         save_profile: bool = False,
-        algorithm: str = None,
-        init_alpha: float = None,
-        tol_obj: float = None,
-        tol_rel_obj: float = None,
-        tol_grad: float = None,
-        tol_rel_grad: float = None,
-        tol_param: float = None,
-        history_size: int = None,
-        iter: int = None,
-        refresh: int = None,
+        algorithm: Optional[str] = None,
+        init_alpha: Optional[float] = None,
+        tol_obj: Optional[float] = None,
+        tol_rel_obj: Optional[float] = None,
+        tol_grad: Optional[float] = None,
+        tol_rel_grad: Optional[float] = None,
+        tol_param: Optional[float] = None,
+        history_size: Optional[int] = None,
+        iter: Optional[int] = None,
+        refresh: Optional[int] = None,
     ) -> CmdStanMLE:
         """
         Run the specified CmdStan optimize algorithm to produce a
@@ -507,32 +507,32 @@ class CmdStanModel:
     # pylint: disable=too-many-arguments
     def sample(
         self,
-        data: Union[Dict, str] = None,
-        chains: Union[int, None] = None,
-        parallel_chains: Union[int, None] = None,
-        threads_per_chain: Union[int, None] = None,
-        seed: Union[int, List[int]] = None,
-        chain_ids: Union[int, List[int]] = None,
-        inits: Union[Dict, float, str, List[str]] = None,
-        iter_warmup: int = None,
-        iter_sampling: int = None,
+        data: Union[Dict[str, Any], str, None] = None,
+        chains: Optional[int] = None,
+        parallel_chains: Optional[int] = None,
+        threads_per_chain: Optional[int] = None,
+        seed: Union[int, List[int], None] = None,
+        chain_ids: Union[int, List[int], None] = None,
+        inits: Union[Dict[str, float], float, str, List[str], None] = None,
+        iter_warmup: Optional[int] = None,
+        iter_sampling: Optional[int] = None,
         save_warmup: bool = False,
-        thin: int = None,
-        max_treedepth: int = None,
-        metric: Union[str, List[str]] = None,
-        step_size: Union[float, List[float]] = None,
+        thin: Optional[int] = None,
+        max_treedepth: Optional[int] = None,
+        metric: Union[str, List[str], None] = None,
+        step_size: Union[float, List[float], None] = None,
         adapt_engaged: bool = True,
-        adapt_delta: float = None,
-        adapt_init_phase: int = None,
-        adapt_metric_window: int = None,
-        adapt_step_size: int = None,
+        adapt_delta: Optional[float] = None,
+        adapt_init_phase: Optional[int] = None,
+        adapt_metric_window: Optional[int] = None,
+        adapt_step_size: Optional[int] = None,
         fixed_param: bool = False,
-        output_dir: str = None,
-        sig_figs: int = None,
+        output_dir: Optional[str] = None,
+        sig_figs: Optional[int] = None,
         save_diagnostics: bool = False,
         save_profile: bool = False,
         show_progress: Union[bool, str] = False,
-        refresh: int = None,
+        refresh: Optional[int] = None,
     ) -> CmdStanMCMC:
         """
         Run or more chains of the NUTS sampler to produce a set of draws
@@ -868,12 +868,12 @@ class CmdStanModel:
 
     def generate_quantities(
         self,
-        data: Union[Dict, str] = None,
-        mcmc_sample: Union[CmdStanMCMC, List[str]] = None,
-        seed: int = None,
-        gq_output_dir: str = None,
-        sig_figs: int = None,
-        refresh: int = None,
+        data: Union[Dict[str, Any], str, None] = None,
+        mcmc_sample: Union[CmdStanMCMC, List[str], None] = None,
+        seed: Optional[int] = None,
+        gq_output_dir: Optional[str] = None,
+        sig_figs: Optional[int] = None,
+        refresh: Optional[int] = None,
     ) -> CmdStanGQ:
         """
         Run CmdStan's generate_quantities method which runs the generated
@@ -1024,25 +1024,25 @@ class CmdStanModel:
 
     def variational(
         self,
-        data: Union[Dict, str] = None,
-        seed: int = None,
-        inits: float = None,
-        output_dir: str = None,
-        sig_figs: int = None,
+        data: Union[Dict[str, Any], str, None] = None,
+        seed: Optional[int] = None,
+        inits: Optional[float] = None,
+        output_dir: Optional[str] = None,
+        sig_figs: Optional[int] = None,
         save_diagnostics: bool = False,
         save_profile: bool = False,
-        algorithm: str = None,
-        iter: int = None,
-        grad_samples: int = None,
-        elbo_samples: int = None,
-        eta: float = None,
+        algorithm: Optional[str] = None,
+        iter: Optional[int] = None,
+        grad_samples: Optional[int] = None,
+        elbo_samples: Optional[int] = None,
+        eta: Optional[float] = None,
         adapt_engaged: bool = True,
-        adapt_iter: int = None,
-        tol_rel_obj: float = None,
-        eval_elbo: int = None,
-        output_samples: int = None,
+        adapt_iter: Optional[int] = None,
+        tol_rel_obj: Optional[float] = None,
+        eval_elbo: Optional[int] = None,
+        output_samples: Optional[int] = None,
         require_converged: bool = True,
-        refresh: int = None,
+        refresh: Optional[int] = None,
     ) -> CmdStanVB:
         """
         Run CmdStan's variational inference algorithm to approximate
@@ -1242,7 +1242,10 @@ class CmdStanModel:
             raise RuntimeError(msg) from e
 
     def _read_progress(
-        self, proc: subprocess.Popen, pbar: Any, idx: int
+        self,
+        proc: subprocess.Popen,  # [] - Popoen is only generic in 3.9
+        pbar: Any,
+        idx: int,
     ) -> bytes:
         """
         Update tqdm progress bars according to CmdStan console progress msgs.

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -1211,7 +1211,7 @@ class CmdStanMLE:
         return pd.DataFrame([self._mle], columns=self.column_names)
 
     @property
-    def optimized_params_dict(self) -> OrderedDict[str, float]:
+    def optimized_params_dict(self) -> Dict[str, float]:
         """Returns optimized params as Dict."""
         return OrderedDict(zip(self.column_names, self._mle))
 
@@ -1446,7 +1446,7 @@ class CmdStanVB:
         return pd.DataFrame([self._variational_mean], columns=self.column_names)
 
     @property
-    def variational_params_dict(self) -> OrderedDict[str, np.ndarray]:
+    def variational_params_dict(self) -> Dict[str, np.ndarray]:
         """Returns inferred parameter means as Dict."""
         return OrderedDict(zip(self.column_names, self._variational_mean))
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -211,7 +211,7 @@ def cmdstan_version_at(maj: int, min: int) -> bool:
     return False
 
 
-def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
+def cxx_toolchain_path(version: Optional[str] = None) -> Tuple[str, ...]:
     """
     Validate, then activate C++ toolchain directory path.
     """
@@ -239,14 +239,14 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
                         'Found invalid installion for RTools40 on %s',
                         toolchain_root,
                     )
-                    toolchain_root = None
+                    toolchain_root = ''
             else:
                 compiler_path = ''
                 logger.warning(
                     'Found invalid installion for RTools40 on %s',
                     toolchain_root,
                 )
-                toolchain_root = None
+                toolchain_root = ''
 
         elif os.path.exists(os.path.join(toolchain_root, 'mingw_64')):
             compiler_path = os.path.join(
@@ -263,14 +263,14 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
                         'Found invalid installion for RTools35 on %s',
                         toolchain_root,
                     )
-                    toolchain_root = None
+                    toolchain_root = ''
             else:
                 compiler_path = ''
                 logger.warning(
                     'Found invalid installion for RTools35 on %s',
                     toolchain_root,
                 )
-                toolchain_root = None
+                toolchain_root = ''
     else:
         rtools40_home = os.environ.get('RTOOLS40_HOME')
         cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
@@ -308,7 +308,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
                                 'Found invalid installation for RTools40 on %s',
                                 toolchain_root,
                             )
-                            toolchain_root = None
+                            toolchain_root = ''
                         else:
                             break
                     else:
@@ -317,7 +317,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
                             'Found invalid installation for RTools40 on %s',
                             toolchain_root,
                         )
-                        toolchain_root = None
+                        toolchain_root = ''
                 else:
                     compiler_path = os.path.join(
                         toolchain_root,
@@ -333,7 +333,7 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
                                 'Found invalid installation for RTools35 on %s',
                                 toolchain_root,
                             )
-                            toolchain_root = None
+                            toolchain_root = ''
                         else:
                             break
                     else:
@@ -342,9 +342,9 @@ def cxx_toolchain_path(version: str = None) -> Tuple[str, ...]:
                             'Found invalid installation for RTools35 on %s',
                             toolchain_root,
                         )
-                        toolchain_root = None
+                        toolchain_root = ''
             else:
-                toolchain_root = None
+                toolchain_root = ''
 
     if not toolchain_root:
         raise ValueError(
@@ -374,7 +374,7 @@ def _rdump_array(key: str, val: np.ndarray) -> str:
         return struct
 
 
-def jsondump(path: str, data: Dict) -> None:
+def jsondump(path: str, data: Dict[str, Any]) -> None:
     """Dump a dict of data to a JSON file."""
     data = data.copy()
     for key, val in data.items():
@@ -387,7 +387,7 @@ def jsondump(path: str, data: Dict) -> None:
         json.dump(data, fd)
 
 
-def rdump(path: str, data: Dict) -> None:
+def rdump(path: str, data: Dict[str, Any]) -> None:
     """Dump a dict of data to a R dump format file."""
     with open(path, 'w') as fd:
         for key, val in data.items():
@@ -398,7 +398,7 @@ def rdump(path: str, data: Dict) -> None:
             print(line, file=fd)
 
 
-def rload(fname: str) -> Dict:
+def rload(fname: str) -> Optional[Dict[str, Union[int, float, np.ndarray]]]:
     """Parse data and parameter variable values from an R dump format file.
     This parser only supports the subset of R dump data as described
     in the "Dump Data Format" section of the CmdStan manual, i.e.,
@@ -440,7 +440,7 @@ def parse_rdump_value(rhs: str) -> Union[int, float, np.ndarray]:
         r'structure\(\s*c\((?P<vals>[^)]*)\)'
         r'(,\s*\.Dim\s*=\s*c\s*\((?P<dims>[^)]*)\s*\))?\)'
     )
-    # val = None
+    val: Union[int, float, np.ndarray]
     try:
         if rhs.startswith('structure'):
             parse = pat.match(rhs)
@@ -465,11 +465,11 @@ def parse_rdump_value(rhs: str) -> Union[int, float, np.ndarray]:
 def check_sampler_csv(
     path: str,
     is_fixed_param: bool = False,
-    iter_sampling: int = None,
-    iter_warmup: int = None,
+    iter_sampling: Optional[int] = None,
+    iter_warmup: Optional[int] = None,
     save_warmup: bool = False,
-    thin: int = None,
-) -> Dict:
+    thin: Optional[int] = None,
+) -> Dict[str, Any]:
     """Capture essential config, shape from stan_csv file."""
     meta = scan_sampler_csv(path, is_fixed_param)
     if thin is None:
@@ -517,9 +517,9 @@ def check_sampler_csv(
     return meta
 
 
-def scan_sampler_csv(path: str, is_fixed_param: bool = False) -> Dict:
+def scan_sampler_csv(path: str, is_fixed_param: bool = False) -> Dict[str, Any]:
     """Process sampler stan_csv output file line by line."""
-    dict = {}
+    dict: Dict[str, Any] = {}
     lineno = 0
     with open(path, 'r') as fd:
         lineno = scan_config(fd, dict, lineno)
@@ -531,9 +531,9 @@ def scan_sampler_csv(path: str, is_fixed_param: bool = False) -> Dict:
     return dict
 
 
-def scan_optimize_csv(path: str) -> Dict[str, List[float]]:
+def scan_optimize_csv(path: str) -> Dict[str, Any]:
     """Process optimizer stan_csv output file line by line."""
-    dict = {}
+    dict: Dict[str, Any] = {}
     lineno = 0
     with open(path, 'r') as fd:
         lineno = scan_config(fd, dict, lineno)
@@ -544,11 +544,11 @@ def scan_optimize_csv(path: str) -> Dict[str, List[float]]:
     return dict
 
 
-def scan_generated_quantities_csv(path: str) -> Dict:
+def scan_generated_quantities_csv(path: str) -> Dict[str, Any]:
     """
     Process standalone generated quantities stan_csv output file line by line.
     """
-    dict = {}
+    dict: Dict[str, Any] = {}
     lineno = 0
     with open(path, 'r') as fd:
         lineno = scan_config(fd, dict, lineno)
@@ -556,9 +556,9 @@ def scan_generated_quantities_csv(path: str) -> Dict:
     return dict
 
 
-def scan_variational_csv(path: str) -> Dict:
+def scan_variational_csv(path: str) -> Dict[str, Any]:
     """Process advi stan_csv output file line by line."""
-    dict = {}
+    dict: Dict[str, Any] = {}
     lineno = 0
     with open(path, 'r') as fd:
         lineno = scan_config(fd, dict, lineno)
@@ -607,6 +607,7 @@ def scan_config(fd: TextIO, config_dict: Dict[str, Any], lineno: int) -> int:
                 config_dict['data_file'] = key_val[1].strip()
             elif key_val[0].strip() != 'file':
                 raw_val = key_val[1].strip()
+                val: Union[int, float, str]
                 try:
                     val = int(raw_val)
                 except ValueError:
@@ -621,7 +622,9 @@ def scan_config(fd: TextIO, config_dict: Dict[str, Any], lineno: int) -> int:
     return lineno
 
 
-def scan_warmup_iters(fd: TextIO, config_dict: Dict, lineno: int) -> int:
+def scan_warmup_iters(
+    fd: TextIO, config_dict: Dict[str, Any], lineno: int
+) -> int:
     """
     Check warmup iterations, if any.
     """
@@ -695,9 +698,10 @@ def parse_stan_vars(
     """
     if names is None:
         raise ValueError('missing argument "names"')
-    dims_map = {}
-    cols_map = {}
+    dims_map: Dict[str, Tuple[int, ...]] = {}
+    cols_map: Dict[str, Tuple[int, ...]] = {}
     idxs = []
+    dims: Union[List[str], List[int]]
     for (idx, name) in enumerate(names):
         idxs.append(idx)
         var, *dims = name.split('[')
@@ -717,7 +721,7 @@ def parse_stan_vars(
     return (dims_map, cols_map)
 
 
-def scan_metric(fd: TextIO, config_dict: Dict, lineno: int) -> int:
+def scan_metric(fd: TextIO, config_dict: Dict[str, Any], lineno: int) -> int:
     """
     Scan step size, metric from  stan_csv file comment lines,
     set config_dict entries 'metric' and 'num_unconstrained_params'
@@ -778,7 +782,9 @@ def scan_metric(fd: TextIO, config_dict: Dict, lineno: int) -> int:
         return lineno
 
 
-def scan_sampling_iters(fd: TextIO, config_dict: Dict, lineno: int) -> int:
+def scan_sampling_iters(
+    fd: TextIO, config_dict: Dict[str, Any], lineno: int
+) -> int:
     """
     Parse sampling iteration, save number of iterations to config_dict.
     """
@@ -812,8 +818,8 @@ def read_metric(path: str) -> List[int]:
         with open(path, 'r') as fd:
             metric_dict = json.load(fd)
         if 'inv_metric' in metric_dict:
-            dims = np.asarray(metric_dict['inv_metric'])
-            return list(dims.shape)
+            dims_np = np.asarray(metric_dict['inv_metric'])
+            return list(dims_np.shape)
         else:
             raise ValueError(
                 'metric file {}, bad or missing'
@@ -834,7 +840,7 @@ def read_rdump_metric(path: str) -> List[int]:
     Find dimensions of variable named 'inv_metric' in Rdump data file.
     """
     metric_dict = rload(path)
-    if not (
+    if metric_dict is None or not (
         'inv_metric' in metric_dict
         and isinstance(metric_dict['inv_metric'], np.ndarray)
     ):
@@ -845,8 +851,10 @@ def read_rdump_metric(path: str) -> List[int]:
 
 
 def do_command(
-    cmd: List[str], cwd: str = None, logger: logging.Logger = None
-) -> str:
+    cmd: List[str],
+    cwd: Optional[str] = None,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[str]:
     """
     Spawn process, print stdout/stderr to console.
     Throws RuntimeError on non-zero returncode.
@@ -928,7 +936,10 @@ def windows_short_path(path: str) -> str:
     from ctypes import wintypes
 
     # pylint: disable=invalid-name
-    _GetShortPathNameW = ctypes.windll.kernel32.GetShortPathNameW
+    _GetShortPathNameW = (
+        ctypes.windll.kernel32.GetShortPathNameW  # type: ignore
+    )
+
     _GetShortPathNameW.argtypes = [
         wintypes.LPCWSTR,
         wintypes.LPWSTR,
@@ -972,8 +983,8 @@ def create_named_text_file(
 
 
 def install_cmdstan(
-    version: str = None,
-    dir: str = None,
+    version: Optional[str] = None,
+    dir: Optional[str] = None,
     overwrite: bool = False,
     verbose: bool = False,
 ) -> bool:
@@ -1020,7 +1031,7 @@ def install_cmdstan(
         stderr=subprocess.PIPE,
         env=os.environ,
     )
-    while proc.poll() is None:
+    while proc.poll() is None and proc.stdout:
         print(proc.stdout.readline().decode('utf-8').strip())
 
     _, stderr = proc.communicate()
@@ -1037,11 +1048,11 @@ class MaybeDictToFilePath:
 
     def __init__(
         self,
-        *objs: Union[str, Dict, List, int, float, None],
-        logger: logging.Logger = None
+        *objs: Union[str, Dict[Any, Any], List[Any], int, float, None],
+        logger: Optional[logging.Logger] = None
     ):
         self._unlink = [False] * len(objs)
-        self._paths = [''] * len(objs)
+        self._paths: List[Any] = [''] * len(objs)
         self._logger = logger or get_logger()
         i = 0
         for obj in objs:
@@ -1095,7 +1106,7 @@ class MaybeDictToFilePath:
     def __enter__(self) -> List[str]:
         return self._paths
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore
         for can_unlink, path in zip(self._unlink, self._paths):
             if can_unlink and path:
                 try:
@@ -1108,7 +1119,6 @@ class TemporaryCopiedFile:
     """Context manager for tmpfiles, handles spaces in filepath."""
 
     def __init__(self, file_path: str):
-        self._path = None
         self._tmpdir = None
         if ' ' in os.path.abspath(file_path) and platform.system() == 'Windows':
             base_path, file_name = os.path.split(os.path.abspath(file_path))
@@ -1136,9 +1146,9 @@ class TemporaryCopiedFile:
         else:
             self._path = file_path
 
-    def __enter__(self):
+    def __enter__(self) -> Tuple[str, bool]:
         return self._path, self._tmpdir is not None
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore
         if self._tmpdir:
             shutil.rmtree(self._tmpdir, ignore_errors=True)

--- a/cmdstanpy_tutorial.py
+++ b/cmdstanpy_tutorial.py
@@ -3,11 +3,12 @@
 
 # ### Import CmdStanPy classes and methods
 
-import matplotlib
-import pandas as pd
 import os
 
-from cmdstanpy import cmdstan_path, CmdStanModel
+import matplotlib
+import pandas as pd
+
+from cmdstanpy import CmdStanModel, cmdstan_path
 
 # ### Instantiate & compile the model
 

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -344,4 +344,3 @@ texinfo_documents = [
 #     'reference_url': {
 #         'skltemplate': None}
 # }
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,10 @@ line_length = 80
 [tool.mypy]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-#no_implicit_optional = true
-disallow_any_generics = true
+no_implicit_optional = true
+# disallow_any_generics = true # disabled due to issues with numpy < 1.20
 warn_return_any = true
+warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = ['tqdm', 'pandas', 'ujson']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,13 @@ use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 80
 
+[tool.mypy]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+#no_implicit_optional = true
+disallow_any_generics = true
+warn_return_any = true
+
+[[tool.mypy.overrides]]
+module = ['tqdm', 'pandas', 'ujson']
+ignore_missing_imports = true

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -14,9 +14,7 @@ class CompilerOptsTest(unittest.TestCase):
         opts = CompilerOptions()
         opts.validate()
         self.assertEqual(opts.compose(), [])
-        self.assertEqual(
-            opts.__repr__(), 'stanc_options=None, cpp_options=None'
-        )
+        self.assertEqual(opts.__repr__(), 'stanc_options={}, cpp_options={}')
 
         stanc_opts = {}
         opts = CompilerOptions(stanc_options=stanc_opts)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -182,7 +182,7 @@ class OptimizeTest(unittest.TestCase):
                 seed=1239812093,
                 inits=jinit,
                 algorithm='LBFGS',
-                tol_obj=-1,
+                tol_obj=-1.0,
             )
 
         with self.assertRaisesRegex(ValueError, 'must be greater than'):
@@ -191,7 +191,7 @@ class OptimizeTest(unittest.TestCase):
                 seed=1239812093,
                 inits=jinit,
                 algorithm='LBFGS',
-                tol_rel_obj=-1,
+                tol_rel_obj=-1.0,
             )
 
         with self.assertRaisesRegex(ValueError, 'must be greater than'):
@@ -200,7 +200,7 @@ class OptimizeTest(unittest.TestCase):
                 seed=1239812093,
                 inits=jinit,
                 algorithm='LBFGS',
-                tol_grad=-1,
+                tol_grad=-1.0,
             )
 
         with self.assertRaisesRegex(ValueError, 'must be greater than'):
@@ -209,7 +209,7 @@ class OptimizeTest(unittest.TestCase):
                 seed=1239812093,
                 inits=jinit,
                 algorithm='LBFGS',
-                tol_rel_grad=-1,
+                tol_rel_grad=-1.0,
             )
 
         with self.assertRaisesRegex(ValueError, 'must be greater than'):
@@ -218,7 +218,7 @@ class OptimizeTest(unittest.TestCase):
                 seed=1239812093,
                 inits=jinit,
                 algorithm='LBFGS',
-                tol_param=-1,
+                tol_param=-1.0,
             )
 
         with self.assertRaisesRegex(ValueError, 'must be greater than'):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,6 @@
 """utils test"""
 
+import collections.abc
 import json
 import os
 import platform
@@ -9,7 +10,6 @@ import stat
 import string
 import tempfile
 import unittest
-import collections.abc
 
 import numpy as np
 import pandas as pd
@@ -25,8 +25,8 @@ from cmdstanpy.utils import (
     do_command,
     get_latest_cmdstan,
     jsondump,
-    parse_rdump_value,
     parse_method_vars,
+    parse_rdump_value,
     parse_stan_vars,
     rdump,
     read_metric,


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR mainly makes changes to the optional typing to bring them up to the standards used by mypy and other linters, as discussed here https://github.com/stan-dev/cmdstanpy/pull/408#discussion_r670471957. Any example of this is turning something like 

`dims: list = None`

into

`dims: Optional[List[int]] = None`

The package now very nearly passes `mypy --strict`, with all of the remaining errors being benign. Fixing them requires using `numpy.typing`, which isn't available to us until we make the numpy minimum version 1.21.

Some minor semantic changes were made to make the types clearer. These should have no outward-facing impact, and all existing tests still pass. This mainly included changing the default values of some variables to match their eventual types, and changing calls like `isinstance(x, number.Integral)` to the more typical `isinstance(x, int)`.

We may want to discuss including mypy in the CI checks or in the pre-commit configuration if we would like to enforce this behavior going forward

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

