### PR TITLE
Fix/complex output ordering

### DIFF
--- a/cmdstanpy/stanfit/gq.py
+++ b/cmdstanpy/stanfit/gq.py
@@ -523,10 +523,15 @@ class CmdStanGQ:
             col_idxs = self._metadata.stan_vars_cols[var]
             if len(col_idxs) > 0:
                 dims.extend(self._metadata.stan_vars_dims[var])
-            # pylint: disable=redundant-keyword-arg
-            draws = self._draws[draw1:, :, col_idxs].reshape(dims, order='F')
+
+            draws = self._draws[draw1:, :, col_idxs]
+
             if self._metadata.stan_vars_types[var] == BaseType.COMPLEX:
-                draws = draws[..., 0] + 1j * draws[..., 1]
+                draws = draws[..., ::2] + 1j * draws[..., 1::2]
+                dims = dims[:-1]
+
+            draws = draws.reshape(dims, order='F')
+
             return draws
 
     def stan_variables(self, inc_warmup: bool = False) -> Dict[str, np.ndarray]:

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -747,9 +747,14 @@ class CmdStanMCMC:
         col_idxs = self._metadata.stan_vars_cols[var]
         if len(col_idxs) > 0:
             dims.extend(self._metadata.stan_vars_dims[var])
-        draws = self._draws[draw1:, :, col_idxs].reshape(dims, order='F')
+        draws = self._draws[draw1:, :, col_idxs]
+
         if self._metadata.stan_vars_types[var] == BaseType.COMPLEX:
-            draws = draws[..., 0] + 1j * draws[..., 1]
+            draws = draws[..., ::2] + 1j * draws[..., 1::2]
+            dims = dims[:-1]
+
+        draws = draws.reshape(dims, order='F')
+
         return draws
 
     def stan_variables(self) -> Dict[str, np.ndarray]:

--- a/cmdstanpy/stanfit/mle.py
+++ b/cmdstanpy/stanfit/mle.py
@@ -218,12 +218,17 @@ class CmdStanMLE:
             dims = (num_rows,) + self._metadata.stan_vars_dims[var]
             # pylint: disable=redundant-keyword-arg
             if num_rows > 1:
-                result = self._all_iters[:, col_idxs].reshape(dims, order='F')
+                result = self._all_iters[:, col_idxs]
             else:
-                result = self._mle[col_idxs].reshape(dims[1:], order="F")
+                result = self._mle[col_idxs]
+                dims = dims[1:]
 
             if self._metadata.stan_vars_types[var] == BaseType.COMPLEX:
-                result = result[..., 0] + 1j * result[..., 1]
+                result = result[..., ::2] + 1j * result[..., 1::2]
+                dims = dims[:-1]
+
+            result = result.reshape(dims, order='F')
+
             return result
 
         else:  # scalar var

--- a/cmdstanpy/stanfit/vb.py
+++ b/cmdstanpy/stanfit/vb.py
@@ -143,12 +143,13 @@ class CmdStanVB:
         shape: Tuple[int, ...] = ()
         if len(col_idxs) > 1:
             shape = self._metadata.stan_vars_dims[var]
-            result: np.ndarray = np.asarray(self._variational_mean)[
-                col_idxs
-            ].reshape(shape, order="F")
-
+            result: np.ndarray = np.asarray(self._variational_mean)[col_idxs]
             if self._metadata.stan_vars_types[var] == BaseType.COMPLEX:
-                result = result[..., 0] + 1j * result[..., 1]
+                result = result[..., ::2] + 1j * result[..., 1::2]
+                shape = shape[:-1]
+
+            result = result.reshape(shape, order="F")
+
             return result
         else:
             return float(self._variational_mean[col_idxs[0]])

--- a/cmdstanpy/utils/data_munging.py
+++ b/cmdstanpy/utils/data_munging.py
@@ -44,12 +44,14 @@ def build_xarray_data(
     if dims:
         var_dims += tuple(f"{var_name}_dim_{i}" for i in range(len(dims)))
 
-        draws = drawset[start_row:, :, col_idxs].reshape(
-            *drawset.shape[:2], *dims, order="F"
-        )
+        draws = drawset[start_row:, :, col_idxs]
+
         if var_type == BaseType.COMPLEX:
-            draws = draws[..., 0] + 1j * draws[..., 1]
+            draws = draws[..., ::2] + 1j * draws[..., 1::2]
             var_dims = var_dims[:-1]
+            dims = dims[:-1]
+
+        draws = draws.reshape(*drawset.shape[:2], *dims, order="F")
 
         data[var_name] = (
             var_dims,

--- a/test/data/complex_var.stan
+++ b/test/data/complex_var.stan
@@ -16,7 +16,9 @@ generated quantities {
                            {{0, 1}, {0, 2}, {0, 3}}};
   array[2, 3] complex zs = {{3, 4i, 5}, {1i, 2i, 3i}};
   complex z = 3 + 4i;
-  
+
   array[2] int imag = {3, 4};
+
+  complex_matrix[2,3] zs_mat = to_matrix(zs);
 }
 

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -440,6 +440,13 @@ class GenerateQuantitiesTest(CustomTestCase):
 
         self.assertEqual(fit.stan_variable('zs').shape, (10, 2, 3))
         self.assertEqual(fit.stan_variable('z')[0], 3 + 4j)
+
+        self.assertTrue(
+            np.allclose(
+                fit.stan_variable('zs')[0], np.array([[3, 4j, 5], [1j, 2j, 3j]])
+            )
+        )
+
         # make sure the name 'imag' isn't magic
         self.assertEqual(fit.stan_variable('imag').shape, (10, 2))
 

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -606,6 +606,13 @@ class OptimizeTest(unittest.TestCase):
 
         self.assertEqual(fit.stan_variable('zs').shape, (2, 3))
         self.assertEqual(fit.stan_variable('z'), 3 + 4j)
+
+        self.assertTrue(
+            np.allclose(
+                fit.stan_variable('zs'), np.array([[3, 4j, 5], [1j, 2j, 3j]])
+            )
+        )
+
         # make sure the name 'imag' isn't magic
         self.assertEqual(fit.stan_variable('imag').shape, (2,))
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1815,6 +1815,12 @@ class CmdStanMCMCTest(CustomTestCase):
                 fit.stan_variable('zs')[0], np.array([[3, 4j, 5], [1j, 2j, 3j]])
             )
         )
+        self.assertTrue(
+            np.allclose(
+                fit.stan_variable('zs_mat')[0],
+                np.array([[3, 4j, 5], [1j, 2j, 3j]]),
+            )
+        )
 
         self.assertNotIn("zs_dim_2", fit.draws_xr())
         # getting a raw scalar out of xarray is heavy

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1810,10 +1810,20 @@ class CmdStanMCMCTest(CustomTestCase):
         # make sure the name 'imag' isn't magic
         self.assertEqual(fit.stan_variable('imag').shape, (10, 2))
 
+        self.assertTrue(
+            np.allclose(
+                fit.stan_variable('zs')[0], np.array([[3, 4j, 5], [1j, 2j, 3j]])
+            )
+        )
+
         self.assertNotIn("zs_dim_2", fit.draws_xr())
         # getting a raw scalar out of xarray is heavy
         self.assertEqual(
             fit.draws_xr().z.isel(chain=0, draw=1).data[()], 3 + 4j
+        )
+        np.testing.assert_allclose(
+            fit.draws_xr().zs.isel(chain=0, draw=1).data,
+            np.array([[3, 4j, 5], [1j, 2j, 3j]]),
         )
 
     def test_attrs(self):

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -258,6 +258,13 @@ class VariationalTest(unittest.TestCase):
 
         self.assertEqual(fit.stan_variable('zs').shape, (2, 3))
         self.assertEqual(fit.stan_variable('z'), 3 + 4j)
+
+        self.assertTrue(
+            np.allclose(
+                fit.stan_variable('zs'), np.array([[3, 4j, 5], [1j, 2j, 3j]])
+            )
+        )
+
         # make sure the name 'imag' isn't magic
         self.assertEqual(fit.stan_variable('imag').shape, (2,))
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

First reported by @tillahoffmann on the [forums here](https://discourse.mc-stan.org/t/difference-in-fft-implementation-between-stan-and-numpy-scipy/28642), CmdStanPy was mangling complex-valued outputs.

The original PR #537 did not include a test asserting that the actual values were recovered in the correct order, which this also fixes. The current code that complex numbers in the output are stored like an extra final dimension of size 2 (this is, after all, how they are treated in the program _inputs_). But they’re not really, they’re stored strided alongside the other dimensions.

To make this concrete, a vector of 3 elements was being read in as if it was stored as `x.1.real, x.2.real, x.3.real, x.1.imag. x.2.imag, x.3.imag`, but really it is actually written to disk as `x.1.real, x.1.imag, x.2.real, x.2.imag, ...`

I think once this is merged we should release a patch version (1.0.7) almost immediately. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

