### PR TITLE
Add pdf build to readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,5 +3,8 @@ version: 2
 build:
     image: stable
 
+formats:
+    - pdf
+
 conda:
     environment: docsrc/env.yml

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -323,8 +323,8 @@ latex_elements = {
 latex_documents = [
     (
         'index',
-        'project-template.tex',
-        u'project-template Documentation',
+        'cmdstanpy.tex',
+        u'CmdStanPy Documentation',
         u'Stan Development Team',
         'manual',
     )
@@ -358,8 +358,8 @@ latex_documents = [
 man_pages = [
     (
         'index',
-        'project-template',
-        u'project-template Documentation',
+        'cmdstanpy',
+        u'CmdStanPy Documentation',
         [u'Stan Development Team'],
         1,
     )


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
This was a regression when changing config format to v2. In the past, RTD always built a PDF and Epub alongside the html. I don't know if many people knew/used it, but I feel like we should at least maintain the option of a downloadable manual. I don't think it's high enough priority to require a doc rebuild though.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

