### PR TITLE
Simplify error reporting during compile()

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,5 +10,5 @@ Describe the issue as clearly as possible.
 Provide any additional information here.
 
 #### Current Version:
-Please include the output of `cmdstanpy.show_versions()`, or
+Please include the output of `import cmdstanpy; cmdstanpy.show_versions()`, or
 at least the cmdstan and cmdstanpy versions used.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -299,13 +299,8 @@ class CmdStanModelTest(CustomTestCase):
 
     def test_model_syntax_error(self):
         stan = os.path.join(DATAFILES_PATH, 'bad_syntax.stan')
-        with LogCapture(level=logging.WARNING) as log:
-            logging.getLogger()
-            with self.assertRaises(ValueError):
-                CmdStanModel(stan_file=stan)
-        log.check_present(
-            ('cmdstanpy', 'WARNING', StringComparison(r'(?s).*Syntax error.*'))
-        )
+        with self.assertRaisesRegex(ValueError, r'.*Syntax error.*'):
+            CmdStanModel(stan_file=stan)
 
     def test_repr(self):
         model = CmdStanModel(stan_file=BERN_STAN)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #618. This change makes it so we are never in a situation where compilation failed but nothing gets printed. It does that by trying to be less clever about errors, it just unconditionally prints the console if `make` failed.

This also fixes something which has bugged me for a while, which is that `compile` never threw its own error, but rather this error was thrown after the fact in the constructor. This was really confusing, especially if you initialized the model with `compile=False` and called `compile()` later.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

