### PR TITLE
Fix tests and src_info for 2.29

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -283,13 +283,10 @@ class CmdStanModel:
                     self.stan_file,
                 ]
             )
-            out = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout
-            result = json.loads(out)
+            proc = subprocess.run(
+                cmd, capture_output=True, text=True, check=True
+            )
+            result = json.loads(proc.stdout)
             return result
         except (
             ValueError,

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -292,7 +292,12 @@ class CmdStanModel:
             ).stdout
             result = json.loads(out)
             return result
-        except (ValueError, RuntimeError, OSError) as e:
+        except (
+            ValueError,
+            RuntimeError,
+            OSError,
+            subprocess.CalledProcessError,
+        ) as e:
             get_logger().debug(e)
             return result
 

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -292,7 +292,7 @@ class CmdStanModel:
             ).stdout
             result = json.loads(out)
             return result
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, OSError) as e:
             get_logger().debug(e)
             return result
 

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -275,7 +275,7 @@ class CmdStanModel:
             return result
         try:
             cmd = (
-                [os.path.join('.', 'bin', 'stanc' + EXTENSION)]
+                [os.path.join(cmdstan_path(), 'bin', 'stanc' + EXTENSION)]
                 # handle include-paths, allow-undefined etc
                 + self._compiler_options.compose_stanc()
                 + [
@@ -285,7 +285,6 @@ class CmdStanModel:
             )
             out = subprocess.run(
                 cmd,
-                cwd=cmdstan_path(),
                 capture_output=True,
                 text=True,
                 check=True,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,7 @@
 """The global configuration for the test suite"""
+import atexit
 import os
+import shutil
 import subprocess
 
 import pytest
@@ -13,7 +15,16 @@ DATAFILES_PATH = os.path.join(HERE, 'data')
 
 @pytest.fixture(scope='session', autouse=True)
 def cleanup_test_files():
+
+    import cmdstanpy
+
+    # see https://github.com/pytest-dev/pytest/issues/5502
+    atexit.unregister(cmdstanpy._cleanup_tmpdir)
+
     yield
+
+    shutil.rmtree(cmdstanpy._TMPDIR, ignore_errors=True)
+
     subprocess.Popen(
         ['git', 'clean', '-fX', DATAFILES_PATH],
         stdout=subprocess.DEVNULL,

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1160,7 +1160,7 @@ class CmdStanMCMCTest(CustomTestCase):
         expected = '\n'.join(
             [
                 'Checking sampler transitions treedepth.',
-                '424 of 1000 (42%) transitions hit the maximum '
+                '424 of 1000 (42.40%) transitions hit the maximum '
                 'treedepth limit of 8, or 2^8 leapfrog steps.',
                 'Trajectories that are prematurely terminated '
                 'due to this limit will result in slow exploration.',

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1157,17 +1157,18 @@ class CmdStanMCMCTest(CustomTestCase):
         ]
         fit = CmdStanMCMC(runset)
         # TODO - use cmdstan test files instead
-        expected = '\n'.join(
-            [
-                'Checking sampler transitions treedepth.',
-                '424 of 1000 (42.40%) transitions hit the maximum '
-                'treedepth limit of 8, or 2^8 leapfrog steps.',
-                'Trajectories that are prematurely terminated '
-                'due to this limit will result in slow exploration.',
-                'For optimal performance, increase this limit.',
-            ]
-        )
-        self.assertIn(expected, fit.diagnose().replace('\r\n', '\n'))
+        expected = [
+            'Checking sampler transitions treedepth.',
+            '424 of 1000',
+            'treedepth limit of 8, or 2^8 leapfrog steps.',
+            'Trajectories that are prematurely terminated '
+            'due to this limit will result in slow exploration.',
+            'For optimal performance, increase this limit.',
+        ]
+
+        diagnose = fit.diagnose()
+        for e in expected:
+            self.assertIn(e, diagnose)
 
     def test_validate_bad_run(self):
         exe = os.path.join(DATAFILES_PATH, 'bernoulli' + EXTENSION)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This fixes a few issues discovered while testing the 2.29 release candidate:

1. The `fixed_param` changes are not in 2.29, which we were assuming they would be
2. src_info() would fail if the model had any warnings, since `do_command` would combine the stderr and stdout streams. This bug exists even without 2.29, it just wasn't uncovered until the new warnings were added to stanc
3. I patched around `atexit` in the tests to handle the intermitten issues with logging and pytest
4. The text of the "diagnose" command changed (it outputs more digits of permission)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

