### PR TITLE
Add write_stan_file function (fixes #513).

### DIFF
--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -55,6 +55,7 @@ from .utils import (
     set_make_env,
     show_versions,
     write_stan_json,
+    write_stan_file,
 )
 
 __all__ = [
@@ -73,4 +74,5 @@ __all__ = [
     'show_versions',
     'rebuild_cmdstan',
     'cmdstan_version',
+    'write_stan_file',
 ]

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1445,11 +1445,9 @@ def write_stan_file(code: str, directory: Union[str, None] = None) -> str:
     :return: Path to the file containing the code..
     """
     # Generate the path based on the code and check whether it already exists.
-    directory = os.path.abspath(
-        directory or os.path.join(tempfile.gettempdir(), 'cmdstanpy_models')
-    )
+    directory = os.path.abspath(directory or _TMPDIR)
     digest = hashlib.sha1(code.encode()).hexdigest()
-    stan_file = os.path.join(directory, f'{digest}.stan')
+    stan_file = os.path.join(directory, f'model_{digest}.stan')
     if os.path.isfile(stan_file):
         return stan_file
 

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1445,7 +1445,9 @@ def write_stan_file(code: str, directory: Union[str, None] = None) -> str:
     :return: Path to the file containing the code..
     """
     # Generate the path based on the code and check whether it already exists.
-    directory = directory or os.path.join(cmdstan_path(), 'models')
+    directory = os.path.abspath(
+        directory or os.path.join(tempfile.gettempdir(), 'cmdstanpy_models')
+    )
     digest = hashlib.sha1(code.encode()).hexdigest()
     stan_file = os.path.join(directory, f'{digest}.stan')
     if os.path.isfile(stan_file):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -884,8 +884,7 @@ class WriteStanFileTest(unittest.TestCase):
     def test_write_stan_file_default_dir(self):
         with mock.patch('builtins.open') as stream:
             actual_path = write_stan_file(self.CODE)
-            expected_suffix = os.path.join('cmdstanpy_models',
-                                           f'{self.HASH}.stan')
+            expected_suffix = f'model_{self.HASH}.stan'
             assert actual_path.endswith(expected_suffix)
             stream.assert_called_once_with(actual_path, 'w')
 
@@ -893,10 +892,9 @@ class WriteStanFileTest(unittest.TestCase):
         directory = 'other'
         with mock.patch('builtins.open') as stream:
             actual_path = write_stan_file(self.CODE, directory)
-            expected_path = os.path.abspath(os.path.join(directory,
-                                                         f'{self.HASH}.stan'))
-            assert actual_path == expected_path
-            stream.assert_called_once_with(expected_path, 'w')
+            expected_suffix = os.path.join(directory, f'model_{self.HASH}.stan')
+            assert actual_path.endswith(expected_suffix)
+            stream.assert_called_once_with(actual_path, 'w')
 
     def test_write_stan_file_already_exists(self):
         directory = 'other'
@@ -904,7 +902,7 @@ class WriteStanFileTest(unittest.TestCase):
                 mock.patch('os.path.isfile') as isfile:
             isfile.return_value = True
             actual_path = write_stan_file(self.CODE, directory)
-            expected_suffix = os.path.join(directory, f'{self.HASH}.stan')
+            expected_suffix = os.path.join(directory, f'model_{self.HASH}.stan')
             assert actual_path.endswith(expected_suffix)
             isfile.assert_called_once_with(actual_path)
             stream.assert_not_called()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -884,16 +884,17 @@ class WriteStanFileTest(unittest.TestCase):
     def test_write_stan_file_default_dir(self):
         with mock.patch('builtins.open') as stream:
             actual_path = write_stan_file(self.CODE)
-            expected_path = os.path.join(cmdstan_path(), 'models',
-                                         f'{self.HASH}.stan')
-            assert actual_path == expected_path
-            stream.assert_called_once_with(expected_path, 'w')
+            expected_suffix = os.path.join('cmdstanpy_models',
+                                           f'{self.HASH}.stan')
+            assert actual_path.endswith(expected_suffix)
+            stream.assert_called_once_with(actual_path, 'w')
 
     def test_write_stan_file_other_dir(self):
         directory = 'other'
         with mock.patch('builtins.open') as stream:
             actual_path = write_stan_file(self.CODE, directory)
-            expected_path = os.path.join(directory, f'{self.HASH}.stan')
+            expected_path = os.path.abspath(os.path.join(directory,
+                                                         f'{self.HASH}.stan'))
             assert actual_path == expected_path
             stream.assert_called_once_with(expected_path, 'w')
 
@@ -903,8 +904,8 @@ class WriteStanFileTest(unittest.TestCase):
                 mock.patch('os.path.isfile') as isfile:
             isfile.return_value = True
             actual_path = write_stan_file(self.CODE, directory)
-            expected_path = os.path.join(directory, f'{self.HASH}.stan')
-            assert actual_path == expected_path
+            expected_suffix = os.path.join(directory, f'{self.HASH}.stan')
+            assert actual_path.endswith(expected_suffix)
             isfile.assert_called_once_with(actual_path)
             stream.assert_not_called()
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds a `write_stan_file` function as discussed in #513 together with unit tests.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Harvard University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

