### PR TITLE
Add an interactive option to `install_cmdstan`

### DIFF
--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -229,8 +229,7 @@ class InteractiveSettings:
         answer = input("Enter a number or hit enter to continue: ")
         try:
             return min(max_cpus, max(int(answer), 1))
-        # pylint: disable=broad-except
-        except Exception:
+        except ValueError:
             return 1
 
 
@@ -614,12 +613,13 @@ def run_install(args: Union[InteractiveSettings, InstallationSettings]) -> None:
 
 
 def parse_cmdline_args() -> Dict[str, Any]:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser("install_cmdstan")
     parser.add_argument(
         '--interactive',
         '-i',
         action='store_true',
-        help="Run the installation in interactive mode",
+        help="Ignore other arguments and run the installation in "
+        + "interactive mode",
     )
     parser.add_argument(
         '--version', '-v', help="version, defaults to latest release version"

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -26,7 +26,7 @@ import urllib.request
 from collections import OrderedDict
 from pathlib import Path
 from time import sleep
-from typing import Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 from tqdm.auto import tqdm
 
@@ -41,10 +41,27 @@ from cmdstanpy.utils import (
 
 from . import progress as progbar
 
-MAKE = os.getenv(
-    'MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make'
-)
-EXTENSION = '.exe' if platform.system() == 'Windows' else ''
+if sys.version_info >= (3, 8) or TYPE_CHECKING:
+    # mypy only knows about the new built-in cached_property
+    from functools import cached_property
+else:
+    # on older Python versions, this is the recommended
+    # way to get the same effect
+    from functools import lru_cache
+
+    def cached_property(fun):
+        return property(lru_cache(maxsize=None)(fun))
+
+
+try:
+    # on MacOS and Linux, importing this
+    # improves the UX of the input() function
+    import readline
+
+    # dummy statement to use import for flake8/pylint
+    _ = readline.__doc__
+except ImportError:
+    pass
 
 
 class CmdStanRetrieveError(RuntimeError):
@@ -55,23 +72,166 @@ class CmdStanInstallError(RuntimeError):
     pass
 
 
-def usage() -> None:
-    """Print usage."""
-    msg = """
-    Arguments:
-        -v (--version) : CmdStan version
-        -d (--dir) : install directory
-        --overwrite : replace installed version
-        --progress : show progress bar for CmdStan download
-        --verbose : show outputs from installation processes
-        """
+def is_windows() -> bool:
+    return platform.system() == 'Windows'
 
-    if platform.system() == "Windows":
-        msg += "-c (--compiler) : add C++ compiler to path (Windows only)\n"
 
-    msg += "        -h (--help) : this message"
+MAKE = os.getenv('MAKE', 'make' if not is_windows() else 'mingw32-make')
+EXTENSION = '.exe' if is_windows() else ''
 
-    print(msg)
+
+def get_headers() -> Dict[str, str]:
+    """Create headers dictionary."""
+    headers = {}
+    GITHUB_PAT = os.environ.get("GITHUB_PAT")  # pylint:disable=invalid-name
+    if GITHUB_PAT is not None:
+        headers["Authorization"] = "token {}".format(GITHUB_PAT)
+    return headers
+
+
+def latest_version() -> str:
+    """Report latest CmdStan release version."""
+    url = 'https://api.github.com/repos/stan-dev/cmdstan/releases/latest'
+    request = urllib.request.Request(url, headers=get_headers())
+    for i in range(6):
+        try:
+            response = urllib.request.urlopen(request).read()
+            break
+        except urllib.error.URLError as e:
+            print('Cannot connect to github.')
+            print(e)
+            if i < 5:
+                print('retry ({}/5)'.format(i + 1))
+                sleep(1)
+                continue
+            raise CmdStanRetrieveError(
+                'Cannot connect to CmdStan github repo.'
+            ) from e
+    content = json.loads(response.decode('utf-8'))
+    tag = content['tag_name']
+    match = re.search(r'v?(.+)', tag)
+    if match is not None:
+        tag = match.group(1)
+    return tag  # type: ignore
+
+
+def home_cmdstan() -> str:
+    return os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
+
+
+# pylint: disable=too-few-public-methods
+class InstallationSettings:
+    """
+    A static installation settings object
+    """
+
+    def __init__(
+        self,
+        *,
+        version: Optional[str] = None,
+        dir: Optional[str] = None,
+        progress: bool = False,
+        verbose: bool = False,
+        overwrite: bool = False,
+        cores: int = 1,
+        compiler: bool = False,
+        **kwargs: Any,
+    ):
+        self.version = version if version else latest_version()
+        self.dir = dir if dir else home_cmdstan()
+        self.progress = progress
+        self.verbose = verbose
+        self.overwrite = overwrite
+        self.cores = cores
+        self.compiler = compiler and is_windows()
+
+        _ = kwargs  # ignore all other inputs.
+        # Useful if initialized from a dictionary like **dict
+
+
+def yes_no(answer: str, default: bool) -> bool:
+    answer = answer.lower()
+    if answer in ('y', 'yes'):
+        return True
+    if answer in ('n', 'no'):
+        return False
+    return default
+
+
+class InteractiveSettings:
+    """
+    Installation settings provided on-demand in an interactive format.
+
+    This provides the same set of properties as the ``InstallationSettings``
+    object, but rather than them being fixed by the constructor the user is
+    asked for input whenever they are accessed for the first time.
+    """
+
+    @cached_property
+    def version(self) -> str:
+        latest = latest_version()
+        print("Which version would you like to install?")
+        print(f"Default: {latest}")
+        answer = input("Type version or hit enter to continue: ")
+        return answer if answer else latest
+
+    @cached_property
+    def dir(self) -> str:
+        directory = home_cmdstan()
+        print("Where would you like to install CmdStan?")
+        print(f"Default: {directory}")
+        answer = input("Type full path or hit enter to continue: ")
+        return os.path.expanduser(answer) if answer else directory
+
+    @cached_property
+    def progress(self) -> bool:
+        print("Show installation progress bars?")
+        print("Default: y")
+        answer = input("[y/n]: ")
+        return yes_no(answer, True)
+
+    @cached_property
+    def verbose(self) -> bool:
+        print("Show verbose output of the installation process?")
+        print("Default: n")
+        answer = input("[y/n]: ")
+        return yes_no(answer, False)
+
+    @cached_property
+    def overwrite(self) -> bool:
+        print("Overwrite existing CmdStan installation?")
+        print("Default: n")
+        answer = input("[y/n]: ")
+        return yes_no(answer, False)
+
+    @cached_property
+    def compiler(self) -> bool:
+        if not is_windows():
+            return False
+        print("Would you like to install the RTools40 C++ toolchain?")
+        print("A C++ toolchain is required for CmdStan.")
+        print(
+            "If you are not sure if you need the toolchain or not, "
+            "the most likely case is you do need it, and should answer 'y'."
+        )
+        print("Default: n")
+        answer = input("[y/n]: ")
+        return yes_no(answer, False)
+
+    @cached_property
+    def cores(self) -> int:
+        max_cpus = os.cpu_count() or 1
+        print(
+            "How many CPU cores would you like to use for installing "
+            "and compiling CmdStan?"
+        )
+        print(f"Default: 1, Max: {max_cpus}")
+        answer = input("Enter a number or hit enter to continue: ")
+        try:
+            return min(max_cpus, max(int(answer), 1))
+        # pylint: disable=broad-except
+        except Exception:
+            return 1
 
 
 def clean_all(verbose: bool = False) -> None:
@@ -132,7 +292,7 @@ def build(verbose: bool = False, progress: bool = True, cores: int = 1) -> None:
             ', please rebuild or report a bug!'
         )
 
-    if platform.system() == 'Windows':
+    if is_windows():
         # Add tbb to the $PATH on Windows
         libtbb = os.path.join(
             os.getcwd(), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
@@ -249,7 +409,7 @@ def install_version(
             'Building version {}, may take several minutes, '
             'depending on your system.'.format(cmdstan_version)
         )
-        if overwrite:
+        if overwrite and os.path.exists('.'):
             print(
                 'Overwrite requested, remove existing build of version '
                 '{}'.format(cmdstan_version)
@@ -289,41 +449,6 @@ def is_version_available(version: str) -> bool:
             print('URLError: {}'.format(e.reason))
             is_available = False
     return is_available
-
-
-def get_headers() -> Dict[str, str]:
-    """Create headers dictionary."""
-    headers = {}
-    GITHUB_PAT = os.environ.get("GITHUB_PAT")  # pylint:disable=invalid-name
-    if GITHUB_PAT is not None:
-        headers["Authorization"] = "token {}".format(GITHUB_PAT)
-    return headers
-
-
-def latest_version() -> str:
-    """Report latest CmdStan release version."""
-    url = 'https://api.github.com/repos/stan-dev/cmdstan/releases/latest'
-    request = urllib.request.Request(url, headers=get_headers())
-    for i in range(6):
-        try:
-            response = urllib.request.urlopen(request).read()
-            break
-        except urllib.error.URLError as e:
-            print('Cannot connect to github.')
-            print(e)
-            if i < 5:
-                print('retry ({}/5)'.format(i + 1))
-                sleep(1)
-                continue
-            raise CmdStanRetrieveError(
-                'Cannot connect to CmdStan github repo.'
-            ) from e
-    content = json.loads(response.decode('utf-8'))
-    tag = content['tag_name']
-    match = re.search(r'v?(.+)', tag)
-    if match is not None:
-        tag = match.group(1)
-    return tag  # type: ignore
 
 
 def retrieve_version(version: str, progress: bool = True) -> None:
@@ -383,7 +508,7 @@ def retrieve_version(version: str, progress: bool = True) -> None:
                 'but found dir {} instead.'.format(cmdstan_dir, top_dir)
             )
         target = os.getcwd()
-        if platform.system() == 'Windows':
+        if is_windows():
             # fixes long-path limitation on Windows
             target = r'\\?\{}'.format(target)
 
@@ -406,8 +531,96 @@ def retrieve_version(version: str, progress: bool = True) -> None:
     print(f'Unpacked download as {cmdstan_dir}')
 
 
+def run_compiler_install(dir: str, verbose: bool, progress: bool) -> None:
+    from .install_cxx_toolchain import is_installed as _is_installed_cxx
+    from .install_cxx_toolchain import run_rtools_install as _main_cxx
+    from .utils import cxx_toolchain_path
+
+    compiler_found = False
+    rtools40_home = os.environ.get('RTOOLS40_HOME')
+    for cxx_loc in ([rtools40_home] if rtools40_home is not None else []) + [
+        home_cmdstan(),
+        os.path.join(os.path.abspath("/"), "RTools40"),
+        os.path.join(os.path.abspath("/"), "RTools"),
+        os.path.join(os.path.abspath("/"), "RTools35"),
+        os.path.join(os.path.abspath("/"), "RBuildTools"),
+    ]:
+        for cxx_version in ['40', '35']:
+            if _is_installed_cxx(cxx_loc, cxx_version):
+                compiler_found = True
+                break
+        if compiler_found:
+            break
+    if not compiler_found:
+        print('Installing RTools40')
+        # copy argv and clear sys.argv
+        _main_cxx(
+            {
+                'dir': dir,
+                'progress': progress,
+                'version': None,
+                'verbose': verbose,
+            }
+        )
+        cxx_version = '40'
+    # Add toolchain to $PATH
+    cxx_toolchain_path(cxx_version, dir)
+
+
+def run_install(args: Union[InteractiveSettings, InstallationSettings]) -> None:
+    """
+    Run a (potentially interactive) installation
+    """
+    if is_version_available(args.version):
+        print('Installing CmdStan version: {}'.format(args.version))
+    else:
+        raise ValueError(
+            f'Version {args.version} cannot be downloaded. '
+            'Connection to GitHub failed. '
+            'Check firewall settings or ensure this version exists.'
+        )
+    validate_dir(args.dir)
+    print('Install directory: {}'.format(args.dir))
+
+    # these accesses just 'warm up' the interactive install
+    _ = args.progress
+    _ = args.verbose
+
+    if args.compiler:
+        run_compiler_install(args.dir, args.verbose, args.progress)
+
+    cmdstan_version = f'cmdstan-{args.version}'
+    with pushd(args.dir):
+
+        already_installed = os.path.exists(cmdstan_version) and os.path.exists(
+            os.path.join(
+                cmdstan_version,
+                'examples',
+                'bernoulli',
+                'bernoulli' + EXTENSION,
+            )
+        )
+        if not already_installed or args.overwrite:
+            retrieve_version(args.version, args.progress)
+            install_version(
+                cmdstan_version=cmdstan_version,
+                overwrite=already_installed and args.overwrite,
+                verbose=args.verbose,
+                progress=args.progress,
+                cores=args.cores,
+            )
+        else:
+            print('CmdStan version {} already installed'.format(args.version))
+
+
 def parse_cmdline_args() -> Dict[str, Any]:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--interactive',
+        '-i',
+        action='store_true',
+        help="Run the installation in interactive mode",
+    )
     parser.add_argument(
         '--version', '-v', help="version, defaults to latest release version"
     )
@@ -435,7 +648,7 @@ def parse_cmdline_args() -> Dict[str, Any]:
         type=int,
         help="number of cores to use while building",
     )
-    if platform.system() == 'Windows':
+    if is_windows():
         # use compiler installed with install_cxx_toolchain
         # Install a new compiler if compiler not found
         # Search order is RTools40, RTools35
@@ -449,99 +662,12 @@ def parse_cmdline_args() -> Dict[str, Any]:
     return vars(parser.parse_args(sys.argv[1:]))
 
 
-def main(args: Dict[str, Any]) -> None:
-    """Main."""
-
-    version = latest_version()
-    if args['version']:
-        version = args['version']
-
-    if is_version_available(version):
-        print('Installing CmdStan version: {}'.format(version))
-    else:
-        raise ValueError(
-            f'Version {version} cannot be downloaded. '
-            'Connection to GitHub failed. '
-            'Check firewall settings or ensure this version exists.'
-        )
-
-    cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
-
-    install_dir = cmdstan_dir
-    if args['dir']:
-        install_dir = args['dir']
-
-    validate_dir(install_dir)
-    print('Install directory: {}'.format(install_dir))
-
-    if args['progress']:
-        progress = args['progress']
-    else:
-        progress = False
-
-    if platform.system() == 'Windows' and args['compiler']:
-        from .install_cxx_toolchain import is_installed as _is_installed_cxx
-        from .install_cxx_toolchain import main as _main_cxx
-        from .utils import cxx_toolchain_path
-
-        cxx_loc = cmdstan_dir
-        compiler_found = False
-        rtools40_home = os.environ.get('RTOOLS40_HOME')
-        for cxx_loc in (
-            [rtools40_home] if rtools40_home is not None else []
-        ) + [
-            cmdstan_dir,
-            os.path.join(os.path.abspath("/"), "RTools40"),
-            os.path.join(os.path.abspath("/"), "RTools"),
-            os.path.join(os.path.abspath("/"), "RTools35"),
-            os.path.join(os.path.abspath("/"), "RBuildTools"),
-        ]:
-            for cxx_version in ['40', '35']:
-                if _is_installed_cxx(cxx_loc, cxx_version):
-                    compiler_found = True
-                    break
-            if compiler_found:
-                break
-        if not compiler_found:
-            print('Installing RTools40')
-            # copy argv and clear sys.argv
-            cxx_args = {k: v for k, v in args.items() if k != 'compiler'}
-            _main_cxx(cxx_args)
-            cxx_version = '40'
-        # Add toolchain to $PATH
-        cxx_toolchain_path(cxx_version, args['dir'])
-
-    cmdstan_version = f'cmdstan-{version}'
-    with pushd(install_dir):
-        if args['overwrite'] or not (
-            os.path.exists(cmdstan_version)
-            and os.path.exists(
-                os.path.join(
-                    cmdstan_version,
-                    'examples',
-                    'bernoulli',
-                    'bernoulli' + EXTENSION,
-                )
-            )
-        ):
-            try:
-                retrieve_version(version, progress)
-                install_version(
-                    cmdstan_version=cmdstan_version,
-                    overwrite=args['overwrite'],
-                    verbose=args['verbose'],
-                    progress=progress,
-                    cores=args['cores'],
-                )
-            except RuntimeError as e:
-                print(e)
-                sys.exit(3)
-        else:
-            print('CmdStan version {} already installed'.format(version))
-
-
 def __main__() -> None:
-    main(parse_cmdline_args())
+    args = parse_cmdline_args()
+    if args.get('interactive', False):
+        run_install(InteractiveSettings())
+    else:
+        run_install(InstallationSettings(**args))
 
 
 if __name__ == '__main__':

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -258,7 +258,7 @@ def get_toolchain_version(name: str, version: str) -> str:
     return toolchain_folder
 
 
-def main(args: Dict[str, Any]) -> None:
+def run_rtools_install(args: Dict[str, Any]) -> None:
     """Main."""
     if platform.system() not in {'Windows'}:
         raise NotImplementedError(
@@ -361,7 +361,7 @@ def parse_cmdline_args() -> Dict[str, Any]:
 
 
 def __main__() -> None:
-    main(parse_cmdline_args())
+    run_rtools_install(parse_cmdline_args())
 
 
 if __name__ == '__main__':

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -148,7 +148,10 @@ def validate_cmdstan_path(path: str) -> None:
         raise ValueError(f'No CmdStan directory, path {path} does not exist.')
     if not os.path.exists(os.path.join(path, 'bin', 'stanc' + EXTENSION)):
         raise ValueError(
-            'CmdStan installataion missing binaries, run "install_cmdstan"'
+            'CmdStan installataion missing binaries. '
+            'Re-install cmdstan by running command "install_cmdstan '
+            '--overwrite", or Python code "import cmdstanpy; '
+            'cmdstanpy.install_cmdstan(overwrite=True)"'
         )
 
 
@@ -178,14 +181,14 @@ def cmdstan_path() -> str:
         cmdstan_dir = os.path.expanduser(os.path.join('~', _DOT_CMDSTAN))
         if not os.path.exists(cmdstan_dir):
             raise ValueError(
-                'No CmdStan installation found, run "install_cmdstan" or'
-                ' (re)activate your conda environment!'
+                'No CmdStan installation found, run command "install_cmdstan"'
+                'or (re)activate your conda environment!'
             )
         latest_cmdstan = get_latest_cmdstan(cmdstan_dir)
         if latest_cmdstan is None:
             raise ValueError(
-                'No CmdStan installation found, run "install_cmdstan" or'
-                ' (re)activate your conda environment!'
+                'No CmdStan installation found, run command "install_cmdstan"'
+                'or (re)activate your conda environment!'
             )
         cmdstan = os.path.join(cmdstan_dir, latest_cmdstan)
         os.environ['CMDSTAN'] = cmdstan

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -1285,23 +1285,22 @@ def install_cmdstan(
 
     :return: Boolean value; ``True`` for success.
     """
-    logger = get_logger()
-    args = {
-        "version": version,
-        "overwrite": overwrite,
-        "verbose": verbose,
-        "compiler": compiler,
-        "progress": progress,
-        "dir": dir,
-        "cores": cores,
-    }
-
     try:
-        from .install_cmdstan import main
+        from .install_cmdstan import InstallationSettings, run_install
 
-        main(args)
+        args = InstallationSettings(
+            version=version,
+            overwrite=overwrite,
+            verbose=verbose,
+            compiler=compiler,
+            progress=progress,
+            dir=dir,
+            cores=cores,
+        )
+        run_install(args)
     # pylint: disable=broad-except
     except Exception as e:
+        logger = get_logger()
         logger.warning('CmdStan installation failed.')
         logger.warning(str(e))
         return False

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,6 +5,7 @@ import os
 import sys
 import unittest
 from importlib import reload
+from io import StringIO
 
 
 class CustomTestCase(unittest.TestCase):
@@ -32,10 +33,11 @@ class CustomTestCase(unittest.TestCase):
             yield
         reload(module)
 
+    # recipe modified from https://stackoverflow.com/a/36491341
     @contextlib.contextmanager
-    def replace_stdin(self, target):
+    def replace_stdin(self, target: str):
         orig = sys.stdin
-        sys.stdin = target
+        sys.stdin = StringIO(target)
         yield
         sys.stdin = orig
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import os
+import sys
 import unittest
 from importlib import reload
 
@@ -30,6 +31,13 @@ class CustomTestCase(unittest.TestCase):
             reload(module)
             yield
         reload(module)
+
+    @contextlib.contextmanager
+    def replace_stdin(self, target):
+        orig = sys.stdin
+        sys.stdin = target
+        yield
+        sys.stdin = orig
 
     # recipe from https://stackoverflow.com/a/34333710
     @contextlib.contextmanager

--- a/test/test_cxx_installation.py
+++ b/test/test_cxx_installation.py
@@ -41,7 +41,7 @@ class InstallCxxScriptTest(unittest.TestCase):
             r'Download for the C\+\+ toolchain on the current platform has not '
             r'been implemented:\s*\S+',
         ):
-            install_cxx_toolchain.main({})
+            install_cxx_toolchain.run_rtools_install({})
 
     @pytest.mark.skipif(
         platform.system() != 'Windows', reason='Windows only tests'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -866,7 +866,7 @@ class InstallCmdstanFunctionTest(CustomTestCase):
 
     def test_interactive_extra_args(self):
         with LogCapture() as log:
-            with self.replace_stdin(io.StringIO("9.99.9\n")):
+            with self.replace_stdin("9.99.9\n"):
                 res = install_cmdstan(version="2.29.2", interactive=True)
         log.check_present(
             (


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is inspired by https://github.com/stan-dev/cmdstanr/issues/605. 

This PR adds a `--interactive` (short `-i`) flag to the `install_cmdstan` script. If this is set, it drops the user into a series of prompts for each setting which would normally be a command line flag. This lets us elaborate on the questions, provide defaults, etc.

For now, this only implements the existing settings: version, installation directory, verbose/progress bars, number of cores to use for building, and on Windows whether they want RTools. This also needs doc, but I wanted to get it up for discussion alongside #578 

With the framework in place, we can later extend to more complicated settings like pre-setting some `make/local` variables.

Example prompt:
```shell
$ install_cmdstan -i
Which version would you like to install?
Default: 2.29.2
Type version or hit enter to continue: 2.28.0
Installing CmdStan version: 2.28.0
Where would you like to install CmdStan?
Default: /home/brian/.cmdstan
Type full path or hit enter to continue: 
Install directory: /home/brian/.cmdstan
Show installation progress bars?
Default: y
[y/n]: y
Show verbose output of the installation process?
Default: n
[y/n]: 
Downloading CmdStan version 2.28.0
Download successful, file: /tmp/tmp9u3v0zgk                                                                                                                   
Extracting distribution
Unpacked download as cmdstan-2.28.0                                                                                                                           
How many CPU cores would you like to use for installing and compiling CmdStan?
Default: 1, Max: 8
Enter a number or hit enter to continue: 
Building version cmdstan-2.28.0, may take several minutes, depending on your system.
Compiling:  (01:29) | ██████████████████████████████████████████████████████████████████████████████████████▋              | g++ -std ... model_header.hpp.gch
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

