### PR TITLE
Avoid changing root logger level

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -51,7 +51,13 @@ def get_logger() -> logging.Logger:
     """cmdstanpy logger"""
     logger = logging.getLogger('cmdstanpy')
     if len(logger.handlers) == 0:
-        logging.basicConfig(level=logging.INFO)
+        # send all messages to handlers
+        logger.setLevel(logging.DEBUG)
+        # add a default handler to the logger to INFO and higher
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
+        logger.addHandler(handler)
     return logger
 
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #522. Avoids the use of `basicConfig`, which changes the root logger level. Behavior for cmdstanpy on its own should be unchanged.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

