### PR TITLE
Separate components of install_version function

### DIFF
--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -67,6 +67,11 @@ def usage() -> None:
 
 
 def clean_all(verbose: bool = False) -> None:
+    """
+    Run `make clean-all` in the current directory (must be a cmdstan library).
+
+    :param verbose: when ``True``, print build msgs to stdout.
+    """
     cmd = [MAKE, 'clean-all']
     proc = subprocess.Popen(
         cmd,
@@ -90,6 +95,11 @@ def clean_all(verbose: bool = False) -> None:
 
 
 def build(verbose: bool = False) -> None:
+    """
+    Run `make build` in the current directory (must be a cmdstan library)
+
+    :param verbose: when ``True``, print build msgs to stdout.
+    """
     cmd = [MAKE, 'build']
     proc = subprocess.Popen(
         cmd,
@@ -135,6 +145,7 @@ def build(verbose: bool = False) -> None:
 
 
 def compile_example():
+    """Compile the example model. The current directory must be a cmdstan library."""
     cmd = [
         MAKE,
         Path(

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -33,7 +33,9 @@ from typing import Callable, Dict, Optional
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
 from cmdstanpy.utils import get_logger, pushd, validate_dir, wrap_progress_hook
 
-MAKE = os.getenv("MAKE", "make" if platform.system() != "Windows" else "mingw32-make")
+MAKE = os.getenv(
+    'MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make'
+)
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 
 
@@ -64,8 +66,8 @@ def usage() -> None:
     print(msg)
 
 
-def clear(verbose: bool = False) -> None:
-    cmd = [MAKE, "clean-all"]
+def clean_all(verbose: bool = False) -> None:
+    cmd = [MAKE, 'clean-all']
     proc = subprocess.Popen(
         cmd,
         cwd=None,
@@ -76,19 +78,19 @@ def clear(verbose: bool = False) -> None:
     )
     while proc.poll() is None:
         if proc.stdout:
-            output = proc.stdout.readline().decode("utf-8").strip()
+            output = proc.stdout.readline().decode('utf-8').strip()
             if verbose and output:
                 print(output, flush=True)
     _, stderr = proc.communicate()
     if proc.returncode:
         msgs = ['Command "make clean-all" failed']
         if stderr:
-            msgs.append(stderr.decode("utf-8").strip())
-        raise CmdStanInstallError("\n".join(msgs))
+            msgs.append(stderr.decode('utf-8').strip())
+        raise CmdStanInstallError('\n'.join(msgs))
 
 
 def build(verbose: bool = False) -> None:
-    cmd = [MAKE, "build"]
+    cmd = [MAKE, 'build']
     proc = subprocess.Popen(
         cmd,
         cwd=None,
@@ -99,27 +101,26 @@ def build(verbose: bool = False) -> None:
     )
     while proc.poll() is None:
         if proc.stdout:
-
-            output = proc.stdout.readline().decode("utf-8").strip()
+            output = proc.stdout.readline().decode('utf-8').strip()
             if verbose and output:
                 print(output, flush=True)
     _, stderr = proc.communicate()
     if proc.returncode:
         msgs = ['Command "make build" failed']
         if stderr:
-            msgs.append(stderr.decode("utf-8").strip())
-        raise CmdStanInstallError("\n".join(msgs))
-    if not os.path.exists(os.path.join("bin", "stansummary" + EXTENSION)):
+            msgs.append(stderr.decode('utf-8').strip())
+        raise CmdStanInstallError('\n'.join(msgs))
+    if not os.path.exists(os.path.join('bin', 'stansummary' + EXTENSION)):
         raise CmdStanInstallError(
-            f"bin/stansummary{EXTENSION} not found"
-            ", please rebuild or report a bug!"
+            f'bin/stansummary{EXTENSION} not found'
+            ', please rebuild or report a bug!'
         )
-    if not os.path.exists(os.path.join("bin", "diagnose" + EXTENSION)):
+    if not os.path.exists(os.path.join('bin', 'diagnose' + EXTENSION)):
         raise CmdStanInstallError(
-            f"bin/stansummary{EXTENSION} not found"
-            ", please rebuild or report a bug!"
+            f'bin/stansummary{EXTENSION} not found'
+            ', please rebuild or report a bug!'
         )
-    if platform.system() == "Windows":
+    if platform.system() == 'Windows':
         # Add tbb to the $PATH on Windows
         libtbb = os.path.join(
             os.getcwd(), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
@@ -133,7 +134,7 @@ def build(verbose: bool = False) -> None:
         )
 
 
-def test():
+def compile_example():
     cmd = [
         MAKE,
         Path(
@@ -178,11 +179,11 @@ def install_version(
                 'Overwrite requested, remove existing build of version '
                 '{}'.format(cmdstan_version)
             )
-            clear(verbose)
+            clean_all(verbose)
             print('Rebuilding version {}'.format(cmdstan_version))
         build(verbose)
         print('Test model compilation')
-        test()
+        compile_example()
     print('Installed {}'.format(cmdstan_version))
 
 

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -144,8 +144,11 @@ def build(verbose: bool = False) -> None:
         )
 
 
-def compile_example():
-    """Compile the example model. The current directory must be a cmdstan library."""
+def compile_example() -> None:
+    """
+    Compile the example model.
+    The current directory must be a cmdstan library.
+    """
     cmd = [
         MAKE,
         Path(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

* This PR doesn't change any functionality.
* I think we could split the `clean-all`, `build`, and `test compile` steps of the `install_version` function into different functions. My main use case is to re-use the `clean-all` and `build` steps separately in a packaging pipeline.

Let me know what you think!

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Cuong Duong (me)

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

#### Unit tests

(macOS Big Sur, cmdstan 2.26.1)

I got 4 unit test errors unrelated to these changes (I think). I'll paste them here anyways:

```
GenerateQuantitiesTest.test_save_warmup
>       self.assertEqual(bern_gqs.draws().shape, (100, 4, 10))
...
>               gq_sample[:, chain, :] = np.loadtxt(
                    lines, dtype=np.ndarray, ndmin=2, skiprows=1, delimiter=','
                )
E               ValueError: could not broadcast input array from shape (100,10) into shape (200,10)
cmdstanpy/stanfit.py:1901: ValueError
```

```
CmdStanModelTest.test_model_pedantic
>           log.check_present(('cmdstanpy', 'WARNING', expect))

test/test_model.py:101: 
        expected = SequenceComparison(
            *expected, ordered=order_matters, partial=True, recursive=self.recursive_check
        )
        if expected != actual:
>           raise AssertionError(expected.failed)
E           expected:
E           [('cmdstanpy',
E             'WARNING',
E             'stanc3 has produced warnings:\nWarning: The parameter theta has no priors.')]
E           
E           actual:
E           []
```

```
SampleTest.test_bernoulli_bad
>               bern_model.sample(data=jdata, chains=1, output_dir=path)
E               AssertionError: ValueError not raised

test/test_sample.py:325: AssertionError
------------------------------------------- Captured log call -------------------------------------------
ERROR    cmdstanpy:model.py:1276 Chain 2 processing error, return code 70
```

```
SampleTest.test_fixed_param_unspecified
E               RuntimeError: Error during sampling:
cmdstanpy/model.py:896: RuntimeError
------------------------------------------- Captured log call -------------------------------------------
ERROR    cmdstanpy:model.py:1276 Chain 4 processing error, return code 78
ERROR    cmdstanpy:model.py:1276 Chain 1 processing error, return code 78
ERROR    cmdstanpy:model.py:1276 Chain 2 processing error, return code 78
ERROR    cmdstanpy:model.py:1276 Chain 3 processing error, return code 78
```