### PR TITLE
more accurate type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: isort
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.982
     hooks:
       - id: mypy
         # Copied from setup.cfg

--- a/cmdstanpy/stanfit/mle.py
+++ b/cmdstanpy/stanfit/mle.py
@@ -152,7 +152,7 @@ class CmdStanMLE:
         return pd.DataFrame(self._all_iters, columns=self.column_names)
 
     @property
-    def optimized_params_dict(self) -> Dict[str, float]:
+    def optimized_params_dict(self) -> Dict[str, np.float64]:
         """
         Returns all estimates from the optimizer, including `lp__` as a
         Python Dict.  Only returns estimate from final iteration.


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [ ] Declare copyright holder and open-source license: see below

#### Summary

The `optimized_params_dict` method generates its dictionary by iterating over a numpy array, which produces a numpy item type instead of the base python type; however, the method was annotated with `Dict[str, float]`.  This was creating type checking errors downstream. Here, the annotation is changed to `Dict[str, np.float64]`

In addition, the various linters were upgraded to get pre-commit to run, since they weren't working on newer python versions.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

- Stan Developers and their Assignees

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

