### PR TITLE
Make a subdirectory of the temporary directory per-runset

### DIFF
--- a/cmdstanpy/stanfit/runset.py
+++ b/cmdstanpy/stanfit/runset.py
@@ -6,6 +6,7 @@ such as file locations
 import os
 import re
 import shutil
+import tempfile
 from datetime import datetime
 from time import time
 from typing import List, Optional
@@ -50,7 +51,10 @@ class RunSet:
         if args.output_dir is not None:
             self._output_dir = args.output_dir
         else:
-            self._output_dir = _TMPDIR
+            # make a per-run subdirectory of our master temp directory
+            self._output_dir = tempfile.mkdtemp(
+                prefix=args.model_name, dir=_TMPDIR
+            )
 
         # output files prefix: ``<model_name>-<YYYYMMDDHHMM>_<chain_id>``
         self._base_outfile = (

--- a/test/data/normal-rng.stan
+++ b/test/data/normal-rng.stan
@@ -1,0 +1,7 @@
+transformed data{
+  real x_;
+  x_ = std_normal_rng();
+}
+generated quantities{
+  real x = x_;
+}

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1769,6 +1769,20 @@ class CmdStanMCMCTest(CustomTestCase):
                 self.assertEqual(int(z_as_ndarray[0, i, j]), i + 1)
                 self.assertEqual(int(z_as_xr.z.data[0, 0, i, j]), i + 1)
 
+    def test_overlapping_names(self):
+        stan = os.path.join(DATAFILES_PATH, 'normal-rng.stan')
+
+        mod = CmdStanModel(stan_file=stan)
+        # %Y to force same names
+        fits = [
+            mod.sample(data={}, time_fmt="%Y", iter_sampling=1, iter_warmup=1)
+            for i in range(10)
+        ]
+
+        self.assertEqual(
+            len(np.unique([fit.stan_variables()["x"][0] for fit in fits])), 10
+        )
+
     def test_complex_output(self):
         stan = os.path.join(DATAFILES_PATH, 'complex_var.stan')
         model = CmdStanModel(stan_file=stan)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #568. When no output directory is specified, each runset creates its own subfolder in the `_TMPDIR` directory to avoid name clashes. This has also affected fbprophet.

When the output directory _is_ specified, name clobbering will still occur - we assume the user knows what is going on in that case.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

