### PR TITLE
Detect failures in generated quantities

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1175,10 +1175,13 @@ class CmdStanModel:
                     " force_one_process_per_chain to True"
                 )
 
-            if not runset._check_retcodes():
-                msg = 'Error during sampling:\n{}'.format(runset.get_err_msgs())
-                msg = '{}Command and output files:\n{}'.format(
-                    msg, runset.__repr__()
+            errors = runset.get_err_msgs()
+            if errors or not runset._check_retcodes():
+                msg = (
+                    f'Error during sampling:\n{errors}\n'
+                    + f'Command and output files:\n{repr(runset)}\n'
+                    + 'Consider re-running with show_console=True if the above'
+                    + ' output is unclear!'
                 )
                 raise RuntimeError(msg)
 
@@ -1317,12 +1320,13 @@ class CmdStanModel:
                         show_console=show_console,
                     )
 
-            if not runset._check_retcodes():
-                msg = 'Error during generate_quantities:\n{}'.format(
-                    runset.get_err_msgs()
-                )
-                msg = '{}Command and output files:\n{}'.format(
-                    msg, runset.__repr__()
+            errors = runset.get_err_msgs()
+            if errors:
+                msg = (
+                    f'Error during generate_quantities:\n{errors}\n'
+                    + f'Command and output files:\n{repr(runset)}\n'
+                    + 'Consider re-running with show_console=True if the above'
+                    + ' output is unclear!'
                 )
                 raise RuntimeError(msg)
             quantities = CmdStanGQ(runset=runset, mcmc_sample=mcmc_fit)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #545. Both `sample` and `generate_quantities` will now detect any errors in the console log even if the return code is not set to a nonzero value. Exceptions in the generated quantities block do not change the return code of the model executable - see https://github.com/stan-dev/cmdstan/issues/1082

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

