### PR TITLE
Update workflow to allow manual runs on different CmdStan versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,7 @@ jobs:
         run: |
             if [[ "${{ github.event.inputs.cmdstan-version }}" == "latest" ]]; then
               echo "::set-output name=version::$(python -c 'import requests;print(requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])')"
-            fi
-            if [[ "${{ github.event.inputs.cmdstan-version }}" != "latest" ]]; then
+            else [[ "${{ github.event.inputs.cmdstan-version }}" != "latest" ]]; then
               echo "::set-output name=version::${{ github.event.inputs.cmdstan-version }}"
             fi
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
         id: check-cmdstan
         run: |
             if [[ "${{ github.event.inputs.cmdstan-version }}" == "latest" ]]; then
-              echo "::set-output name=version::$(python -c 'import requests;print(requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])')"
-            else [[ "${{ github.event.inputs.cmdstan-version }}" != "latest" ]]; then
               echo "::set-output name=version::${{ github.event.inputs.cmdstan-version }}"
+            else
+                echo "::set-output name=version::$(python -c 'import requests;print(requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])')"
             fi
     outputs:
       version: ${{ steps.check-cmdstan.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CmdStanPy
-
+    
 on:
   push:
     branches:
@@ -8,6 +8,13 @@ on:
     tags:
       - '**'
   pull_request:
+  workflow_dispatch:
+    inputs:
+      cmdstan-version:
+        description: 'Version to test'
+        required: false
+        default: 'latest'
+      
 jobs:
   get-cmdstan-version:
     # get the latest cmdstan version to use as part of the cache key
@@ -17,7 +24,12 @@ jobs:
       - name: Get CmdStan version
         id: check-cmdstan
         run: |
-          echo "::set-output name=version::$(python -c 'import requests;print(requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])')"
+            if [[ "${{ github.event.inputs.cmdstan-version }}" == "latest" ]]; then
+              echo "::set-output name=version::$(python -c 'import requests;print(requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])')"
+            fi
+            if [[ "${{ github.event.inputs.cmdstan-version }}" != "latest" ]]; then
+              echo "::set-output name=version::${{ github.event.inputs.cmdstan-version }}"
+            fi
     outputs:
       version: ${{ steps.check-cmdstan.outputs.version }}
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This edits our main workflow to allow you to run it manually and specify a cmdstan version. Hopefully it is useful for things like https://github.com/stan-dev/cmdstan/issues/1061

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

