### PR TITLE
Expose write_stan_json utility

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -45,7 +45,7 @@ from .stanfit import (  # noqa
     from_csv,
 )
 from .utils import set_cmdstan_path  # noqa
-from .utils import cmdstan_path, install_cmdstan, set_make_env
+from .utils import cmdstan_path, install_cmdstan, set_make_env, write_stan_json
 
 __all__ = [
     'set_cmdstan_path',
@@ -58,4 +58,5 @@ __all__ = [
     'CmdStanVB',
     'CmdStanModel',
     'from_csv',
+    'write_stan_json',
 ]

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from cmdstanpy.cmdstan_args import (
     CmdStanArgs,
@@ -360,7 +360,7 @@ class CmdStanModel:
 
     def optimize(
         self,
-        data: Union[Dict[str, Any], str, None] = None,
+        data: Union[Mapping[str, Any], str, None] = None,
         seed: Optional[int] = None,
         inits: Union[Dict[str, float], float, str, None] = None,
         output_dir: Optional[str] = None,
@@ -507,7 +507,7 @@ class CmdStanModel:
     # pylint: disable=too-many-arguments
     def sample(
         self,
-        data: Union[Dict[str, Any], str, None] = None,
+        data: Union[Mapping[str, Any], str, None] = None,
         chains: Optional[int] = None,
         parallel_chains: Optional[int] = None,
         threads_per_chain: Optional[int] = None,
@@ -868,7 +868,7 @@ class CmdStanModel:
 
     def generate_quantities(
         self,
-        data: Union[Dict[str, Any], str, None] = None,
+        data: Union[Mapping[str, Any], str, None] = None,
         mcmc_sample: Union[CmdStanMCMC, List[str], None] = None,
         seed: Optional[int] = None,
         gq_output_dir: Optional[str] = None,
@@ -1024,7 +1024,7 @@ class CmdStanModel:
 
     def variational(
         self,
-        data: Union[Dict[str, Any], str, None] = None,
+        data: Union[Mapping[str, Any], str, None] = None,
         seed: Optional[int] = None,
         inits: Optional[float] = None,
         output_dir: Optional[str] = None,

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -416,7 +416,8 @@ def write_stan_json(path: str, data: Mapping[str, Any]) -> None:
                 val, (Collection, bool, int, float)
             ):
                 raise TypeError(
-                    f"Invalid type '{type(val)}'' provided to write_stan_json"
+                    f"Invalid type '{type(val)}'' provided to "
+                    + f"write_stan_json for key '{key}'"
                 )
             if not np.all(np.isfinite(val)):
                 raise ValueError(

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1166,7 +1166,7 @@ class MaybeDictToFilePath:
         self._logger = logger or get_logger()
         i = 0
         for obj in objs:
-            if isinstance(obj, dict):
+            if isinstance(obj, Mapping):
                 data_file = create_named_text_file(
                     dir=_TMPDIR, prefix='', suffix='.json'
                 )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -251,6 +251,12 @@ class DataFilesTest(unittest.TestCase):
         with open(file_vec_pd) as fd:
             cmp(json.load(fd), dict_vec_pd)
 
+        df_vec = pd.DataFrame(dict_list)
+        file_pd = os.path.join(_TMPDIR, 'pd.json')
+        write_stan_json(file_pd, df_vec)
+        with open(file_pd) as fd:
+            cmp(json.load(fd), dict_list)
+
         dict_zero_vec = {'a': []}
         file_zero_vec = os.path.join(_TMPDIR, 'empty_vec.json')
         write_stan_json(file_zero_vec, dict_zero_vec)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -295,6 +295,10 @@ class DataFilesTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             write_stan_json(file_bad, dict_badtype)
 
+        dict_badtype_nested = {'a': ['a string']}
+        with self.assertRaises(ValueError):
+            write_stan_json(file_bad, dict_badtype_nested)
+
         dict_inf = {'a': [np.inf]}
         with self.assertRaises(ValueError):
             write_stan_json(file_bad, dict_inf)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -27,7 +27,6 @@ from cmdstanpy.utils import (
     parse_method_vars,
     parse_rdump_value,
     parse_stan_vars,
-    rdump,
     read_metric,
     rload,
     set_cmdstan_path,
@@ -581,21 +580,6 @@ class RloadTest(unittest.TestCase):
         dfile = os.path.join(DATAFILES_PATH, 'rdump_bad_3.data.R')
         with self.assertRaises(ValueError):
             rload(dfile)
-
-    def test_roundtrip_metric(self):
-        dfile = os.path.join(DATAFILES_PATH, 'metric_diag.data.R')
-        data_dict_1 = rload(dfile)
-        self.assertEqual(data_dict_1['inv_metric'].shape, (3,))
-
-        dfile_tmp = os.path.join(DATAFILES_PATH, 'tmp.data.R')
-        rdump(dfile_tmp, data_dict_1)
-        data_dict_2 = rload(dfile_tmp)
-
-        self.assertTrue('inv_metric' in data_dict_2)
-        for i, x in enumerate(data_dict_2['inv_metric']):
-            self.assertEqual(x, data_dict_2['inv_metric'][i])
-
-        os.remove(dfile_tmp)
 
     def test_parse_rdump_value(self):
         struct1 = (


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
Addresses #410 by exposing `jsondump` as `write_stan_json` and **removing** `rdump`. 

As part of this I am allowing the more general `Mapping` type (which essentially means `.items()` is implemented) rather than strictly `Dict`, so you can now do things like `write_stan_json(path, dataframe)` or even `write_stan_json(path, xarray_dataset)`

I also added additional checks modeled on the cmdstanr function of the same name for clarity. These checks consist of:
* Verify the type of each value is numeric, a boolean, or a collection with a meaningful error if not.
* Verify that the values present are finite (meaning not NaN or inf/-inf)

Checking these two issues in particular mean that the call to `ujson.dump` should never itself fail

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

