### PR TITLE
Add timeout parameter.

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1612,7 +1612,7 @@ class CmdStanModel:
             )
             if timeout:
 
-                def _timer_target():
+                def _timer_target() -> None:
                     # Abort if the process has already terminated.
                     if proc.poll() is not None:
                         return

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -727,8 +727,12 @@ class CmdStanModel:
             )
             dummy_chain_id = 0
             runset = RunSet(args=args, chains=1, time_fmt=time_fmt)
-            self._run_cmdstan(runset, dummy_chain_id, show_console=show_console,
-                              timeout=timeout)
+            self._run_cmdstan(
+                runset,
+                dummy_chain_id,
+                show_console=show_console,
+                timeout=timeout,
+            )
 
         if not runset._check_retcodes():
             msg = 'Error during optimization: {}'.format(runset.get_err_msgs())
@@ -1508,8 +1512,12 @@ class CmdStanModel:
 
             dummy_chain_id = 0
             runset = RunSet(args=args, chains=1, time_fmt=time_fmt)
-            self._run_cmdstan(runset, dummy_chain_id, show_console=show_console,
-                              timeout=timeout)
+            self._run_cmdstan(
+                runset,
+                dummy_chain_id,
+                show_console=show_console,
+                timeout=timeout,
+            )
 
         # treat failure to converge as failure
         transcript_file = runset.stdout_files[dummy_chain_id]
@@ -1546,7 +1554,8 @@ class CmdStanModel:
                 )
             else:
                 msg = 'Error during variational inference: {}'.format(
-                    runset.get_err_msgs())
+                    runset.get_err_msgs()
+                )
             raise RuntimeError(msg)
         # pylint: disable=invalid-name
         vb = CmdStanVB(runset)

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1614,8 +1614,10 @@ class CmdStanModel:
 
             stdout, _ = proc.communicate()
             retcode = proc.returncode
-            if timer and retcode == -15:
-                retcode = 60
+            if timer:
+                timer.cancel()
+                if retcode == -15:
+                    retcode = 60
             runset._set_retcode(idx, retcode)
 
             if stdout:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1527,10 +1527,8 @@ class CmdStanModel:
                     'current value is {}.'.format(grad_samples)
                 )
             else:
-                msg = (
-                    'Variational algorithm failed.\n '
-                    'Console output:\n{}'.format(contents)
-                )
+                msg = 'Error during variational inference: {}'.format(
+                    runset.get_err_msgs())
             raise RuntimeError(msg)
         # pylint: disable=invalid-name
         vb = CmdStanVB(runset)

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -1620,7 +1620,7 @@ class CmdStanModel:
                     runset._set_timeout_flag(idx, True)
 
                 timer = threading.Timer(timeout, _timer_target)
-                timer.setDaemon(True)
+                timer.daemon = True
                 timer.start()
             else:
                 timer = None

--- a/cmdstanpy/stanfit/runset.py
+++ b/cmdstanpy/stanfit/runset.py
@@ -234,6 +234,8 @@ class RunSet:
         """Checks console messages for each CmdStan run."""
         msgs = []
         for i in range(self._num_procs):
+            if self._retcodes[i] == 60:
+                msgs.append("processing timed out")
             if (
                 os.path.exists(self._stdout_files[i])
                 and os.stat(self._stdout_files[i]).st_size > 0

--- a/test/data/timeout.stan
+++ b/test/data/timeout.stan
@@ -1,0 +1,21 @@
+data {
+    // Indicator for endless looping.
+    int loop;
+}
+
+transformed data {
+    // Maybe loop forever so the model times out.
+    real y = 1;
+    while(loop && y) {
+        y += 1;
+    }
+}
+
+parameters {
+    real x;
+}
+
+model {
+    // A nice model so we can get a fit for the `generated_quantities` call.
+    x ~ normal(0, 1);
+}

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -480,7 +480,7 @@ class GenerateQuantitiesTest(CustomTestCase):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
         fit = timeout_model.sample(data={'loop': 0}, chains=1, iter_sampling=10)
-        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+        with self.assertRaises(TimeoutError):
             timeout_model.generate_quantities(
                 timeout=0.1, mcmc_sample=fit, data={'loop': 1}
             )

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -480,11 +480,9 @@ class GenerateQuantitiesTest(CustomTestCase):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
         fit = timeout_model.sample(data={'loop': 0}, chains=1, iter_sampling=10)
-        self.assertRaisesRegex(
-            RuntimeError, 'processing timed out',
-            timeout_model.generate_quantities, timeout=0.1,
-            mcmc_sample=fit, data={'loop': 1},
-        )
+        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+            timeout_model.generate_quantities(timeout=0.1, mcmc_sample=fit,
+                                              data={'loop': 1})
 
 
 if __name__ == '__main__':

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -476,6 +476,16 @@ class GenerateQuantitiesTest(CustomTestCase):
         with self.assertRaisesRegex(AttributeError, 'Unknown variable name:'):
             dummy = fit.c
 
+    def test_timeout(self):
+        stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
+        timeout_model = CmdStanModel(stan_file=stan)
+        fit = timeout_model.sample(data={'loop': 0}, chains=1, iter_sampling=10)
+        self.assertRaisesRegex(
+            RuntimeError, 'processing timed out',
+            timeout_model.generate_quantities, timeout=0.1,
+            mcmc_sample=fit, data={'loop': 1},
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -481,8 +481,9 @@ class GenerateQuantitiesTest(CustomTestCase):
         timeout_model = CmdStanModel(stan_file=stan)
         fit = timeout_model.sample(data={'loop': 0}, chains=1, iter_sampling=10)
         with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
-            timeout_model.generate_quantities(timeout=0.1, mcmc_sample=fit,
-                                              data={'loop': 1})
+            timeout_model.generate_quantities(
+                timeout=0.1, mcmc_sample=fit, data={'loop': 1}
+            )
 
 
 if __name__ == '__main__':

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -637,7 +637,7 @@ class OptimizeTest(unittest.TestCase):
     def test_timeout(self):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
-        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+        with self.assertRaises(TimeoutError):
             timeout_model.optimize(data={'loop': 1}, timeout=0.1)
 
 

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -634,6 +634,14 @@ class OptimizeTest(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, 'Unknown variable name:'):
             dummy = fit.c
 
+    def test_timeout(self):
+        stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
+        timeout_model = CmdStanModel(stan_file=stan)
+        self.assertRaisesRegex(
+            RuntimeError, 'processing timed out', timeout_model.optimize,
+            data={'loop': 1}, timeout=0.1,
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -637,10 +637,8 @@ class OptimizeTest(unittest.TestCase):
     def test_timeout(self):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
-        self.assertRaisesRegex(
-            RuntimeError, 'processing timed out', timeout_model.optimize,
-            data={'loop': 1}, timeout=0.1,
-        )
+        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+            timeout_model.optimize(data={'loop': 1}, timeout=0.1)
 
 
 if __name__ == '__main__':

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1916,7 +1916,7 @@ class CmdStanMCMCTest(CustomTestCase):
     def test_timeout(self):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
-        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+        with self.assertRaises(TimeoutError):
             timeout_model.sample(timeout=0.1, chains=1, data={'loop': 1})
 
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1913,6 +1913,14 @@ class CmdStanMCMCTest(CustomTestCase):
         self.assertEqual(fit.max_treedepths, None)
         self.assertEqual(fit.divergences, None)
 
+    def test_timeout(self):
+        stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
+        timeout_model = CmdStanModel(stan_file=stan)
+        self.assertRaisesRegex(
+            RuntimeError, 'processing timed out', timeout_model.sample,
+            timeout=0.1, chains=1, data={'loop': 1},
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1916,10 +1916,8 @@ class CmdStanMCMCTest(CustomTestCase):
     def test_timeout(self):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
-        self.assertRaisesRegex(
-            RuntimeError, 'processing timed out', timeout_model.sample,
-            timeout=0.1, chains=1, data={'loop': 1},
-        )
+        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+            timeout_model.sample(timeout=0.1, chains=1, data={'loop': 1})
 
 
 if __name__ == '__main__':

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -294,10 +294,8 @@ class VariationalTest(unittest.TestCase):
     def test_timeout(self):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
-        self.assertRaisesRegex(
-            RuntimeError, 'processing timed out', timeout_model.variational,
-            timeout=0.1, data={'loop': 1}, show_console=True,
-        )
+        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+            timeout_model.variational(timeout=0.1, data={'loop': 1})
 
 
 if __name__ == '__main__':

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -291,6 +291,14 @@ class VariationalTest(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, 'Unknown variable name:'):
             dummy = fit.c
 
+    def test_timeout(self):
+        stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
+        timeout_model = CmdStanModel(stan_file=stan)
+        self.assertRaisesRegex(
+            RuntimeError, 'processing timed out', timeout_model.variational,
+            timeout=0.1, data={'loop': 1}, show_console=True,
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -294,7 +294,7 @@ class VariationalTest(unittest.TestCase):
     def test_timeout(self):
         stan = os.path.join(DATAFILES_PATH, 'timeout.stan')
         timeout_model = CmdStanModel(stan_file=stan)
-        with self.assertRaisesRegex(RuntimeError, 'processing timed out'):
+        with self.assertRaises(TimeoutError):
             timeout_model.variational(timeout=0.1, data={'loop': 1})
 
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests (on macOS; will have to wait for Windows and Linux in CI)
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR adds a `timeout` parameter to `optimize`, `sample`, `generate_quantities`, and `variational` including unit tests. I was running hyperparameter sweeps for a model and some configurations took much longer than others. Setting a timeout means that "bad" configurations can be aborted if they take too long.

I used a `threading.Timer` to terminate the cmdstan subprocess. Checking the elapsed time in `_run_cmdstan` didn't work because the `readline` call blocks until the next line of `stdout` becomes available (which can take a while if the model is sampling inefficiently).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Harvard University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

