### PR TITLE
Fix custom version in GHA runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
       cmdstan-version:
         description: 'Version to test'
         required: false
-        default: 'latest'
+        default: ''
 
 jobs:
   get-cmdstan-version:
@@ -24,7 +24,7 @@ jobs:
       - name: Get CmdStan version
         id: check-cmdstan
         run: |
-            if [[ "${{ github.event.inputs.cmdstan-version }}" == "latest" ]]; then
+            if [[ "${{ github.event.inputs.cmdstan-version }}" != "" ]]; then
               echo "::set-output name=version::${{ github.event.inputs.cmdstan-version }}"
             else
                 echo "::set-output name=version::$(python -c 'import requests;print(requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])')"


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

The condition in the Github Actions file was backwards, so it was impossible to actually run with a custom version. Wanted to fix this before the RC next week

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

