### PR TITLE
Add warnings for PCH error

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -336,6 +336,21 @@ class CmdStanModel:
                         get_logger().error(
                             'file %s, exception %s', stan_file, str(e)
                         )
+                        if 'PCH file' in str(e):
+                            get_logger().warning(
+                                "%s, %s",
+                                "CmdStan's precompiled header (PCH) files ",
+                                "may need to be rebuilt.",
+                            )
+                            get_logger().warning(
+                                "%s %s",
+                                "If your model failed to compile please run ",
+                                "install_cmdstan(overwrite=True).",
+                            )
+                            get_logger().warning(
+                                "If the issue persists please open a bug report"
+                            )
+
                         compilation_failed = True
 
                 if not compilation_failed:


### PR DESCRIPTION
Resolves #382. Based on the same idea in cmdstanr

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is a (partial?) solution to #382. It produces a warning if the compile command fails for this reason, which currently directs the user to call `install_cmdstan(overwrite=True)`. 

If we believe there is merit to providing a separate `rebuild_cmdstan()`, I can refactor the install code to support this, but it would be largely the same as this call, I believe. 

I should also mention I'm not sure how to artificially recreate this issue to test it, but the logic behind showing the warning is simple enough (based on cmdstanr) that I am pretty positive it would work

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

