### PR TITLE
fix numbering of compiler options

### DIFF
--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -11,8 +11,8 @@ from cmdstanpy.utils import get_logger
 
 STANC_OPTS = [
     'O',
+    'O0',
     'O1',
-    'O2',
     'Oexperimental',
     'allow-undefined',
     'use-opencl',

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -127,23 +127,26 @@ class CmdStanModelTest(CustomTestCase):
             CmdStanModel(stan_file=BERN_STAN, exe_file=BERN_EXE)
 
     def test_stanc_options(self):
-        opts = {
-            'O': True,
-            'allow-undefined': True,
-            'use-opencl': True,
-            'name': 'foo',
-        }
-        model = CmdStanModel(
-            stan_file=BERN_STAN, compile=False, stanc_options=opts
-        )
-        stanc_opts = model.stanc_options
-        self.assertTrue(stanc_opts['O'])
-        self.assertTrue(stanc_opts['allow-undefined'])
-        self.assertTrue(stanc_opts['use-opencl'])
-        self.assertTrue(stanc_opts['name'] == 'foo')
 
-        cpp_opts = model.cpp_options
-        self.assertEqual(cpp_opts['STAN_OPENCL'], 'TRUE')
+        allowed_optims = ("", "0", "1", "experimental")
+        for optim in allowed_optims:
+            opts = {
+                f'O{optim}': True,
+                'allow-undefined': True,
+                'use-opencl': True,
+                'name': 'foo',
+            }
+            model = CmdStanModel(
+                stan_file=BERN_STAN, compile=False, stanc_options=opts
+            )
+            stanc_opts = model.stanc_options
+            self.assertTrue(stanc_opts[f'O{optim}'])
+            self.assertTrue(stanc_opts['allow-undefined'])
+            self.assertTrue(stanc_opts['use-opencl'])
+            self.assertTrue(stanc_opts['name'] == 'foo')
+
+            cpp_opts = model.cpp_options
+            self.assertEqual(cpp_opts['STAN_OPENCL'], 'TRUE')
 
         with self.assertRaises(ValueError):
             bad_opts = {'X': True}


### PR DESCRIPTION
add test for all compile options

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
Accidentally numbered the 'O' options as ```O1``` and ```O2``` rather than ```O0``` and ```O1``` .
Fixed this and extended tests to try each optimization during compile. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

J. Michael Burgess


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

