### PR TITLE
Project/1.0 cleanup

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -46,7 +46,13 @@ from .stanfit import (  # noqa
     from_csv,
 )
 from .utils import set_cmdstan_path  # noqa
-from .utils import cmdstan_path, install_cmdstan, set_make_env, write_stan_json
+from .utils import (
+    cmdstan_path,
+    install_cmdstan,
+    set_make_env,
+    show_versions,
+    write_stan_json,
+)
 
 __all__ = [
     'set_cmdstan_path',
@@ -61,4 +67,5 @@ __all__ = [
     'InferenceMetadata',
     'from_csv',
     'write_stan_json',
+    'show_versions',
 ]

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -481,7 +481,7 @@ class CmdStanModel:
             between progress messages. Default value is 100.
 
         :param time_fmt: A format string passed to
-            :func:`datetime.strftime` to decide the file names for
+            :meth:`~datetime.datetime.strftime` to decide the file names for
             output CSVs. Defaults to "%Y%m%d%H%M%S"
 
         :return: CmdStanMLE object
@@ -720,7 +720,7 @@ class CmdStanModel:
             between progress messages. Default value is 100.
 
         :param time_fmt: A format string passed to
-            :func:`datetime.strftime` to decide the file names for
+            :meth:`~datetime.datetime.strftime` to decide the file names for
             output CSVs. Defaults to "%Y%m%d%H%M%S"
 
         :return: CmdStanMCMC object
@@ -959,7 +959,7 @@ class CmdStanModel:
             between progress messages. Default value is 100.
 
         :param time_fmt: A format string passed to
-            :func:`datetime.strftime` to decide the file names for
+            :meth:`~datetime.datetime.strftime` to decide the file names for
             output CSVs. Defaults to "%Y%m%d%H%M%S"
 
         :return: CmdStanGQ object
@@ -1139,7 +1139,7 @@ class CmdStanModel:
             between progress messages. Default value is 100.
 
         :param time_fmt: A format string passed to
-            :func:`datetime.strftime` to decide the file names for
+            :meth:`~datetime.datetime.strftime` to decide the file names for
             output CSVs. Defaults to "%Y%m%d%H%M%S"
 
         :return: CmdStanVB object

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -344,17 +344,12 @@ class CmdStanModel:
                         )
                         if 'PCH file' in str(e):
                             get_logger().warning(
-                                "%s, %s",
-                                "CmdStan's precompiled header (PCH) files ",
-                                "may need to be rebuilt.",
-                            )
-                            get_logger().warning(
-                                "%s %s",
-                                "If your model failed to compile please run ",
-                                "install_cmdstan(overwrite=True).",
-                            )
-                            get_logger().warning(
-                                "If the issue persists please open a bug report"
+                                "%s",
+                                "CmdStan's precompiled header (PCH) files "
+                                "may need to be rebuilt."
+                                "If your model failed to compile please run "
+                                "install_cmdstan(overwrite=True).\nIf the "
+                                "issue persists please open a bug report",
                             )
 
                         compilation_failed = True
@@ -398,6 +393,7 @@ class CmdStanModel:
         history_size: Optional[int] = None,
         iter: Optional[int] = None,
         refresh: Optional[int] = None,
+        time_fmt: str = "%Y%m%d%H%M%S",
     ) -> CmdStanMLE:
         """
         Run the specified CmdStan optimize algorithm to produce a
@@ -484,6 +480,10 @@ class CmdStanModel:
         :param refresh: Specify the number of iterations cmdstan will take
             between progress messages. Default value is 100.
 
+        :param time_fmt: A format string passed to
+            :func:`datetime.strftime` to decide the file names for
+            output CSVs. Defaults to "%Y%m%d%H%M%S"
+
         :return: CmdStanMLE object
         """
         optimize_args = OptimizeArgs(
@@ -514,7 +514,7 @@ class CmdStanModel:
             )
 
             dummy_chain_id = 0
-            runset = RunSet(args=args, chains=1)
+            runset = RunSet(args=args, chains=1, time_fmt=time_fmt)
             self._run_cmdstan(runset, dummy_chain_id)
 
         if not runset._check_retcodes():
@@ -555,6 +555,7 @@ class CmdStanModel:
         save_profile: bool = False,
         show_progress: Union[bool, str] = False,
         refresh: Optional[int] = None,
+        time_fmt: str = "%Y%m%d%H%M%S",
     ) -> CmdStanMCMC:
         """
         Run or more chains of the NUTS-HMC sampler to produce a set of draws
@@ -718,6 +719,10 @@ class CmdStanModel:
         :param refresh: Specify the number of iterations cmdstan will take
             between progress messages. Default value is 100.
 
+        :param time_fmt: A format string passed to
+            :func:`datetime.strftime` to decide the file names for
+            output CSVs. Defaults to "%Y%m%d%H%M%S"
+
         :return: CmdStanMCMC object
         """
         if chains is None:
@@ -829,7 +834,9 @@ class CmdStanModel:
                 method_args=sampler_args,
                 refresh=refresh,
             )
-            runset = RunSet(args=args, chains=chains, chain_ids=chain_ids)
+            runset = RunSet(
+                args=args, chains=chains, chain_ids=chain_ids, time_fmt=time_fmt
+            )
             pbar = None
             all_pbars = []
 
@@ -899,6 +906,7 @@ class CmdStanModel:
         gq_output_dir: Optional[str] = None,
         sig_figs: Optional[int] = None,
         refresh: Optional[int] = None,
+        time_fmt: str = "%Y%m%d%H%M%S",
     ) -> CmdStanGQ:
         """
         Run CmdStan's generate_quantities method which runs the generated
@@ -950,6 +958,10 @@ class CmdStanModel:
         :param refresh: Specify the number of iterations cmdstan will take
             between progress messages. Default value is 100.
 
+        :param time_fmt: A format string passed to
+            :func:`datetime.strftime` to decide the file names for
+            output CSVs. Defaults to "%Y%m%d%H%M%S"
+
         :return: CmdStanGQ object
         """
         if isinstance(mcmc_sample, CmdStanMCMC):
@@ -999,7 +1011,9 @@ class CmdStanModel:
                 method_args=generate_quantities_args,
                 refresh=refresh,
             )
-            runset = RunSet(args=args, chains=chains, chain_ids=chain_ids)
+            runset = RunSet(
+                args=args, chains=chains, chain_ids=chain_ids, time_fmt=time_fmt
+            )
 
             parallel_chains_avail = cpu_count()
             parallel_chains = max(min(parallel_chains_avail - 2, chains), 1)
@@ -1039,6 +1053,7 @@ class CmdStanModel:
         output_samples: Optional[int] = None,
         require_converged: bool = True,
         refresh: Optional[int] = None,
+        time_fmt: str = "%Y%m%d%H%M%S",
     ) -> CmdStanVB:
         """
         Run CmdStan's variational inference algorithm to approximate
@@ -1123,6 +1138,10 @@ class CmdStanModel:
         :param refresh: Specify the number of iterations cmdstan will take
             between progress messages. Default value is 100.
 
+        :param time_fmt: A format string passed to
+            :func:`datetime.strftime` to decide the file names for
+            output CSVs. Defaults to "%Y%m%d%H%M%S"
+
         :return: CmdStanVB object
         """
         variational_args = VariationalArgs(
@@ -1155,7 +1174,7 @@ class CmdStanModel:
             )
 
             dummy_chain_id = 0
-            runset = RunSet(args=args, chains=1)
+            runset = RunSet(args=args, chains=1, time_fmt=time_fmt)
             self._run_cmdstan(runset, dummy_chain_id)
 
         # treat failure to converge as failure

--- a/cmdstanpy/stanfit.py
+++ b/cmdstanpy/stanfit.py
@@ -70,6 +70,7 @@ class RunSet:
         chains: int = 4,
         chain_ids: Optional[List[int]] = None,
         logger: Optional[logging.Logger] = None,
+        time_fmt: str = "%Y%m%d%H%M%S",
     ) -> None:
         """Initialize object."""
         self._args = args
@@ -100,7 +101,7 @@ class RunSet:
         # prefix: ``<model_name>-<YYYYMMDDHHMM>-<chain_id>``
         # suffixes: ``-stdout.txt``, ``-stderr.txt``
         now = datetime.now()
-        now_str = now.strftime('%Y%m%d%H%M')
+        now_str = now.strftime(time_fmt)
         file_basename = '-'.join([args.model_name, now_str])
         if args.output_dir is not None:
             output_dir = args.output_dir
@@ -794,7 +795,7 @@ class CmdStanMCMC:
                         line = fd.readline().strip()  # metric type
                         line = fd.readline().lstrip(' #\t')
                         num_unconstrained_params = len(line.split(','))
-                        if chain == 0:   # can't allocate w/o num params
+                        if chain == 0:  # can't allocate w/o num params
                             if self.metric_type == 'diag_e':
                                 self._metric = np.empty(
                                     (self.chains, num_unconstrained_params),

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1027,6 +1027,68 @@ def create_named_text_file(
     return path
 
 
+def show_versions(output: bool = True) -> str:
+    """Prints out system and dependency information for debugging"""
+
+    import importlib
+    import locale
+    import struct
+
+    deps_info = []
+    try:
+        (sysname, _, release, _, machine, processor) = platform.uname()
+        deps_info.extend(
+            [
+                ("python", sys.version),
+                ("python-bits", struct.calcsize("P") * 8),
+                ("OS", f"{sysname}"),
+                ("OS-release", f"{release}"),
+                ("machine", f"{machine}"),
+                ("processor", f"{processor}"),
+                ("byteorder", f"{sys.byteorder}"),
+                ("LC_ALL", f'{os.environ.get("LC_ALL", "None")}'),
+                ("LANG", f'{os.environ.get("LANG", "None")}'),
+                ("LOCALE", f"{locale.getlocale()}"),
+            ]
+        )
+    # pylint: disable=broad-except
+    except Exception:
+        pass
+
+    try:
+        deps_info.append(('cmdstan_folder', cmdstan_path()))
+    # pylint: disable=broad-except
+    except Exception:
+        deps_info.append(('cmdstan', 'NOT FOUND'))
+
+    deps = ['cmdstanpy', 'pandas', 'xarray', 'tdqm', 'numpy', 'ujson']
+    for module in deps:
+        try:
+            if module in sys.modules:
+                mod = sys.modules[module]
+            else:
+                mod = importlib.import_module(module)
+        # pylint: disable=broad-except
+        except Exception:
+            deps_info.append((module, None))
+        else:
+            try:
+                ver = mod.__version__  # type: ignore
+                deps_info.append((module, ver))
+            # pylint: disable=broad-except
+            except Exception:
+                deps_info.append((module, "installed"))
+
+    out = 'INSTALLED VERSIONS\n---------------------\n'
+    for k, info in deps_info:
+        out += f'{k}: {info}\n'
+    if output:
+        print(out)
+        return " "
+    else:
+        return out
+
+
 def install_cmdstan(
     version: Optional[str] = None,
     dir: Optional[str] = None,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -127,12 +127,19 @@ class CmdStanPathTest(unittest.TestCase):
             self.assertEqual(install_version, os.environ['CMDSTAN'])
 
     def test_validate_path(self):
-        cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
-        if not os.path.exists(cmdstan_dir):
-            cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTANPY))
-        install_version = os.path.join(
-            cmdstan_dir, get_latest_cmdstan(cmdstan_dir)
-        )
+        if 'CMDSTAN' in os.environ:
+            install_version = os.environ.get('CMDSTAN')
+        else:
+            cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+            if not os.path.exists(cmdstan_dir):
+                cmdstan_dir = os.path.expanduser(
+                    os.path.join('~', _DOT_CMDSTANPY)
+                )
+
+            install_version = os.path.join(
+                cmdstan_dir, get_latest_cmdstan(cmdstan_dir)
+            )
+
         set_cmdstan_path(install_version)
         validate_cmdstan_path(install_version)
         path_foo = os.path.abspath(os.path.join('releases', 'foo'))


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This closes up a couple tiny issues (seconds in filenames, a show_versions command) and fixes our tests failing if cmdstan isn't installed in ~/.cmdstan[py]

`sample()`, `generate_quantities()` et al now accept a `time_fmt` string which is passed to `RunSet` for the time format of the csv files. It defaults to `"%Y%m%d%H%M%S"`, which is the same as before but with seconds appended.

Output of show_versions is based on what xarray does for it's method of the same name, but it is simpler than their use case. It looks like:

```
INSTALLED VERSIONS
---------------------
python: 3.9.5 | packaged by conda-forge | (default, Jun 19 2021, 00:32:32) 
[GCC 9.3.0]
python-bits: 64
OS: Linux
OS-release: 5.11.0-27-generic
machine: x86_64
processor: x86_64
byteorder: little
LC_ALL: None
LANG: en_US.UTF-8
LOCALE: ('en_US', 'UTF-8')
cmdstan_folder: /home/brian/miniconda3/envs/stan/cmdstan-2.27.0/
cmdstanpy: 0.9.77
pandas: 1.3.1
xarray: 0.18.2
tdqm: None
numpy: 1.21.0
ujson: 4.0.2

```


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

