### PR TITLE
Code cleanup - mypy enforcement and typo correction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,11 @@ jobs:
           pip install -r requirements-test.txt
           pip install codecov
 
-      - name: Run flake8 and pylint
+      - name: Run flake8, pylint, mypy
         run: |
-          mkdir run_tests
-          cd run_tests
-          flake8 --extend-ignore=E127,E201,E202,E203,E231,E252,E266,E402,E999,F841,W503,W605 --max-line-length=80 ../cmdstanpy ../test
-          pylint -v --rcfile=../.pylintrc ../cmdstanpy ../test
+          flake8 cmdstanpy test
+          pylint -v cmdstanpy test
+          mypy cmdstanpy
 
       - name: Build wheel
         run: python setup.py bdist_wheel
@@ -72,6 +71,7 @@ jobs:
 
       - name: Run tests
         run: |
+          mkdir run_tests
           cd run_tests
           pytest -v ../test --cov=../cmdstanpy
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,13 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy
+        # Copied from setup.cfg
+        exclude: ^test/
+        additional_dependencies: [ numpy >= 1.21 ]
   # local uses the user-installed pylint, this allows dependency checking
   - repo: local
     hooks:

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -668,7 +668,11 @@ class CmdStanArgs:
         elif isinstance(method_args, VariationalArgs):
             self.method = Method.VARIATIONAL
         self.method_args.validate(len(chain_ids) if chain_ids else None)
-        self._logger = logger or get_logger()
+        if logger is not None:
+            get_logger().warning(
+                "Parameter 'logger' is deprecated."
+                " Control logging behavior via logging.getLogger('cmdstanpy')"
+            )
         self.validate()
 
     def validate(self) -> None:
@@ -696,7 +700,7 @@ class CmdStanArgs:
             if not os.path.exists(self.output_dir):
                 try:
                     os.makedirs(self.output_dir)
-                    self._logger.info(
+                    get_logger().info(
                         'created output directory: %s', self.output_dir
                     )
                 except (RuntimeError, PermissionError) as exc:
@@ -740,7 +744,7 @@ class CmdStanArgs:
                 )
             if not cmdstan_version_at(2, 25):
                 self.sig_figs = None
-                self._logger.warning(
+                get_logger().warning(
                     'arg sig_figs not valid, CmdStan version must be 2.25 '
                     'or higher, using verson %s in directory %s',
                     os.path.basename(cmdstan_path()),

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -68,7 +68,11 @@ class CompilerOptions:
         """Initialize object."""
         self._stanc_options = stanc_options if stanc_options is not None else {}
         self._cpp_options = cpp_options if cpp_options is not None else {}
-        self._logger = logger or get_logger()
+        if logger is not None:
+            get_logger().warning(
+                "Parameter 'logger' is deprecated."
+                " Control logging behavior via logging.getLogger('cmdstanpy')"
+            )
 
     def __repr__(self) -> str:
         return 'stanc_options={}, cpp_options={}'.format(
@@ -105,7 +109,7 @@ class CompilerOptions:
         paths = None
         for key, val in self._stanc_options.items():
             if key in STANC_IGNORE_OPTS:
-                self._logger.info('ignoring compiler option: %s', key)
+                get_logger().info('ignoring compiler option: %s', key)
                 ignore.append(key)
             elif key not in STANC_OPTS:
                 raise ValueError(

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -89,7 +89,6 @@ class CmdStanModel:
         :param compile: Whether or not to compile the model.
         :param stanc_options: Options for stanc compiler.
         :param cpp_options: Options for C++ compiler.
-        :param logger: Python logger object.
         """
         self._name = ''
         self._stan_file = None
@@ -864,7 +863,7 @@ class CmdStanModel:
                 )
                 raise RuntimeError(msg)
 
-            mcmc = CmdStanMCMC(runset, logger=get_logger())
+            mcmc = CmdStanMCMC(runset)
         return mcmc
 
     def generate_quantities(

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -46,8 +46,8 @@ from cmdstanpy.utils import (
     cmdstan_version_at,
     create_named_text_file,
     do_command,
-    get_logger,
     flatten_chains,
+    get_logger,
     parse_method_vars,
     parse_stan_vars,
     scan_config,
@@ -74,7 +74,11 @@ class RunSet:
         """Initialize object."""
         self._args = args
         self._chains = chains
-        self._logger = logger or get_logger()
+        if logger is not None:
+            get_logger().warning(
+                "Parameter 'logger' is deprecated."
+                " Control logging behavior via logging.getLogger('cmdstanpy)'"
+            )
         if chains < 1:
             raise ValueError(
                 'Chains must be positive integer value, '
@@ -354,7 +358,7 @@ class RunSet:
                     'File exists, not overwriting: {}'.format(to_path)
                 )
             try:
-                self._logger.debug(
+                get_logger().debug(
                     'saving tmpfile: "%s" as: "%s"', self._csv_files[i], to_path
                 )
                 shutil.move(self._csv_files[i], to_path)
@@ -448,7 +452,11 @@ class CmdStanMCMC:
                 'found method {}'.format(runset.method)
             )
         self.runset = runset
-        self._logger = logger or get_logger()
+        if logger is not None:
+            get_logger().warning(
+                "Parameter 'logger' is deprecated."
+                " Control logging behavior via logging.getLogger('cmdstanpy')"
+            )
         # info from runset to be exposed
         sampler_args = self.runset._args.method_args
         assert isinstance(
@@ -531,7 +539,7 @@ class CmdStanMCMC:
         """
         Deprecated - use "metadata.method_vars_cols" instead
         """
-        self._logger.warning(
+        get_logger().warning(
             'Property "sampler_vars_cols" has been deprecated, '
             'use "metadata.method_vars_cols" instead.'
         )
@@ -542,7 +550,7 @@ class CmdStanMCMC:
         """
         Deprecated - use "metadata.stan_vars_cols" instead
         """
-        self._logger.warning(
+        get_logger().warning(
             'Property "stan_vars_cols" has been deprecated, '
             'use "metadata.stan_vars_cols" instead.'
         )
@@ -553,7 +561,7 @@ class CmdStanMCMC:
         """
         Deprecated - use "metadata.stan_vars_dims" instead
         """
-        self._logger.warning(
+        get_logger().warning(
             'Property "stan_vars_dims" has been deprecated, '
             'use "metadata.stan_vars_dims" instead.'
         )
@@ -655,7 +663,7 @@ class CmdStanMCMC:
             self._assemble_draws()
 
         if inc_warmup and not self._save_warmup:
-            self._logger.warning(
+            get_logger().warning(
                 "Sample doesn't contain draws from warmup iterations,"
                 ' rerun sampler with "save_warmup=True".'
             )
@@ -673,7 +681,7 @@ class CmdStanMCMC:
         """
         Deprecated - use method "draws()" instead.
         """
-        self._logger.warning(
+        get_logger().warning(
             'Method "sample" has been deprecated, use method "draws" instead.'
         )
         return self.draws()
@@ -683,7 +691,7 @@ class CmdStanMCMC:
         """
         Deprecated - use "draws(inc_warmup=True)"
         """
-        self._logger.warning(
+        get_logger().warning(
             'Method "warmup" has been deprecated, instead use method'
             ' "draws(inc_warmup=True)", returning draws from both'
             ' warmup and sampling iterations.'
@@ -867,7 +875,7 @@ class CmdStanMCMC:
                 )
             csv_sig_figs = self._sig_figs or 6
             if sig_figs > csv_sig_figs:
-                self._logger.warning(
+                get_logger().warning(
                     'Requesting %d significant digits of output, but CSV files'
                     ' only have %d digits of precision.',
                     sig_figs,
@@ -890,7 +898,7 @@ class CmdStanMCMC:
             sig_figs_str,
             csv_str,
         ] + self.runset.csv_files
-        do_command(cmd, logger=self.runset._logger)
+        do_command(cmd)
         with open(tmp_csv_path, 'rb') as fd:
             summary_data = pd.read_csv(
                 fd,
@@ -919,9 +927,9 @@ class CmdStanMCMC:
         """
         cmd_path = os.path.join(cmdstan_path(), 'bin', 'diagnose' + EXTENSION)
         cmd = [cmd_path] + self.runset.csv_files
-        result = do_command(cmd=cmd, logger=self.runset._logger)
+        result = do_command(cmd=cmd)
         if result:
-            self.runset._logger.info(result)
+            get_logger().info(result)
         return result
 
     def draws_pd(
@@ -946,11 +954,9 @@ class CmdStanMCMC:
         """
         if params is not None:
             if vars is not None:
-                raise ValueError(
-                    "Cannot use both vars and (depreciated) params"
-                )
+                raise ValueError("Cannot use both vars and (deprecated) params")
             get_logger().warning(
-                'Keyword "params" is depreciated, use "vars" instead.'
+                'Keyword "params" is deprecated, use "vars" instead.'
             )
             vars = params
         if vars is not None:
@@ -1002,7 +1008,7 @@ class CmdStanMCMC:
                 'Package "xarray" is not installed, cannot produce draws array.'
             )
         if inc_warmup and not self._save_warmup:
-            self._logger.warning(
+            get_logger().warning(
                 "Draws from warmup iterations not available,"
                 ' must run sampler with "save_warmup=True".'
             )
@@ -1049,7 +1055,11 @@ class CmdStanMCMC:
         )
 
     def stan_variable(
-        self, var: str = None, inc_warmup: bool = False, *, name: str = None
+        self,
+        var: Optional[str] = None,
+        inc_warmup: bool = False,
+        *,
+        name: Optional[str] = None,
     ) -> np.ndarray:
         """
         Return a numpy.ndarray which contains the set of draws
@@ -1085,10 +1095,10 @@ class CmdStanMCMC:
         if name is not None:
             if var is not None:
                 raise ValueError(
-                    'Cannot use both "var" and (depreciated) "name"'
+                    'Cannot use both "var" and (deprecated) "name"'
                 )
             get_logger().warning(
-                'Keyword "name" is depreciated, use "var" instead.'
+                'Keyword "name" is deprecated, use "var" instead.'
             )
             var = name
         if var is None:
@@ -1140,7 +1150,7 @@ class CmdStanMCMC:
         """
         Deprecated, use "method_variables" instead
         """
-        self._logger.warning(
+        get_logger().warning(
             'Method "sampler_variables" has been deprecated, '
             'use method "method_variables" instead.'
         )
@@ -1150,7 +1160,7 @@ class CmdStanMCMC:
         """
         Deprecated, use "method_variables" instead
         """
-        self._logger.warning(
+        get_logger().warning(
             'Method "sampler_diagnostics" has been deprecated, '
             'use method "method_variables" instead.'
         )
@@ -1233,7 +1243,9 @@ class CmdStanMLE:
         """Returns optimized params as Dict."""
         return OrderedDict(zip(self.column_names, self._mle))
 
-    def stan_variable(self, var: str = None, *, name: str = None) -> np.ndarray:
+    def stan_variable(
+        self, var: Optional[str] = None, *, name: Optional[str] = None
+    ) -> np.ndarray:
         """
         Return a numpy.ndarray which contains the estimates for the
         for the named Stan program variable where the dimensions of the
@@ -1244,10 +1256,10 @@ class CmdStanMLE:
         if name is not None:
             if var is not None:
                 raise ValueError(
-                    'Cannot use both "var" and (depreciated) "name".'
+                    'Cannot use both "var" and (deprecated) "name".'
                 )
             get_logger().warning(
-                'Keyword "name" is depreciated, use "var" instead.'
+                'Keyword "name" is deprecated, use "var" instead.'
             )
             var = name
         if var is None:
@@ -1475,7 +1487,7 @@ class CmdStanGQ:
                 for item, count in Counter(cols_1 + cols_2).items()
                 if count > 1
             ]
-            drop_cols = []
+            drop_cols: List[int] = []
             for dup in dups:
                 drop_cols.extend(self.mcmc_sample.metadata.stan_vars_cols[dup])
 
@@ -1653,21 +1665,25 @@ class CmdStanGQ:
 
         num_draws = self.mcmc_sample.num_draws_sampling
         sample_config = self.mcmc_sample.metadata.cmdstan_config
-        attrs = {
+        attrs: MutableMapping[Hashable, Any] = {
             "stan_version": f"{sample_config['stan_version_major']}."
             f"{sample_config['stan_version_minor']}."
             f"{sample_config['stan_version_patch']}",
             "model": sample_config["model"],
-            "num_unconstrained_params":
-            self.mcmc_sample.num_unconstrained_params,
+            "num_unconstrained_params": (
+                self.mcmc_sample.num_unconstrained_params
+            ),
             "num_draws_sampling": num_draws,
         }
         if inc_warmup and sample_config['save_warmup']:
             num_draws += self.mcmc_sample.num_draws_warmup
             attrs["num_draws_warmup"] = self.mcmc_sample.num_draws_warmup
 
-        data = {}
-        coordinates = {"chain": self.chain_ids, "draw": np.arange(num_draws)}
+        data: MutableMapping[Hashable, Any] = {}
+        coordinates: MutableMapping[Hashable, Any] = {
+            "chain": self.chain_ids,
+            "draw": np.arange(num_draws),
+        }
 
         for var in vars_list:
             build_xarray_data(
@@ -1694,7 +1710,11 @@ class CmdStanGQ:
         )
 
     def stan_variable(
-        self, var: str = None, inc_warmup: bool = False, *, name: str = None
+        self,
+        var: Optional[str] = None,
+        inc_warmup: bool = False,
+        *,
+        name: Optional[str] = None,
     ) -> np.ndarray:
         """
         Return a numpy.ndarray which contains the set of draws
@@ -1730,10 +1750,10 @@ class CmdStanGQ:
         if name is not None:
             if var is not None:
                 raise ValueError(
-                    'Cannot use both "var" and (depreciated) "name"'
+                    'Cannot use both "var" and (deprecated) "name"'
                 )
             get_logger().warning(
-                'Keyword "name" is depreciated, use "var" instead.'
+                'Keyword "name" is deprecated, use "var" instead.'
             )
             var = name
         if var is None:
@@ -1882,7 +1902,9 @@ class CmdStanVB:
         """
         return self._metadata
 
-    def stan_variable(self, var: str = None, *, name: str = None) -> np.ndarray:
+    def stan_variable(
+        self, var: Optional[str] = None, *, name: Optional[str] = None
+    ) -> np.ndarray:
         """
         Return a numpy.ndarray which contains the estimates for the
         for the named Stan program variable where the dimensions of the
@@ -1893,10 +1915,10 @@ class CmdStanVB:
         if name is not None:
             if var is not None:
                 raise ValueError(
-                    'Cannot use both "var" and (depreciated) "name"'
+                    'Cannot use both "var" and (deprecated) "name"'
                 )
             get_logger().warning(
-                'Keyword "name" is depreciated, use "var" instead.'
+                'Keyword "name" is deprecated, use "var" instead.'
             )
             var = name
         if var is None:
@@ -2098,7 +2120,7 @@ def from_csv(
 
 
 def build_xarray_data(
-    data: Dict[str, Tuple[Tuple[str, ...], np.ndarray]],
+    data: MutableMapping[Hashable, Tuple[Tuple[str, ...], np.ndarray]],
     var_name: str,
     dims: Tuple[int, ...],
     col_idxs: Tuple[int, ...],
@@ -2109,11 +2131,9 @@ def build_xarray_data(
     Adds Stan variable name, labels, and values to a dictionary
     that will be used to construct an xarray DataSet.
     """
-    var_dims = ('draw', 'chain')
+    var_dims: Tuple[str, ...] = ('draw', 'chain')
     if dims:
-        var_dims = ("draw", "chain") + tuple(
-            f"{var_name}_dim_{i}" for i in range(len(dims))
-        )
+        var_dims += tuple(f"{var_name}_dim_{i}" for i in range(len(dims)))
         data[var_name] = (var_dims, drawset[start_row:, :, col_idxs])
     else:
         data[var_name] = (

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -418,7 +418,7 @@ class InferenceMetadata:
         """
         Returns map from Stan program variable names to variable dimensions.
         Scalar types are mapped to the empty tuple, e.g.,
-        program variable ``int foo`` has dimesion ``()`` and
+        program variable ``int foo`` has dimension ``()`` and
         program variable ``vector[10] bar`` has single dimension ``(10)``.
         Uses deepcopy for immutability.
         """
@@ -1216,7 +1216,7 @@ class CmdStanMLE:
     def column_names(self) -> Tuple[str, ...]:
         """
         Names of estimated quantities, includes joint log probability,
-        and all parameters, transformed parameters, and generated quantitites.
+        and all parameters, transformed parameters, and generated quantities.
         """
         return self._column_names
 

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -725,6 +725,7 @@ class CmdStanMCMC:
                     save_warmup=self._save_warmup,
                     thin=self._thin,
                 )
+                # pylint: disable=consider-using-dict-items
                 for key in dzero:
                     if (
                         key
@@ -1348,6 +1349,7 @@ class CmdStanGQ:
                 drest = scan_generated_quantities_csv(
                     path=self.runset.csv_files[i],
                 )
+                # pylint: disable=consider-using-dict-items
                 for key in dzero:
                     if (
                         key

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -44,7 +44,7 @@ from cmdstanpy import (
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def get_logger() -> logging.Logger:
     """cmdstanpy logger"""
     logger = logging.getLogger('cmdstanpy')

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -2,6 +2,7 @@
 Utility functions
 """
 import contextlib
+import functools
 import logging
 import math
 import os
@@ -43,6 +44,7 @@ from cmdstanpy import (
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
 
+@functools.cache
 def get_logger() -> logging.Logger:
     """cmdstanpy logger"""
     logger = logging.getLogger('cmdstanpy')
@@ -892,14 +894,12 @@ def read_rdump_metric(path: str) -> List[int]:
 def do_command(
     cmd: List[str],
     cwd: Optional[str] = None,
-    logger: Optional[logging.Logger] = None,
 ) -> Optional[str]:
     """
     Spawn process, print stdout/stderr to console.
     Throws RuntimeError on non-zero returncode.
     """
-    if logger:
-        logger.debug('cmd: %s', cmd)
+    get_logger().debug('cmd: %s', cmd)
     try:
         proc = subprocess.Popen(
             cmd,
@@ -1090,7 +1090,9 @@ def install_cmdstan(
         if version is not None:
             set_cmdstan_path(os.path.join(dir, 'cmdstan-' + version))
         else:
-            set_cmdstan_path(os.path.join(dir, get_latest_cmdstan(dir)))
+            set_cmdstan_path(
+                os.path.join(dir, get_latest_cmdstan(dir))  # type: ignore
+            )
     return True
 
 
@@ -1156,18 +1158,16 @@ class MaybeDictToFilePath:
     def __init__(
         self,
         *objs: Union[str, Mapping[str, Any], List[Any], int, float, None],
-        logger: Optional[logging.Logger] = None,
     ):
         self._unlink = [False] * len(objs)
         self._paths: List[Any] = [''] * len(objs)
-        self._logger = logger or get_logger()
         i = 0
         for obj in objs:
             if isinstance(obj, Mapping):
                 data_file = create_named_text_file(
                     dir=_TMPDIR, prefix='', suffix='.json'
                 )
-                self._logger.debug('input tempfile: %s', data_file)
+                get_logger().debug('input tempfile: %s', data_file)
                 write_stan_json(data_file, obj)
                 self._paths[i] = data_file
                 self._unlink[i] = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ disallow_incomplete_defs = true
 no_implicit_optional = true
 # disallow_any_generics = true # disabled due to issues with numpy < 1.20
 warn_return_any = true
-warn_unused_ignores = true
+# warn_unused_ignores = true # can't be run on CI due to windows having different ctypes
 
 [[tool.mypy.overrides]]
-module = ['tqdm', 'pandas', 'ujson']
+module = ['tqdm', 'pandas', 'ujson', 'numpy']
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,11 @@ warn_return_any = true
 # warn_unused_ignores = true # can't be run on CI due to windows having different ctypes
 
 [[tool.mypy.overrides]]
-module = ['tqdm', 'pandas', 'ujson', 'numpy']
+module = [
+    'tqdm',
+    'pandas',
+    'ujson',
+    'numpy', # these two are required for py36, which numpy 1.21 doesn't support
+    'numpy.random'
+    ]
 ignore_missing_imports = true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,7 @@ flake8
 pylint
 pytest
 pytest-cov
+mypy
 testfixtures
 tqdm
 xarray

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -4,9 +4,9 @@ import json
 import logging
 import os
 import unittest
+
 import numpy as np
 import pandas as pd
-
 from numpy.testing import assert_array_equal, assert_raises
 from testfixtures import LogCapture
 
@@ -216,7 +216,7 @@ class GenerateQuantitiesTest(unittest.TestCase):
             (
                 'cmdstanpy',
                 'WARNING',
-                'Keyword "name" is depreciated, use "var" instead.',
+                'Keyword "name" is deprecated, use "var" instead.',
             )
         )
 

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -95,7 +95,7 @@ class CmdStanMLETest(unittest.TestCase):
             (
                 'cmdstanpy',
                 'WARNING',
-                'Keyword "name" is depreciated, use "var" instead.',
+                'Keyword "name" is deprecated, use "var" instead.',
             )
         )
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -555,7 +555,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             (
                 'cmdstanpy',
                 'WARNING',
-                'Keyword "params" is depreciated, use "vars" instead.',
+                'Keyword "params" is deprecated, use "vars" instead.',
             )
         )
         self.assertEqual(fit.draws_pd(vars=['theta']).shape, (400, 1))
@@ -1251,7 +1251,7 @@ class CmdStanMCMCTest(unittest.TestCase):
             (
                 'cmdstanpy',
                 'WARNING',
-                'Keyword "name" is depreciated, use "var" instead.',
+                'Keyword "name" is deprecated, use "var" instead.',
             )
         )
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1,5 +1,6 @@
 """CmdStan method sample tests"""
 
+import contextlib
 import logging
 import os
 import platform
@@ -7,6 +8,7 @@ import shutil
 import stat
 import tempfile
 import unittest
+from importlib import reload
 from multiprocessing import cpu_count
 from time import time
 
@@ -19,6 +21,7 @@ try:
 except ImportError:
     import json
 
+import cmdstanpy.stanfit
 from cmdstanpy import _TMPDIR
 from cmdstanpy.cmdstan_args import CmdStanArgs, Method, SamplerArgs
 from cmdstanpy.model import CmdStanModel
@@ -42,6 +45,14 @@ SAMPLER_STATE = [
 ]
 # metadata should make this unnecessary
 BERNOULLI_COLS = SAMPLER_STATE + ['theta']
+
+
+@contextlib.contextmanager
+def without_import(library, module):
+    with unittest.mock.patch.dict('sys.modules', {library: None}):
+        reload(module)
+        yield
+    reload(module)
 
 
 class SampleTest(unittest.TestCase):
@@ -1117,7 +1128,17 @@ class CmdStanMCMCTest(unittest.TestCase):
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
         jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
 
-        bern_model = CmdStanModel(stan_file=stan)
+        with LogCapture() as log:
+            bern_model = CmdStanModel(stan_file=stan, logger="Not None")
+        log.check_present(
+            (
+                "cmdstanpy",
+                "WARNING",
+                "Parameter 'logger' is deprecated."
+                " Control logging behavior via logging.getLogger('cmdstanpy')",
+            )
+        )
+
         bern_fit = bern_model.sample(
             data=jdata,
             chains=2,
@@ -1586,6 +1607,26 @@ class CmdStanMCMCTest(unittest.TestCase):
         xr_var = bern_fit.draws_xr(vars=['theta'])
         self.assertEqual(xr_var.theta.dims, ('chain', 'draw', 'theta_dim_0'))
         self.assertEqual(xr_var.theta.values.shape, (1, 100, 1))
+
+    def test_no_xarray(self):
+        with without_import('xarray', cmdstanpy.stanfit):
+            with self.assertRaises(ImportError):
+                # if this fails the testing framework is the problem
+                import xarray as _  # noqa
+
+            stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+            jdata = os.path.join(DATAFILES_PATH, 'bernoulli.data.json')
+            bern_model = CmdStanModel(stan_file=stan)
+            bern_fit = bern_model.sample(
+                data=jdata,
+                chains=2,
+                seed=12345,
+                iter_warmup=100,
+                iter_sampling=100,
+            )
+
+            with self.assertRaises(RuntimeError):
+                bern_fit.draws_xr()
 
 
 if __name__ == '__main__':

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -147,7 +147,7 @@ class CmdStanVBTest(unittest.TestCase):
             (
                 'cmdstanpy',
                 'WARNING',
-                'Keyword "name" is depreciated, use "var" instead.',
+                'Keyword "name" is deprecated, use "var" instead.',
             )
         )
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

* Finishes #415. Uses `get_logger` universally, caches `get_logger`, and emits deprecation warnings if old keyword is used, to be removed in 1.0
* Fixes some typos that made it through review ('depreciated' vs 'deprecated')
* Fix some mypy errors **and add mypy to the CI**. This may be controversial, as it will end up rejecting a lot of first passes, but if we'd like to commit to having a decently typed package, that needs to be enforced automatically somewhere.
* Add tests that mock xarray not being installed to ensure correct behavior of `.draws_xr` in that case 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

