### PR TITLE
Fix location setting after install_cmdstan()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,14 +96,14 @@ jobs:
         run: |
           install_cmdstan -h
           install_cxx_toolchain -h
-          python -m cmdstanpy.install_cmdstan --version ${{ needs.get-cmdstan-version.outputs.version }}
+          python -c "import cmdstanpy; cmdstanpy.install_cmdstan(version='${{ needs.get-cmdstan-version.outputs.version }}', cores=2)"
 
       - name: Install CmdStan (Windows)
         if: matrix.os == 'windows-latest'
         run: |
           install_cmdstan -h
           install_cxx_toolchain -h
-          python -m cmdstanpy.install_cmdstan --compiler --version ${{ needs.get-cmdstan-version.outputs.version }}
+          python -m cmdstanpy.install_cmdstan --compiler --version ${{ needs.get-cmdstan-version.outputs.version }} --cores 2
 
       - name: Run tests
         run: |

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -7,11 +7,14 @@ Builds CmdStan executables and tests the compiler by building
 example model ``bernoulli.stan``.
 
 Optional command line arguments:
+   -i, --interactive: flag, when specified ignore other arguments and
+                      ask user for settings on STDIN
    -v, --version <release> : version, defaults to latest release version
    -d, --dir <path> : install directory, defaults to '$HOME/.cmdstan
    --overwrite: flag, when specified re-installs existing version
    --progress: flag, when specified show progress bar for CmdStan download
    --verbose: flag, when specified prints output from CmdStan build process
+   --cores: int, number of cores to use when building, defaults to 1
    -c, --compiler : flag, add C++ compiler to path (Windows only)
 """
 import argparse

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -218,15 +218,9 @@ def cmdstan_version() -> Optional[Tuple[int, ...]]:
     """
     try:
         makefile = os.path.join(cmdstan_path(), 'makefile')
-    except ValueError:
+    except ValueError as e:
         get_logger().info('No CmdStan installation found.')
-        return None
-
-    if not os.path.exists(makefile):
-        get_logger().info(
-            'CmdStan installation %s missing makefile, cannot get version.',
-            cmdstan_path(),
-        )
+        get_logger().debug("%s", e)
         return None
 
     with open(makefile, 'r') as fd:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -151,11 +151,6 @@ def validate_cmdstan_path(path: str) -> None:
     """
     if not os.path.isdir(path):
         raise ValueError(f'No CmdStan directory, path {path} does not exist.')
-    if not os.path.isfile(os.path.join(path, "makefile")):
-        raise ValueError(
-            'CmdStan folder does not contain "makefile". '
-            f'Are you sure this is the correct path: {path}?'
-        )
     if not os.path.exists(os.path.join(path, 'bin', 'stanc' + EXTENSION)):
         raise ValueError(
             f'CmdStan installataion missing binaries in {path}/bin. '
@@ -221,6 +216,13 @@ def cmdstan_version() -> Optional[Tuple[int, ...]]:
     except ValueError as e:
         get_logger().info('No CmdStan installation found.')
         get_logger().debug("%s", e)
+        return None
+
+    if not os.path.exists(makefile):
+        get_logger().info(
+            'CmdStan installation %s missing makefile, cannot get version.',
+            cmdstan_path(),
+        )
         return None
 
     with open(makefile, 'r') as fd:

--- a/cmdstanpy/utils.py
+++ b/cmdstanpy/utils.py
@@ -151,9 +151,14 @@ def validate_cmdstan_path(path: str) -> None:
     """
     if not os.path.isdir(path):
         raise ValueError(f'No CmdStan directory, path {path} does not exist.')
+    if not os.path.isfile(os.path.join(path, "makefile")):
+        raise ValueError(
+            'CmdStan folder does not contain "makefile". '
+            f'Are you sure this is the correct path: {path}?'
+        )
     if not os.path.exists(os.path.join(path, 'bin', 'stanc' + EXTENSION)):
         raise ValueError(
-            'CmdStan installataion missing binaries. '
+            f'CmdStan installataion missing binaries in {path}/bin. '
             'Re-install cmdstan by running command "install_cmdstan '
             '--overwrite", or Python code "import cmdstanpy; '
             'cmdstanpy.install_cmdstan(overwrite=True)"'
@@ -299,7 +304,7 @@ def cxx_toolchain_path(
         if os.path.exists(os.path.join(toolchain_root, 'mingw64')):
             compiler_path = os.path.join(
                 toolchain_root,
-                'mingw64' if (sys.maxsize > 2**32) else 'mingw32',
+                'mingw64' if (sys.maxsize > 2 ** 32) else 'mingw32',
                 'bin',
             )
             if os.path.exists(compiler_path):
@@ -323,7 +328,7 @@ def cxx_toolchain_path(
         elif os.path.exists(os.path.join(toolchain_root, 'mingw_64')):
             compiler_path = os.path.join(
                 toolchain_root,
-                'mingw_64' if (sys.maxsize > 2**32) else 'mingw_32',
+                'mingw_64' if (sys.maxsize > 2 ** 32) else 'mingw_32',
                 'bin',
             )
             if os.path.exists(compiler_path):
@@ -375,7 +380,7 @@ def cxx_toolchain_path(
                 if version not in ('35', '3.5', '3'):
                     compiler_path = os.path.join(
                         toolchain_root,
-                        'mingw64' if (sys.maxsize > 2**32) else 'mingw32',
+                        'mingw64' if (sys.maxsize > 2 ** 32) else 'mingw32',
                         'bin',
                     )
                     if os.path.exists(compiler_path):
@@ -400,7 +405,7 @@ def cxx_toolchain_path(
                 else:
                     compiler_path = os.path.join(
                         toolchain_root,
-                        'mingw_64' if (sys.maxsize > 2**32) else 'mingw_32',
+                        'mingw_64' if (sys.maxsize > 2 ** 32) else 'mingw_32',
                         'bin',
                     )
                     if os.path.exists(compiler_path):
@@ -1361,7 +1366,7 @@ def install_cmdstan(
         logger.warning('CmdStan installation failed.\n%s', str(e))
         return False
 
-    set_cmdstan_path(args.dir)
+    set_cmdstan_path(os.path.join(args.dir, f"cmdstan-{args.version}"))
 
     return True
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -138,11 +138,6 @@ class CmdStanPathTest(CustomTestCase):
         with self.assertRaisesRegex(ValueError, 'No CmdStan directory'):
             validate_cmdstan_path(path_foo)
 
-        with self.assertRaisesRegex(
-            ValueError, ".*Are you sure this is the correct path.*"
-        ):
-            set_cmdstan_path(str(DATAFILES_PATH))
-
         folder_name = ''.join(
             random.choice(string.ascii_letters) for _ in range(10)
         )
@@ -153,6 +148,7 @@ class CmdStanPathTest(CustomTestCase):
         folder = pathlib.Path(folder_name)
         folder.mkdir(parents=True)
         (folder / "makefile").touch()
+
         with self.assertRaisesRegex(ValueError, 'missing binaries'):
             validate_cmdstan_path(str(folder.absolute()))
         shutil.rmtree(folder)
@@ -216,16 +212,17 @@ class CmdStanPathTest(CustomTestCase):
                     'found: "dont_need_no_mmp".'
                 )
                 with LogCapture() as log:
-                    logging.getLogger()
                     cmdstan_version()
                 log.check_present(('cmdstanpy', 'INFO', expect))
 
                 fake_makefile.unlink()
-                expect = StringComparison('.*does not contain "makefile".*')
+                expect = (
+                    'CmdStan installation {} missing makefile, '
+                    'cannot get version.'.format(fake_path)
+                )
                 with LogCapture() as log:
-                    logging.getLogger()
                     cmdstan_version()
-                log.check_present(('cmdstanpy', 'DEBUG', expect))
+                log.check_present(('cmdstanpy', 'INFO', expect))
         cmdstan_path()
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import pathlib
 import platform
 import random
 import shutil
@@ -137,6 +138,12 @@ class CmdStanPathTest(CustomTestCase):
         path_foo = os.path.abspath(os.path.join('releases', 'foo'))
         with self.assertRaisesRegex(ValueError, 'No CmdStan directory'):
             validate_cmdstan_path(path_foo)
+
+        with self.assertRaisesRegex(
+            ValueError, ".*Are you sure this is the correct path.*"
+        ):
+            set_cmdstan_path(str(DATAFILES_PATH))
+
         folder_name = ''.join(
             random.choice(string.ascii_letters) for _ in range(10)
         )
@@ -144,11 +151,12 @@ class CmdStanPathTest(CustomTestCase):
             folder_name = ''.join(
                 random.choice(string.ascii_letters) for _ in range(10)
             )
-        os.makedirs(folder_name)
-        path_test = os.path.abspath(folder_name)
+        folder = pathlib.Path(folder_name)
+        folder.mkdir(parents=True)
+        (folder / "makefile").touch()
         with self.assertRaisesRegex(ValueError, 'missing binaries'):
-            validate_cmdstan_path(path_test)
-        shutil.rmtree(folder_name)
+            validate_cmdstan_path(str(folder.absolute()))
+        shutil.rmtree(folder)
 
     def test_validate_dir(self):
         with tempfile.TemporaryDirectory(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #585. Improves error messaging when cmdstan path is pointed toward a folder with no binaries, and changes our CI to use the code path on linux and mac.

Now:

Linux, mac: uses `python -c "import cmdstanpy; cmdstanpy.install_cmdstan()"`
Windows: uses `python -m cmdstanpy.install_cmdstan`

Hopefully this will catch regressions like this in the future

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

