### PR TITLE
Revert "Avoid changing root logger level"

### DIFF
--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -51,13 +51,7 @@ def get_logger() -> logging.Logger:
     """cmdstanpy logger"""
     logger = logging.getLogger('cmdstanpy')
     if len(logger.handlers) == 0:
-        # send all messages to handlers
-        logger.setLevel(logging.DEBUG)
-        # add a default handler to the logger to INFO and higher
-        handler = logging.StreamHandler()
-        handler.setLevel(logging.INFO)
-        handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
-        logger.addHandler(handler)
+        logging.basicConfig(level=logging.INFO)
     return logger
 
 


### PR DESCRIPTION
Reverts stan-dev/cmdstanpy#525

this seems to break things -

```
--- Logging error ---
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/logging/__init__.py", line 1084, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "/Users/mitzi/github/stan-dev/cmdstanpy/cmdstanpy/__init__.py", line 31, in _cleanup_tmpdir
    logging.getLogger('cmdstanpy').info('deleting tmpfiles dir: %s', _TMPDIR)
Message: 'deleting tmpfiles dir: %s'
Arguments: ('/var/folders/db/4jnggnf549s42z50bd61jskm0000gq/T/tmpqgyh_gr5',)
--- Logging error ---
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/logging/__init__.py", line 1084, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "/Users/mitzi/github/stan-dev/cmdstanpy/cmdstanpy/__init__.py", line 33, in _cleanup_tmpdir
    logging.getLogger('cmdstanpy').info('done')
Message: 'done'
Arguments: ()

```