### PR TITLE
Formally mark ~/.cmdstanpy as deprecated

### DIFF
--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -31,7 +31,7 @@ from time import sleep
 from typing import Callable, Dict, Optional
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
-from cmdstanpy.utils import pushd, validate_dir, wrap_progress_hook
+from cmdstanpy.utils import get_logger, pushd, validate_dir, wrap_progress_hook
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
@@ -353,6 +353,11 @@ def main() -> None:
         cmdstanpy_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
         if os.path.exists(cmdstanpy_dir):
             cmdstan_dir = cmdstanpy_dir
+            get_logger().warning(
+                "Using ~/.cmdstanpy is deprecated and"
+                " will not be automatically detected in version 1.0!\n"
+                " Please rename to ~/.cmdstan"
+            )
 
     install_dir = cmdstan_dir
     if vars(args)['dir']:

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -8,7 +8,7 @@ example model ``bernoulli.stan``.
 
 Optional command line arguments:
    -v, --version <release> : version, defaults to latest release version
-   -d, --dir <path> : install directory, defaults to '$HOME/.cmdstan(py)
+   -d, --dir <path> : install directory, defaults to '$HOME/.cmdstan
    --overwrite: flag, when specified re-installs existing version
    --verbose: flag, when specified prints output from CmdStan build process
    --progress: flag, when specified show progress bar for CmdStan download
@@ -307,7 +307,7 @@ def main() -> None:
         '--version', '-v', help="version, defaults to latest release version"
     )
     parser.add_argument(
-        '--dir', '-d', help="install directory, defaults to '$HOME/.cmdstan(py)"
+        '--dir', '-d', help="install directory, defaults to '$HOME/.cmdstan"
     )
     parser.add_argument(
         '--overwrite',

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -24,7 +24,7 @@ from time import sleep
 from typing import List
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
-from cmdstanpy.utils import pushd, validate_dir, wrap_progress_hook
+from cmdstanpy.utils import get_logger, pushd, validate_dir, wrap_progress_hook
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 IS_64BITS = sys.maxsize > 2 ** 32
@@ -317,6 +317,11 @@ def main() -> None:
             )
             if os.path.exists(cmdstanpy_dir):
                 cmdstan_dir = cmdstanpy_dir
+                get_logger().warning(
+                    "Using ~/.cmdstanpy is deprecated and"
+                    " will not be automatically detected in version 1.0!\n"
+                    " Please rename to ~/.cmdstan"
+                )
         install_dir = cmdstan_dir
     validate_dir(install_dir)
     print('Install directory: {}'.format(install_dir))

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -160,6 +160,11 @@ def cmdstan_path() -> str:
                     'no CmdStan installation found, '
                     'run command line script "install_cmdstan"'
                 )
+            get_logger().warning(
+                "Using ~/.cmdstanpy is deprecated and"
+                " will not be automatically detected in version 1.0!\n"
+                " Please rename to ~/.cmdstan"
+            )
         latest_cmdstan = get_latest_cmdstan(cmdstan_dir)
         if latest_cmdstan is None:
             raise ValueError(

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1045,7 +1045,7 @@ def install_cmdstan(
 
     :param dir: Path to install directory.  Defaults to hidden directory
         ``$HOME/.cmdstan``.
-        If no directory is specified and the above directory does not exist
+        If no directory is specified and the above directory does not
         exist, directory ``$HOME/.cmdstan`` will be created and populated.
 
     :param overwrite:  Boolean value; when ``True``, will overwrite and

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1044,8 +1044,8 @@ def install_cmdstan(
         Defaults to latest CmdStan release.
 
     :param dir: Path to install directory.  Defaults to hidden directory
-        ``$HOME/.cmdstan`` or ``$HOME/.cmdstanpy``, if the latter exists.
-        If no directory is specified and neither of the above directories
+        ``$HOME/.cmdstan``.
+        If no directory is specified and the above directory does not exist
         exist, directory ``$HOME/.cmdstan`` will be created and populated.
 
     :param overwrite:  Boolean value; when ``True``, will overwrite and


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

The logic for finding a cmdstan instance is complicated by the legacy support for `~/.cmdstanpy`. This PR emits a warning whenever this is detected asking the user to rename to the newer `~/.cmdstan`, so we can drop this for version 1.0

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

