### PR TITLE
Add include paths to src_info, update stanc3 argument handling

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -152,13 +152,9 @@ class CmdStanModel:
                 program = fd.read()
             if '#include' in program:
                 path, _ = os.path.split(self._stan_file)
-                if self._compiler_options is None:
-                    self._compiler_options = CompilerOptions(
-                        stanc_options={'include_paths': [path]}
-                    )
-                elif self._compiler_options._stanc_options is None:
+                if self._compiler_options._stanc_options is None:
                     self._compiler_options._stanc_options = {
-                        'include_paths': [path]
+                        'include-paths': [path]
                     }
                 else:
                     self._compiler_options.add_include_path(path)
@@ -279,9 +275,18 @@ class CmdStanModel:
         if self.stan_file is None:
             return result
         try:
-
+            includes = ''
+            if (
+                self.stanc_options is not None
+                and 'include-paths' in self.stanc_options
+            ):
+                includes = '--include-paths=' + ','.join(
+                    Path(p).as_posix()
+                    for p in self.stanc_options['include-paths']  # type: ignore
+                )
             cmd = [
                 os.path.join('.', 'bin', 'stanc' + EXTENSION),
+                includes,
                 '--info',
                 self.stan_file,
             ]

--- a/docsrc/examples/Using External C++.ipynb
+++ b/docsrc/examples/Using External C++.ipynb
@@ -60,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Even enabling the `--allow_undefined` flag to stanc3 will not allow this model to be compiled quite yet."
+    "Even enabling the `--allow-undefined` flag to stanc3 will not allow this model to be compiled quite yet."
    ]
   },
   {
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_external.compile(stanc_options={'allow_undefined':True})"
+    "model_external.compile(stanc_options={'allow-undefined':True})"
    ]
   },
   {
@@ -80,7 +80,7 @@
     "\n",
     "We can provide a definition in a C++ header file by using the `user_header` argument to either the CmdStanModel constructor or the `compile` method. \n",
     "\n",
-    "This will enables the `allow_undefined` flag automatically."
+    "This will enables the `allow-undefined` flag automatically."
    ]
   },
   {

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -3,6 +3,8 @@
 import os
 import unittest
 
+from testfixtures import LogCapture
+
 from cmdstanpy.compiler_opts import CompilerOptions
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -70,6 +72,28 @@ class CompilerOptsTest(unittest.TestCase):
             ['STANCFLAGS+=--warn-uninitialized', 'STANCFLAGS+=--name=foo'],
         )
 
+    def test_opts_stanc_deprecated(self):
+        stanc_opts = {}
+        stanc_opts['allow_undefined'] = True
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        with LogCapture() as log:
+            opts.validate()
+        log.check_present(
+            (
+                'cmdstanpy',
+                'WARNING',
+                'compiler option "allow_undefined" is deprecated,'
+                ' use "allow-undefined" instead',
+            )
+        )
+        self.assertEqual(opts.compose(), ['STANCFLAGS+=--allow-undefined'])
+
+        stanc_opts['include_paths'] = DATAFILES_PATH
+        opts = CompilerOptions(stanc_options=stanc_opts)
+        opts.validate()
+        self.assertIn('include-paths', opts.stanc_options)
+        self.assertNotIn('include_paths', opts.stanc_options)
+
     def test_opts_stanc_opencl(self):
         stanc_opts = {}
         stanc_opts['use-opencl'] = 'foo'
@@ -89,22 +113,22 @@ class CompilerOptsTest(unittest.TestCase):
     def test_opts_stanc_includes(self):
         path2 = os.path.join(HERE, 'data', 'optimize')
         paths_str = ','.join([DATAFILES_PATH, path2]).replace('\\', '/')
-        expect = 'STANCFLAGS+=--include_paths=' + paths_str
+        expect = 'STANCFLAGS+=--include-paths=' + paths_str
 
-        stanc_opts = {'include_paths': paths_str}
+        stanc_opts = {'include-paths': paths_str}
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
         opts_list = opts.compose()
         self.assertTrue(expect in opts_list)
 
-        stanc_opts = {'include_paths': [DATAFILES_PATH, path2]}
+        stanc_opts = {'include-paths': [DATAFILES_PATH, path2]}
         opts = CompilerOptions(stanc_options=stanc_opts)
         opts.validate()
         opts_list = opts.compose()
         self.assertTrue(expect in opts_list)
 
     def test_opts_add_include_paths(self):
-        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace(
+        expect = 'STANCFLAGS+=--include-paths=' + DATAFILES_PATH.replace(
             '\\', '/'
         )
         stanc_opts = {'warn-uninitialized': True}
@@ -120,7 +144,7 @@ class CompilerOptsTest(unittest.TestCase):
 
         path2 = os.path.join(HERE, 'data', 'optimize')
         paths_str = ','.join([DATAFILES_PATH, path2]).replace('\\', '/')
-        expect = 'STANCFLAGS+=--include_paths=' + paths_str
+        expect = 'STANCFLAGS+=--include-paths=' + paths_str
         opts.add_include_path(path2)
         opts.validate()
         opts_list = opts.compose()
@@ -169,7 +193,7 @@ class CompilerOptsTest(unittest.TestCase):
         header_file = os.path.join(DATAFILES_PATH, 'return_one.hpp')
         opts = CompilerOptions(user_header=header_file)
         opts.validate()
-        self.assertTrue(opts.stanc_options['allow_undefined'])
+        self.assertTrue(opts.stanc_options['allow-undefined'])
 
         bad = os.path.join(DATAFILES_PATH, 'nonexistant.hpp')
         opts = CompilerOptions(user_header=bad)
@@ -209,20 +233,20 @@ class CompilerOptsTest(unittest.TestCase):
         self.assertTrue('STAN_OPENCL=FALSE' in opts_list)
         self.assertTrue('OPENCL_DEVICE_ID=2' in opts_list)
 
-        expect = 'STANCFLAGS+=--include_paths=' + DATAFILES_PATH.replace(
+        expect = 'STANCFLAGS+=--include-paths=' + DATAFILES_PATH.replace(
             '\\', '/'
         )
-        stanc_opts2 = {'include_paths': DATAFILES_PATH}
+        stanc_opts2 = {'include-paths': DATAFILES_PATH}
         new_opts2 = CompilerOptions(stanc_options=stanc_opts2)
         opts.add(new_opts2)
         opts_list = opts.compose()
         self.assertTrue(expect in opts_list)
 
         path2 = os.path.join(HERE, 'data', 'optimize')
-        expect = 'STANCFLAGS+=--include_paths=' + ','.join(
+        expect = 'STANCFLAGS+=--include-paths=' + ','.join(
             [DATAFILES_PATH, path2]
         ).replace('\\', '/')
-        stanc_opts3 = {'include_paths': path2}
+        stanc_opts3 = {'include-paths': path2}
         new_opts3 = CompilerOptions(stanc_options=stanc_opts3)
         opts.add(new_opts3)
         opts_list = opts.compose()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -129,7 +129,7 @@ class CmdStanModelTest(CustomTestCase):
     def test_stanc_options(self):
         opts = {
             'O': True,
-            'allow_undefined': True,
+            'allow-undefined': True,
             'use-opencl': True,
             'name': 'foo',
         }
@@ -138,7 +138,7 @@ class CmdStanModelTest(CustomTestCase):
         )
         stanc_opts = model.stanc_options
         self.assertTrue(stanc_opts['O'])
-        self.assertTrue(stanc_opts['allow_undefined'])
+        self.assertTrue(stanc_opts['allow-undefined'])
         self.assertTrue(stanc_opts['use-opencl'])
         self.assertTrue(stanc_opts['name'] == 'foo')
 
@@ -151,12 +151,12 @@ class CmdStanModelTest(CustomTestCase):
                 stan_file=BERN_STAN, compile=False, stanc_options=bad_opts
             )
         with self.assertRaises(ValueError):
-            bad_opts = {'include_paths': True}
+            bad_opts = {'include-paths': True}
             model = CmdStanModel(
                 stan_file=BERN_STAN, compile=False, stanc_options=bad_opts
             )
         with self.assertRaises(ValueError):
-            bad_opts = {'include_paths': 'lkjdf'}
+            bad_opts = {'include-paths': 'lkjdf'}
             model = CmdStanModel(
                 stan_file=BERN_STAN, compile=False, stanc_options=bad_opts
             )
@@ -189,6 +189,15 @@ class CmdStanModelTest(CustomTestCase):
         model_info = model.src_info()
         self.assertNotEqual(model_info, {})
         self.assertIn('theta', model_info['parameters'])
+
+        model_include = CmdStanModel(
+            stan_file=os.path.join(DATAFILES_PATH, "bernoulli_include.stan"),
+            compile=False,
+        )
+        model_info_include = model_include.src_info()
+        self.assertNotEqual(model_info_include, {})
+        self.assertIn('theta', model_info_include['parameters'])
+        self.assertIn('included_files', model_info_include)
 
     def test_compile_force(self):
         if os.path.exists(BERN_EXE):
@@ -349,7 +358,7 @@ class CmdStanModelTest(CustomTestCase):
         if os.path.exists(BERN_EXE):
             os.remove(BERN_EXE)
         model = CmdStanModel(
-            stan_file=BERN_STAN, stanc_options={'include_paths': DATAFILES_PATH}
+            stan_file=BERN_STAN, stanc_options={'include-paths': DATAFILES_PATH}
         )
         self.assertEqual(BERN_STAN, model.stan_file)
         self.assertPathsEqual(model.exe_file, BERN_EXE)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #516 by adding include paths if they exist. 

Updates compiler_opts to reflect that `allow_undefined` and `include_paths` are being replaced by `allow-undefined` and `include-paths` respectively. We emit a warning and use the non-deprecated versions.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

