### PR TITLE
speed up _assemble_generated_quantities

### DIFF
--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -1222,7 +1222,7 @@ class CmdStanGQ:
         return result
 
     def _assemble_generated_quantities(self) -> None:
-        # use numpy loadtxt
+        # use pandas read_csv
         warmup = self.mcmc_sample.metadata.cmdstan_config['save_warmup']
         num_draws = self.mcmc_sample.draws(inc_warmup=warmup).shape[0]
         gq_sample: np.ndarray = np.empty(
@@ -1231,11 +1231,9 @@ class CmdStanGQ:
             order='F',
         )
         for chain in range(self.chains):
-            with open(self.runset.csv_files[chain], 'r') as fd:
-                lines = (line for line in fd if not line.startswith('#'))
-                gq_sample[:, chain, :] = np.loadtxt(
-                    lines, dtype=np.ndarray, ndmin=2, skiprows=1, delimiter=','
-                )
+            gq_sample[:, chain, :] = pd.read_csv(
+                self.runset.csv_files[chain], sep=',', comment='#', header=0,
+            ).values
         self._draws = gq_sample
 
     def save_csvfiles(self, dir: Optional[str] = None) -> None:


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
```python
import numpy as np
import pandas as pd

def new(f):
    return pd.read_csv(
        f,
        sep=',',
        comment='#',
        header=0,
    ).values

# current implementation
def current(f):
    with open(f, 'r') as fd:
        lines = (line for line in fd if not line.startswith('#'))
        return  np.loadtxt(
            lines, dtype=np.ndarray, ndmin=2, skiprows=1, delimiter=','
        )
```

Runtime comparison for different file sizes on my laptop measured by ipython's `%timeit`:

|        | 49KB    | 2.2MB   | 66MB    | 132MB   |
|--------|---------|---------|---------|---------|
|new | 1.56 ms | 26.7 ms | 632 ms  | 1250 ms |
|current | 5.03 ms | 204 ms  | 2030 ms | 4190 ms |

The 49KB file is the one generated by the bernoulli experiment in the cmdstan repository.

Adding the parameters `quoting=3` or `low_memory=False` to `read_csv` did not improve the performance of `new`.

One difference between the two versions is, that for a file with zero samples `new` returns an array of shape `(0,num_columns)` while `current` returns an array of shape `(0,1)` and prints a `UserWarning: loadtxt: Empty input file`.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): University of Stuttgart

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)