### PR TITLE
Serialize inf/nan to json

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -412,6 +412,7 @@ def cxx_toolchain_path(
 def rewrite_inf_nan(
     data: Union[float, int, List[Any]]
 ) -> Union[str, int, float, List[Any]]:
+    """Replaces NaN and Infinity with string representations"""
     if isinstance(data, float):
         if math.isnan(data):
             return 'NaN'
@@ -442,9 +443,6 @@ def write_stan_json(path: str, data: Mapping[str, Any]) -> None:
     :param data: A mapping from strings to values. This can be a dictionary
         or something more exotic like an :class:`xarray.Dataset`. This will be
         copied before type conversion, not modified
-
-    :param handle_nan_inf: If enabled, perform the (Slow!) checks necessary to
-        output NaN and inf as required for Stan
     """
     data_out = {}
     for key, val in data.items():

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -409,6 +409,21 @@ def cxx_toolchain_path(
     return compiler_path, tool_path
 
 
+def rewrite_inf_nan(
+    data: Union[float, int, List[Any]]
+) -> Union[str, int, float, List[Any]]:
+    if isinstance(data, float):
+        if math.isnan(data):
+            return 'NaN'
+        if math.isinf(data):
+            return ('+' if data > 0 else '-') + 'inf'
+        return data
+    elif isinstance(data, list):
+        return [rewrite_inf_nan(item) for item in data]
+    else:
+        return data
+
+
 def write_stan_json(path: str, data: Mapping[str, Any]) -> None:
     """
     Dump a mapping of strings to data to a JSON file.
@@ -427,9 +442,13 @@ def write_stan_json(path: str, data: Mapping[str, Any]) -> None:
     :param data: A mapping from strings to values. This can be a dictionary
         or something more exotic like an :class:`xarray.Dataset`. This will be
         copied before type conversion, not modified
+
+    :param handle_nan_inf: If enabled, perform the (Slow!) checks necessary to
+        output NaN and inf as required for Stan
     """
     data_out = {}
     for key, val in data.items():
+        handle_nan_inf = False
         if val is not None:
             if isinstance(val, (str, bytes)) or (
                 type(val).__module__ != 'numpy'
@@ -440,18 +459,14 @@ def write_stan_json(path: str, data: Mapping[str, Any]) -> None:
                     + f"write_stan_json for key '{key}'"
                 )
             try:
-                if not np.all(np.isfinite(val)):
-                    raise ValueError(
-                        "Input to write_stan_json has nan or infinite "
-                        + f"values for key '{key}'"
-                    )
+                handle_nan_inf = not np.all(np.isfinite(val))
             except TypeError:
                 # handles cases like val == ['hello']
                 # pylint: disable=raise-missing-from
                 raise ValueError(
                     "Invalid type provided to "
-                    + f"write_stan_json for key '{key}' "
-                    + f"as part of collection {type(val)}"
+                    f"write_stan_json for key '{key}' "
+                    f"as part of collection {type(val)}"
                 )
 
         if type(val).__module__ == 'numpy':
@@ -462,6 +477,9 @@ def write_stan_json(path: str, data: Mapping[str, Any]) -> None:
             data_out[key] = int(val)
         else:
             data_out[key] = val
+
+        if handle_nan_inf:
+            data_out[key] = rewrite_inf_nan(data_out[key])
 
     with open(path, 'w') as fd:
         json.dump(data_out, fd)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -339,11 +339,21 @@ class DataFilesTest(unittest.TestCase):
             cmp(json.load(fd), dict_scalr)
 
         # custom Stan serialization
-
         dict_inf_nan = {
-            'a': np.array([[-np.inf, np.inf, np.NaN, float('NaN')]])
+            'a': np.array(
+                [
+                    [-np.inf, np.inf, np.NaN],
+                    [-float('inf'), float('inf'), float('NaN')],
+                    [
+                        np.float32(-np.inf),
+                        np.float32(np.inf),
+                        np.float32(np.NaN),
+                    ],
+                    [1e200 * -1e200, 1e220 * 1e200, -np.nan],
+                ]
+            )
         }
-        dict_inf_nan_exp = {'a': np.array([["-inf", "+inf", "NaN", "NaN"]])}
+        dict_inf_nan_exp = {'a': [["-inf", "+inf", "NaN"]] * 4}
         file_fin = os.path.join(_TMPDIR, 'inf.json')
         write_stan_json(file_fin, dict_inf_nan)
         with open(file_fin) as fd:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -338,6 +338,17 @@ class DataFilesTest(unittest.TestCase):
         with open(file_scalr) as fd:
             cmp(json.load(fd), dict_scalr)
 
+        # custom Stan serialization
+
+        dict_inf_nan = {
+            'a': np.array([[-np.inf, np.inf, np.NaN, float('NaN')]])
+        }
+        dict_inf_nan_exp = {'a': np.array([["-inf", "+inf", "NaN", "NaN"]])}
+        file_fin = os.path.join(_TMPDIR, 'inf.json')
+        write_stan_json(file_fin, dict_inf_nan)
+        with open(file_fin) as fd:
+            cmp(json.load(fd), dict_inf_nan_exp)
+
     def test_write_stan_json_bad(self):
         file_bad = os.path.join(_TMPDIR, 'bad.json')
 
@@ -348,14 +359,6 @@ class DataFilesTest(unittest.TestCase):
         dict_badtype_nested = {'a': ['a string']}
         with self.assertRaises(ValueError):
             write_stan_json(file_bad, dict_badtype_nested)
-
-        dict_inf = {'a': [np.inf]}
-        with self.assertRaises(ValueError):
-            write_stan_json(file_bad, dict_inf)
-
-        dict_nan = {'a': np.nan}
-        with self.assertRaises(ValueError):
-            write_stan_json(file_bad, dict_nan)
 
 
 class ReadStanCsvTest(unittest.TestCase):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This changes `write_stan_json` to turn `Nan` into `"NaN"`, `inf` to `"+inf"`, and `-inf` to `"-inf"` as CmdStan expects. It only calls this as necessary, so it shouldn't be too much less efficient than the prior check which threw an error in these cases.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

