### PR TITLE
Add a rebuild_cmdstan function

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -36,6 +36,7 @@ atexit.register(_cleanup_tmpdir)
 
 
 from ._version import __version__  # noqa
+from .install_cmdstan import rebuild_cmdstan
 from .model import CmdStanModel  # noqa
 from .stanfit import (  # noqa
     CmdStanGQ,
@@ -68,4 +69,5 @@ __all__ = [
     'from_csv',
     'write_stan_json',
     'show_versions',
+    'rebuild_cmdstan',
 ]

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -31,7 +31,13 @@ from time import sleep
 from typing import Callable, Dict, Optional
 
 from cmdstanpy import _DOT_CMDSTAN, _DOT_CMDSTANPY
-from cmdstanpy.utils import get_logger, pushd, validate_dir, wrap_progress_hook
+from cmdstanpy.utils import (
+    cmdstan_path,
+    get_logger,
+    pushd,
+    validate_dir,
+    wrap_progress_hook,
+)
 
 MAKE = os.getenv(
     'MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make'
@@ -172,6 +178,21 @@ def compile_example() -> None:
         if stderr:
             msgs.append(stderr.decode('utf-8').strip())
         raise CmdStanInstallError('\n'.join(msgs))
+
+
+def rebuild_cmdstan(verbose: bool = True) -> None:
+    """
+    Rebuilds the existing cmdstan installation
+    """
+    try:
+        with pushd(cmdstan_path()):
+            clean_all(verbose)
+            build(verbose)
+            compile_example()
+    except ValueError as e:
+        raise CmdStanInstallError(
+            "Failed to rebuild CmdStan. Are you sure it is installed?"
+        ) from e
 
 
 def install_version(

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -182,7 +182,13 @@ def compile_example() -> None:
 
 def rebuild_cmdstan(verbose: bool = True) -> None:
     """
-    Rebuilds the existing cmdstan installation
+    Rebuilds the existing CmdStan installation.
+    This assumes CmdStan has already been installed,
+    though it need not be installed via CmdStanPy for
+    this function to work.
+
+    :param verbose:  Boolean value; when ``True``, output from CmdStan build
+        processes will be streamed to the console.  Default is ``False``.
     """
     try:
         with pushd(cmdstan_path()):

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -348,7 +348,7 @@ class CmdStanModel:
                                 "CmdStan's precompiled header (PCH) files "
                                 "may need to be rebuilt."
                                 "If your model failed to compile please run "
-                                "install_cmdstan(overwrite=True).\nIf the "
+                                "cmdstanpy.rebuild_cmdstan().\nIf the "
                                 "issue persists please open a bug report",
                             )
 

--- a/test/test_install_cmdstan.py
+++ b/test/test_install_cmdstan.py
@@ -1,11 +1,14 @@
 """install_cmdstan test"""
 
+import os
 import unittest
 
 from cmdstanpy.install_cmdstan import (
+    CmdStanInstallError,
     CmdStanRetrieveError,
     is_version_available,
     latest_version,
+    rebuild_cmdstan,
     retrieve_version,
 )
 
@@ -33,6 +36,13 @@ class InstallCmdStanTest(unittest.TestCase):
             retrieve_version(None)
         with self.assertRaises(ValueError):
             retrieve_version('')
+
+    @unittest.mock.patch.dict(os.environ, {"CMDSTAN": "~/some/fake/path"})
+    def test_rebuild_bad_path(self):
+        with self.assertRaisesRegex(
+            CmdStanInstallError, "you sure it is installed"
+        ):
+            rebuild_cmdstan()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This adds a `rebuild_cmdstan` function which goes to the current cmdstan_path and runs make clean and make build using the functions from #451. In theory this should be even better than `install_cmdstan(overwrite=True)` because it allows you to rebuild cmdstan even if it was installed manually or via conda, so long as `cmdstan_path()` can find it.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

