### PR TITLE
Allow user to supply a c++ header file

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -68,6 +68,10 @@ class CmdStanModel:
     :param cpp_options: Options for C++ compiler, specified as a Python
         dictionary containing C++ compiler option name, value pairs.
         Optional.
+
+    :param user_header: A path to a header file to include during C++
+        compilation.
+        Optional.
     """
 
     def __init__(
@@ -78,6 +82,7 @@ class CmdStanModel:
         compile: bool = True,
         stanc_options: Optional[Dict[str, Any]] = None,
         cpp_options: Optional[Dict[str, Any]] = None,
+        user_header: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         """
@@ -89,12 +94,16 @@ class CmdStanModel:
         :param compile: Whether or not to compile the model.
         :param stanc_options: Options for stanc compiler.
         :param cpp_options: Options for C++ compiler.
+        :param user_header: A path to a header file to include during C++
+            compilation.
         """
         self._name = ''
         self._stan_file = None
         self._exe_file = None
         self._compiler_options = CompilerOptions(
-            stanc_options=stanc_options, cpp_options=cpp_options
+            stanc_options=stanc_options,
+            cpp_options=cpp_options,
+            user_header=user_header,
         )
         if logger is not None:
             get_logger().warning(
@@ -227,6 +236,11 @@ class CmdStanModel:
         """Options to C++ compilers."""
         return self._compiler_options._cpp_options
 
+    @property
+    def user_header(self) -> str:
+        """The user header file if it exists, otherwise empty"""
+        return self._compiler_options._user_header
+
     def code(self) -> Optional[str]:
         """Return Stan program as a string."""
         if not self._stan_file:
@@ -247,6 +261,7 @@ class CmdStanModel:
         force: bool = False,
         stanc_options: Optional[Dict[str, Any]] = None,
         cpp_options: Optional[Dict[str, Any]] = None,
+        user_header: Optional[str] = None,
         override_options: bool = False,
     ) -> None:
         """
@@ -264,6 +279,8 @@ class CmdStanModel:
 
         :param stanc_options: Options for stanc compiler.
         :param cpp_options: Options for C++ compiler.
+        :param user_header: A path to a header file to include during C++
+            compilation.
 
         :param override_options: When ``True``, override existing option.
             When ``False``, add/replace existing options.  Default is ``False``.
@@ -272,9 +289,15 @@ class CmdStanModel:
             raise RuntimeError('Please specify source file')
 
         compiler_options = None
-        if not (stanc_options is None and cpp_options is None):
+        if not (
+            stanc_options is None
+            and cpp_options is None
+            and user_header is None
+        ):
             compiler_options = CompilerOptions(
-                stanc_options=stanc_options, cpp_options=cpp_options
+                stanc_options=stanc_options,
+                cpp_options=cpp_options,
+                user_header=user_header,
             )
             compiler_options.validate()
             if self._compiler_options is None:

--- a/docsrc/examples.rst
+++ b/docsrc/examples.rst
@@ -8,3 +8,4 @@ __________________
     examples/Maximum Likelihood Estimation.ipynb
     examples/Variational Inference.ipynb
     examples/Run Generated Quantities.ipynb
+    examples/Using External C++.ipynb

--- a/docsrc/examples/.gitignore
+++ b/docsrc/examples/.gitignore
@@ -8,3 +8,4 @@
 *.exe
 *.csv
 .ipynb_checkpoints
+!make_odds.hpp

--- a/docsrc/examples/Using External C++.ipynb
+++ b/docsrc/examples/Using External C++.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Advanced Topic: Using External C++ Functions\n",
+    "\n",
+    "This is based on the relevant portion of the CmdStan documentation [here](https://mc-stan.org/docs/cmdstan-guide/using-external-cpp-code.html)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Consider the following Stan model, based on the bernoulli example."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "import os\n",
+    "from cmdstanpy import cmdstan_path, CmdStanModel\n",
+    "model_external = CmdStanModel(stan_file='bernoulli_external.stan', compile=False)\n",
+    "print(model_external.code())"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "As you can see, it features a function declaration for `make_odds`, but no definition. If we try to compile this, we will get an error. "
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "model_external.compile()"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Even enabling the `--allow_undefined` flag to stanc3 will not allow this model to be compiled quite yet."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "model_external.compile(stanc_options={'allow_undefined':True})"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To resolve this, we need to both tell the Stan compiler an undefined function is okay **and** let C++ know what it should be. \n",
+    "\n",
+    "We can provide a definition in a C++ header file by using the `user_header` argument to either the CmdStanModel constructor or the `compile` method. \n",
+    "\n",
+    "This will enables the `allow_undefined` flag automatically."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "model_external.compile(user_header='make_odds.hpp')"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can then run this model and inspect the output"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "fit = model_external.sample(data={'N':10, 'y':[0,1,0,0,0,0,0,0,0,1]})\n",
+    "fit.stan_variable('odds')"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The contents of this header file are a bit complicated unless you are familiar with the C++ internals of Stan, so they are presented without comment:\n",
+    "\n",
+    "```c++\n",
+    "#include <boost/math/tools/promotion.hpp>\n",
+    "#include <ostream>\n",
+    "\n",
+    "namespace bernoulli_model_namespace {\n",
+    "    template <typename T0__>  inline  typename\n",
+    "          boost::math::tools::promote_args<T0__>::type  \n",
+    "          make_odds(const T0__& theta, std::ostream* pstream__) {\n",
+    "            return theta / (1 - theta);  \n",
+    "       }\n",
+    "}\n",
+    "```"
+   ],
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "orig_nbformat": 4,
+  "language_info": {
+   "name": "python",
+   "version": "3.9.5",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.9.5 64-bit ('stan': conda)"
+  },
+  "interpreter": {
+   "hash": "d31ce8e45781476cfd394e192e0962028add96ff436d4fd4e560a347d206b9cb"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docsrc/examples/bernoulli_external.stan
+++ b/docsrc/examples/bernoulli_external.stan
@@ -1,0 +1,18 @@
+functions {
+  real make_odds(real theta);
+}
+data {
+  int<lower=0> N;
+  array[N] int<lower=0, upper=1> y;
+}
+parameters {
+  real<lower=0, upper=1> theta;
+}
+model {
+  theta ~ beta(1, 1); // uniform prior on interval 0, 1
+  y ~ bernoulli(theta);
+}
+generated quantities {
+  real odds;
+  odds = make_odds(theta);
+}

--- a/docsrc/examples/make_odds.hpp
+++ b/docsrc/examples/make_odds.hpp
@@ -1,0 +1,13 @@
+#include <boost/math/tools/promotion.hpp>
+#include <ostream>
+
+namespace bernoulli_external_model_namespace
+{
+    template <typename T0__>
+    inline typename boost::math::tools::promote_args<T0__>::type make_odds(const T0__ &
+                                                                               theta,
+                                                                           std::ostream *pstream__)
+    {
+        return theta / (1 - theta);
+    }
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,19 @@
+"""The global configuration for the test suite"""
+import os
+import subprocess
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DATAFILES_PATH = os.path.join(HERE, 'data')
+
+
+# after we have run all tests, use git to delete the built files in data/
+@pytest.fixture(scope='session', autouse=True)
+def cleanup_test_files():
+    yield
+    subprocess.Popen(
+        ['git', 'clean', '-fX', DATAFILES_PATH],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )

--- a/test/data/.gitignore
+++ b/test/data/.gitignore
@@ -6,3 +6,4 @@
 # and we re-ignore hpp and exe files
 *.hpp
 *.exe
+!return_one.hpp

--- a/test/data/external.stan
+++ b/test/data/external.stan
@@ -1,0 +1,7 @@
+functions {
+   real return_one();
+}
+
+generated quantities {
+   real one = return_one();
+}

--- a/test/data/return_one.hpp
+++ b/test/data/return_one.hpp
@@ -1,0 +1,9 @@
+#include <ostream>
+namespace external_model_namespace
+{
+    double return_one(
+        std::ostream *pstream__)
+    {
+        return 1.0;
+    }
+}

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -14,7 +14,9 @@ class CompilerOptsTest(unittest.TestCase):
         opts = CompilerOptions()
         opts.validate()
         self.assertEqual(opts.compose(), [])
-        self.assertEqual(opts.__repr__(), 'stanc_options={}, cpp_options={}')
+        self.assertEqual(
+            opts.__repr__(), 'stanc_options={}, cpp_options={}, user_header='
+        )
 
         stanc_opts = {}
         opts = CompilerOptions(stanc_options=stanc_opts)
@@ -29,7 +31,9 @@ class CompilerOptsTest(unittest.TestCase):
         opts = CompilerOptions(stanc_options=stanc_opts, cpp_options=cpp_opts)
         opts.validate()
         self.assertEqual(opts.compose(), [])
-        self.assertEqual(opts.__repr__(), 'stanc_options={}, cpp_options={}')
+        self.assertEqual(
+            opts.__repr__(), 'stanc_options={}, cpp_options={}, user_header='
+        )
 
     def test_opts_stanc(self):
         stanc_opts = {}
@@ -149,6 +153,27 @@ class CompilerOptsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             opts.validate()
 
+    def test_user_header(self):
+        header_file = os.path.join(DATAFILES_PATH, 'return_one.hpp')
+        opts = CompilerOptions(user_header=header_file)
+        opts.validate()
+        self.assertTrue(opts.stanc_options['allow_undefined'])
+
+        bad = os.path.join(DATAFILES_PATH, 'nonexistant.hpp')
+        opts = CompilerOptions(user_header=bad)
+        with self.assertRaisesRegex(ValueError, "cannot be found"):
+            opts.validate()
+
+        bad_dir = os.path.join(DATAFILES_PATH, 'optimize')
+        opts = CompilerOptions(user_header=bad_dir)
+        with self.assertRaisesRegex(ValueError, "cannot be found"):
+            opts.validate()
+
+        non_header = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
+        opts = CompilerOptions(user_header=non_header)
+        with self.assertRaisesRegex(ValueError, "must end in .hpp"):
+            opts.validate()
+
     def test_opts_add(self):
         stanc_opts = {'warn-uninitialized': True}
         cpp_opts = {'STAN_OPENCL': 'TRUE', 'OPENCL_DEVICE_ID': 1}
@@ -183,6 +208,12 @@ class CompilerOptsTest(unittest.TestCase):
         opts.add(new_opts3)
         opts_list = opts.compose()
         self.assertTrue(expect in opts_list)
+
+        header_file = os.path.join(DATAFILES_PATH, 'return_one.hpp')
+        opts = CompilerOptions()
+        opts.add(CompilerOptions(user_header=header_file))
+        opts_list = opts.compose()
+        self.assertTrue(len(opts_list) == 1)
 
 
 if __name__ == '__main__':

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -44,11 +44,15 @@ class CmdStanModelTest(unittest.TestCase):
         for root, _, files in os.walk(DATAFILES_PATH):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
-                    filename != ".gitignore"
+                if (
+                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
+                    and filename != ".gitignore"
+                    and filename != "return_one.hpp"
                 ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
+                    # we should really make this module-level
+                    # and use something like git clean -Xf data/
 
     def show_cmdstan_version(self):
         print('\n\nCmdStan version: {}\n\n'.format(cmdstan_path()))
@@ -60,6 +64,12 @@ class CmdStanModelTest(unittest.TestCase):
         self.assertEqual(BERN_STAN, model.stan_file)
         self.assertTrue(model.exe_file.endswith(BERN_EXE.replace('\\', '/')))
         self.assertEqual('bern', model.name)
+
+        # compile with external header
+        model = CmdStanModel(
+            stan_file=os.path.join(DATAFILES_PATH, "external.stan"),
+            user_header=os.path.join(DATAFILES_PATH, 'return_one.hpp'),
+        )
 
         # default model name
         model = CmdStanModel(stan_file=BERN_STAN)
@@ -109,6 +119,10 @@ class CmdStanModelTest(unittest.TestCase):
             CmdStanModel(model_name='', stan_file=BERN_STAN)
         with self.assertRaises(ValueError):
             CmdStanModel(model_name='   ', stan_file=BERN_STAN)
+        with self.assertRaises(ValueError):
+            CmdStanModel(
+                stan_file=os.path.join(DATAFILES_PATH, "external.stan")
+            )
 
     def test_stanc_options(self):
         opts = {

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -8,7 +8,6 @@ import unittest
 from unittest.mock import Mock
 
 import numpy as np
-import pytest
 import tqdm
 from testfixtures import LogCapture
 
@@ -37,23 +36,6 @@ BERN_BASENAME = 'bernoulli'
 
 
 class CmdStanModelTest(unittest.TestCase):
-
-    # pylint: disable=no-self-use
-    @pytest.fixture(scope='class', autouse=True)
-    def do_clean_up(self):
-        for root, _, files in os.walk(DATAFILES_PATH):
-            for filename in files:
-                _, ext = os.path.splitext(filename)
-                if (
-                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
-                    and filename != ".gitignore"
-                    and filename != "return_one.hpp"
-                ):
-                    filepath = os.path.join(root, filename)
-                    os.remove(filepath)
-                    # we should really make this module-level
-                    # and use something like git clean -Xf data/
-
     def show_cmdstan_version(self):
         print('\n\nCmdStan version: {}\n\n'.format(cmdstan_path()))
         self.assertTrue(True)
@@ -94,6 +76,7 @@ class CmdStanModelTest(unittest.TestCase):
         self.assertEqual(BERN_STAN, model.stan_file)
         self.assertEqual(None, model.exe_file)
 
+    # pylint: disable=no-self-use
     def test_model_pedantic(self):
         with LogCapture() as log:
             logging.getLogger()

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -5,7 +5,6 @@ import os
 import unittest
 
 import numpy as np
-import pytest
 from testfixtures import LogCapture
 
 from cmdstanpy.cmdstan_args import CmdStanArgs, OptimizeArgs
@@ -18,21 +17,6 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 
 
 class CmdStanMLETest(unittest.TestCase):
-
-    # pylint: disable=no-self-use
-    @pytest.fixture(scope='class', autouse=True)
-    def do_clean_up(self):
-        for root, _, files in os.walk(DATAFILES_PATH):
-            for filename in files:
-                _, ext = os.path.splitext(filename)
-                if (
-                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
-                    and filename != ".gitignore"
-                    and filename != "return_one.hpp"
-                ):
-                    filepath = os.path.join(root, filename)
-                    os.remove(filepath)
-
     def test_instantiate(self):
         stan = os.path.join(DATAFILES_PATH, 'optimize', 'rosenbrock.stan')
         model = CmdStanModel(stan_file=stan)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -25,8 +25,10 @@ class CmdStanMLETest(unittest.TestCase):
         for root, _, files in os.walk(DATAFILES_PATH):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
-                    filename != ".gitignore"
+                if (
+                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
+                    and filename != ".gitignore"
+                    and filename != "return_one.hpp"
                 ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -13,7 +13,6 @@ from multiprocessing import cpu_count
 from time import time
 
 import numpy as np
-import pytest
 from testfixtures import LogCapture
 
 try:
@@ -56,21 +55,6 @@ def without_import(library, module):
 
 
 class SampleTest(unittest.TestCase):
-
-    # pylint: disable=no-self-use
-    @pytest.fixture(scope='class', autouse=True)
-    def do_clean_up(self):
-        for root, _, files in os.walk(DATAFILES_PATH):
-            for filename in files:
-                _, ext = os.path.splitext(filename)
-                if (
-                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
-                    and filename != ".gitignore"
-                    and filename != "return_one.hpp"
-                ):
-                    filepath = os.path.join(root, filename)
-                    os.remove(filepath)
-
     def test_bernoulli_good(self, stanfile='bernoulli.stan'):
         stan = os.path.join(DATAFILES_PATH, stanfile)
         bern_model = CmdStanModel(stan_file=stan)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -63,8 +63,10 @@ class SampleTest(unittest.TestCase):
         for root, _, files in os.walk(DATAFILES_PATH):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
-                    filename != ".gitignore"
+                if (
+                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
+                    and filename != ".gitignore"
+                    and filename != "return_one.hpp"
                 ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -4,7 +4,6 @@ import os
 import unittest
 from math import fabs
 
-import pytest
 from testfixtures import LogCapture
 
 from cmdstanpy.cmdstan_args import CmdStanArgs, VariationalArgs
@@ -16,23 +15,6 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 
 
 class CmdStanVBTest(unittest.TestCase):
-
-    # pylint: disable=no-self-use
-    @pytest.fixture(scope='class', autouse=True)
-    def do_clean_up(self):
-        for root, _, files in os.walk(
-            os.path.join(DATAFILES_PATH, 'variational')
-        ):
-            for filename in files:
-                _, ext = os.path.splitext(filename)
-                if (
-                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
-                    and filename != ".gitignore"
-                    and filename != "return_one.hpp"
-                ):
-                    filepath = os.path.join(root, filename)
-                    os.remove(filepath)
-
     def test_instantiate(self):
         stan = os.path.join(
             DATAFILES_PATH, 'variational', 'eta_should_be_big.stan'
@@ -155,23 +137,6 @@ class CmdStanVBTest(unittest.TestCase):
 
 
 class VariationalTest(unittest.TestCase):
-
-    # pylint: disable=no-self-use
-    @pytest.fixture(scope='class', autouse=True)
-    def do_clean_up(self):
-        for root, _, files in os.walk(
-            os.path.join(DATAFILES_PATH, 'variational')
-        ):
-            for filename in files:
-                _, ext = os.path.splitext(filename)
-                if (
-                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
-                    and filename != ".gitignore"
-                    and filename != "return_one.hpp"
-                ):
-                    filepath = os.path.join(root, filename)
-                    os.remove(filepath)
-
     def test_variational_good(self):
         stan = os.path.join(
             DATAFILES_PATH, 'variational', 'eta_should_be_big.stan'

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -25,8 +25,10 @@ class CmdStanVBTest(unittest.TestCase):
         ):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
-                    filename != ".gitignore"
+                if (
+                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
+                    and filename != ".gitignore"
+                    and filename != "return_one.hpp"
                 ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)
@@ -162,8 +164,10 @@ class VariationalTest(unittest.TestCase):
         ):
             for filename in files:
                 _, ext = os.path.splitext(filename)
-                if ext.lower() in ('.o', '.d', '.hpp', '.exe', '') and (
-                    filename != ".gitignore"
+                if (
+                    ext.lower() in ('.o', '.d', '.hpp', '.exe', '')
+                    and filename != ".gitignore"
+                    and filename != "return_one.hpp"
                 ):
                     filepath = os.path.join(root, filename)
                     os.remove(filepath)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds the ability to specify a .hpp file for external function definitions. Closes #463.

This requires storing some .hpp files in the test data, which overcomplicated the removal routine. I've switched to a global fixture which uses `git clean -Xf data/` to remove all files in the git ignore in the test/data folder. This is only run once per session at the moment, at the end of all testing. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

