### PR TITLE
Download correct CmdStan tarball on non-x86 linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10.6"]
+        # more specific version of 3.10 due to https://github.com/python/mypy/issues/13627
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -41,6 +41,7 @@ from cmdstanpy.utils import (
     validate_dir,
     wrap_url_progress_hook,
 )
+from cmdstanpy.utils.cmdstan import get_download_url
 
 from . import progress as progbar
 
@@ -426,10 +427,7 @@ def install_version(
 
 def is_version_available(version: str) -> bool:
     is_available = True
-    url = (
-        'https://github.com/stan-dev/cmdstan/releases/download/'
-        'v{0}/cmdstan-{0}.tar.gz'.format(version)
-    )
+    url = get_download_url(version)
     for i in range(6):
         try:
             urllib.request.urlopen(url)
@@ -458,10 +456,7 @@ def retrieve_version(version: str, progress: bool = True) -> None:
     if version is None or version == '':
         raise ValueError('Argument "version" unspecified.')
     print('Downloading CmdStan version {}'.format(version))
-    url = (
-        'https://github.com/stan-dev/cmdstan/releases/download/'
-        'v{0}/cmdstan-{0}.tar.gz'.format(version)
-    )
+    url = get_download_url(version)
     for i in range(6):  # always retry to allow for transient URLErrors
         try:
             if progress and progbar.allow_show_progress():

--- a/cmdstanpy/utils/cmdstan.py
+++ b/cmdstanpy/utils/cmdstan.py
@@ -48,7 +48,7 @@ def get_download_url(version: str) -> str:
     if not arch and platform.system() == "Linux":
         arch = determine_linux_arch()
 
-    if arch:
+    if arch and arch.lower() != "false":
         url_end = f'v{version}/cmdstan-{version}-linux-{arch}.tar.gz'
     else:
         url_end = f'v{version}/cmdstan-{version}.tar.gz'

--- a/cmdstanpy/utils/cmdstan.py
+++ b/cmdstanpy/utils/cmdstan.py
@@ -21,9 +21,9 @@ EXTENSION = '.exe' if platform.system() == 'Windows' else ''
 def determine_linux_arch() -> str:
     machine = platform.machine()
     arch = ""
-    if machine == "-aarch64":
+    if machine == "aarch64":
         arch = "arm64"
-    elif machine == "-armv7l":
+    elif machine == "armv7l":
         # Telling armel and armhf apart is nontrivial
         # c.f. https://forums.raspberrypi.com/viewtopic.php?t=20873
         if subprocess.run(

--- a/cmdstanpy/utils/cmdstan.py
+++ b/cmdstanpy/utils/cmdstan.py
@@ -26,11 +26,13 @@ def determine_linux_arch() -> str:
     elif machine == "armv7l":
         # Telling armel and armhf apart is nontrivial
         # c.f. https://forums.raspberrypi.com/viewtopic.php?t=20873
-        if subprocess.run(
-            ["readelf -A /proc/self/exe | grep Tag_ABI_VFP_args"],
-            shell=True,
-            check=False,
-        ).returncode:
+        readelf = subprocess.run(
+            ["readelf", "-A", "/proc/self/exe"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        if "Tag_ABI_VFP_args" in readelf.stdout:
             arch = "armel"
         else:
             arch = "armhf"

--- a/docsrc/installation.rst
+++ b/docsrc/installation.rst
@@ -209,6 +209,17 @@ can be used to override these defaults:
     install_cmdstan -d my_local_cmdstan -v 2.27.0
     ls -F my_local_cmdstan
 
+Alternate Linux Architectures
+.............................
+
+CmdStan can be installed on Linux for the following non-x86 architectures:
+``arm64``, ``armel``, ``armhf``, ``mips64el``, ``ppc64el`` and ``s390x``.
+
+CmdStanPy will do its best to determine which of these is applicable for your
+machine when running ``install_cmdstan``. If the wrong choice is made, or if you
+need to manually override this, you can set the ``CMDSTAN_ARCH`` environment variable
+to one of the above options, or to "false" to use the standard x86 download.
+
 DIY Installation
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #615. This PR changes the URL used in `install_cmdstan` to try to use the specific non-x86 linux binaries when applicable. It does its best to determine this automatically based on the value of `platform.machine()`. 

Users can specify an environment variable, `CMDSTAN_ARCH`, to override the default choice

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

