### PR TITLE
Add community page to docs

### DIFF
--- a/docsrc/community.rst
+++ b/docsrc/community.rst
@@ -1,0 +1,27 @@
+Community
+=========
+
+This page highlights community projects that involve CmdStanPy. Check them out!
+
+Project templates
+-----------------
+
+Templates are a great way to piggy back on other users' work, saving you time
+when you start a new project.
+
+- `cookiecutter-cmdstanpy-analysis
+  <https://github.com/teddygroves/cookiecutter-cmdstanpy-analysis>`_ A
+  cookiecutter template for cmdstanpy-based statistical analysis projects.
+
+Software
+--------
+
+- `Prophet <https://github.com/facebook/prophet>`_ A procedure for forecasting
+  time series data based on an additive model where non-linear trends are fit
+  with yearly, weekly, and daily seasonality, plus holiday effects.
+
+- `ArviZ <https://github.com/arviz-devs/arviz>`_ A Python package (with a `Julia
+  interface <https://julia.arviz.org/stable/>`_) for exploratory analysis of
+  Bayesian models. Includes functions for posterior analysis, data storage,
+  model checking, comparison and diagnostics.
+

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -29,6 +29,7 @@ set of model, data, and posterior estimates.
    hello_world
    workflow
    examples
+   community
    api
 
 :ref:`genindex`


### PR DESCRIPTION
This change addresses issue #548 by adding a community section to the documentation.

Sidenote - I had to install the following packages after running `pip install -e '.[docs]'` in order to get `make html` to work: `jupyter nbsphinx sphinx-copybutton pydata-sphinx-theme`. I think the correct docs requirements are in `docsrc/env.yml`, but I don't know how to install them from the file. Can anyone could tell me the best way to get set up for editing cmdstanpy's docs?

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Teddy Groves

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

