### PR TITLE
Resolve several issues related to install functionality

### DIFF
--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -127,6 +127,16 @@ def install_version(
             if stderr:
                 msgs.append(stderr.decode('utf-8').strip())
             raise CmdStanInstallError('\n'.join(msgs))
+        if not os.path.exists(os.path.join('bin', 'stansummary' + EXTENSION)):
+            raise CmdStanInstallError(
+                f"bin/stansummary{EXTENSION} not found"
+                ", please rebuild or report a bug!"
+            )
+        if not os.path.exists(os.path.join('bin', 'diagnose' + EXTENSION)):
+            raise CmdStanInstallError(
+                f"bin/stansummary{EXTENSION} not found"
+                ", please rebuild or report a bug!"
+            )
         print('Test model compilation')
         cmd = [
             make,

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -405,7 +405,7 @@ def main() -> None:
             sys.argv = original_argv
             cxx_version = '40'
         # Add toolchain to $PATH
-        cxx_toolchain_path(cxx_version)
+        cxx_toolchain_path(cxx_version, vars(args)['dir'])
 
     cmdstan_version = 'cmdstan-{}'.format(version)
     with pushd(install_dir):

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1064,7 +1064,10 @@ def install_cmdstan(
             logger.warning(stderr.decode('utf-8').strip())
         return False
     if dir is not None:
-        set_cmdstan_path(os.path.join(dir, get_latest_cmdstan(dir)))
+        if version is not None:
+            set_cmdstan_path(os.path.join(dir, 'cmdstan-' + version))
+        else:
+            set_cmdstan_path(os.path.join(dir, get_latest_cmdstan(dir)))
     return True
 
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1024,9 +1024,9 @@ def install_cmdstan(
     if dir is not None:
         cmd.extend(['--dir', dir])
     if overwrite:
-        cmd.extend(['--overwrite', 'TRUE'])
+        cmd.extend(['--overwrite'])
     if verbose:
-        cmd.extend(['--verbose', 'TRUE'])
+        cmd.extend(['--verbose'])
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.DEVNULL,

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -990,6 +990,7 @@ def install_cmdstan(
     dir: Optional[str] = None,
     overwrite: bool = False,
     verbose: bool = False,
+    compiler: bool = False,
 ) -> bool:
     """
     Download and install a CmdStan release from GitHub by running
@@ -1012,6 +1013,10 @@ def install_cmdstan(
     :param verbose:  Boolean value; when ``True``, output from CmdStan build
         processes will be streamed to the console.  Default is ``False``.
 
+    :param compiler: Boolean value; when ``True`` on WINDOWS ONLY, use the
+        C++ compiler from the ``install_cxx_toolchain`` command or install
+        one if none is found.
+
     :return: Boolean value; ``True`` for success.
     """
     logger = get_logger()
@@ -1024,9 +1029,11 @@ def install_cmdstan(
     if dir is not None:
         cmd.extend(['--dir', dir])
     if overwrite:
-        cmd.extend(['--overwrite'])
+        cmd.append('--overwrite')
     if verbose:
-        cmd.extend(['--verbose'])
+        cmd.append('--verbose')
+    if compiler:
+        cmd.append('--compiler')
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.DEVNULL,

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1043,6 +1043,8 @@ def install_cmdstan(
         if stderr:
             logger.warning(stderr.decode('utf-8').strip())
         return False
+    if dir is not None:
+        set_cmdstan_path(os.path.join(dir, get_latest_cmdstan(dir)))
     return True
 
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -214,7 +214,9 @@ def cmdstan_version_at(maj: int, min: int) -> bool:
     return False
 
 
-def cxx_toolchain_path(version: Optional[str] = None) -> Tuple[str, ...]:
+def cxx_toolchain_path(
+    version: Optional[str] = None, install_dir: Optional[str] = None
+) -> Tuple[str, ...]:
     """
     Validate, then activate C++ toolchain directory path.
     """
@@ -279,19 +281,30 @@ def cxx_toolchain_path(version: Optional[str] = None) -> Tuple[str, ...]:
         cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
         cmdstan_dir_old = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
         for toolchain_root in (
-            [rtools40_home] if rtools40_home is not None else []
-        ) + [
-            os.path.join(cmdstan_dir, 'RTools40'),
-            os.path.join(cmdstan_dir_old, 'RTools40'),
-            os.path.join(os.path.abspath("/"), "RTools40"),
-            os.path.join(cmdstan_dir, 'RTools35'),
-            os.path.join(cmdstan_dir_old, 'RTools35'),
-            os.path.join(os.path.abspath("/"), "RTools35"),
-            os.path.join(cmdstan_dir, 'RTools'),
-            os.path.join(cmdstan_dir_old, 'RTools'),
-            os.path.join(os.path.abspath("/"), "RTools"),
-            os.path.join(os.path.abspath("/"), "RBuildTools"),
-        ]:
+            ([rtools40_home] if rtools40_home is not None else [])
+            + (
+                [
+                    os.path.join(install_dir, 'RTools40'),
+                    os.path.join(install_dir, 'RTools35'),
+                    os.path.join(install_dir, 'RTools30'),
+                    os.path.join(install_dir, 'RTools'),
+                ]
+                if install_dir is not None
+                else []
+            )
+            + [
+                os.path.join(cmdstan_dir, 'RTools40'),
+                os.path.join(cmdstan_dir_old, 'RTools40'),
+                os.path.join(os.path.abspath("/"), "RTools40"),
+                os.path.join(cmdstan_dir, 'RTools35'),
+                os.path.join(cmdstan_dir_old, 'RTools35'),
+                os.path.join(os.path.abspath("/"), "RTools35"),
+                os.path.join(cmdstan_dir, 'RTools'),
+                os.path.join(cmdstan_dir_old, 'RTools'),
+                os.path.join(os.path.abspath("/"), "RTools"),
+                os.path.join(os.path.abspath("/"), "RBuildTools"),
+            ]
+        ):
             compiler_path = ''
             tool_path = ''
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR does five things, all related to open problems with the installation script/function:
 * Resolves #351
Output is now 
```python
>>> import cmdstanpy
>>> cmdstanpy.install_cmdstan(verbose=True)
Installing CmdStan version: 2.27.0
Install directory: /home/brian/.cmdstan
Downloading CmdStan version 2.27.0
Download successful, file: /tmp/tmpf5fuwyke
Unpacked download as cmdstan-2.27.0
 ...[installation continues]
True
```
 * Resolves #275
Output is now
```python
>>> import cmdstanpy
>>> cmdstanpy.install_cmdstan(dir='/home/brian/.cmdstancustom')
Installing CmdStan version: 2.27.0
Install directory: /home/brian/.cmdstancustom
... [installation continues]
True
>>> cmdstanpy.cmdstan_path()
'/home/brian/.cmdstancustom/cmdstan-2.27.0'
```
 * Resolves #396 
The install script now checks that these exist and prints a meaningful error if not. I should note that part of the problem in this issue was resolved by #393 already, but this finishes it.
 * Allows the compile flag to be passed through `utils.install_cmdstan`
 * Allows for the compile and dir flags to be used together on windows. Previously, an error was reported that the toolchain could not be found if a custom directory was used.

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

