### PR TITLE
macOS force arch

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -43,6 +43,7 @@ from cmdstanpy.utils import (
     do_command,
     get_logger,
     returncode_msg,
+    macos_make_arch_args,
 )
 
 from . import progress as progbar
@@ -413,7 +414,8 @@ class CmdStanModel:
                 'MAKE',
                 'make' if platform.system() != 'Windows' else 'mingw32-make',
             )
-            cmd = [make]
+            maybe_force_arch = macos_make_arch_args()
+            cmd = maybe_force_arch + [make]
             if self._compiler_options is not None:
                 cmd.extend(self._compiler_options.compose())
             cmd.append(Path(exe_file).as_posix())


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is a WIP to force the architecture for invoking the Make toolchain on macOS, to avoid annoying errors about incompatible PCH files, when running (a) make from arm64 on a x86_64 compiled cmdstan and (b) vice versa.

This is WIP w/o tests yet to ask for initial feedback: (a) is this useful/desirable and (b) does it want full tests (i.e. building two arch copies) or can exist on a best effort basis?

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): myself



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

