### PR TITLE
Add serialization of samples.

### DIFF
--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -129,6 +129,10 @@ class CmdStanMCMC:
             # pylint: disable=raise-missing-from
             raise AttributeError(*e.args)
 
+    def __getstate__(self) -> dict:
+        self._assemble_draws()
+        return self.__dict__
+
     @property
     def chains(self) -> int:
         """Number of chains."""
@@ -259,8 +263,7 @@ class CmdStanMCMC:
         CmdStanMCMC.draws_xr
         CmdStanGQ.draws
         """
-        if self._draws.shape == (0,):
-            self._assemble_draws()
+        self._assemble_draws()
 
         if inc_warmup and not self._save_warmup:
             get_logger().warning(
@@ -591,8 +594,7 @@ class CmdStanMCMC:
                 ' must run sampler with "save_warmup=True".'
             )
 
-        if self._draws.shape == (0,):
-            self._assemble_draws()
+        self._assemble_draws()
         cols = []
         if vars is not None:
             for var in dict.fromkeys(vars_list):
@@ -648,8 +650,7 @@ class CmdStanMCMC:
         else:
             vars_list = vars
 
-        if self._draws.shape == (0,):
-            self._assemble_draws()
+        self._assemble_draws()
 
         num_draws = self.num_draws_sampling
         meta = self._metadata.cmdstan_config
@@ -735,8 +736,7 @@ class CmdStanMCMC:
                 'Available variables are '
                 + ", ".join(self._metadata.stan_vars_dims)
             )
-        if self._draws.shape == (0,):
-            self._assemble_draws()
+        self._assemble_draws()
         draw1 = 0
         if not inc_warmup and self._save_warmup:
             draw1 = self.num_draws_warmup
@@ -783,8 +783,7 @@ class CmdStanMCMC:
         containing per-draw diagnostic values.
         """
         result = {}
-        if self._draws.shape == (0,):
-            self._assemble_draws()
+        self._assemble_draws()
         for idxs in self.metadata.method_vars_cols.values():
             for idx in idxs:
                 result[self.column_names[idx]] = self._draws[:, :, idx]

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -130,6 +130,10 @@ class CmdStanMCMC:
             raise AttributeError(*e.args)
 
     def __getstate__(self) -> dict:
+        # This function returns the mapping of objects to serialize with pickle.
+        # See https://docs.python.org/3/library/pickle.html#object.__getstate__
+        # for details. We call _assemble_draws to ensure posterior samples have
+        # been loaded prior to serialization.
         self._assemble_draws()
         return self.__dict__
 

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -6,13 +6,13 @@ import json
 import logging
 import os
 import pickle
-import pytest
 import shutil
 import unittest
 from test import CustomTestCase
 
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_array_equal, assert_raises
 from testfixtures import LogCapture
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -12,11 +12,11 @@ import tempfile
 import unittest
 from multiprocessing import cpu_count
 import pickle
-import pytest
 from test import CustomTestCase
 from time import time
 
 import numpy as np
+import pytest
 from testfixtures import LogCapture, StringComparison
 
 import cmdstanpy.stanfit

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1929,7 +1929,10 @@ class CmdStanMCMCTest(CustomTestCase):
         self.assertTrue(np.isnan(fit.stan_variable("nan_out")[0]))
         self.assertTrue(np.isinf(fit.stan_variable("inf_out")[0]))
 
-    def test_serialization(self, stanfile='bernoulli.stan'):
+    def test_mcmc_serialization(self, stanfile='bernoulli.stan'):
+        # This test must have a name with lexicographical less than any test
+        # that uses the `without_import` context manager because the latter uses
+        # `reload` with side effects that affect the consistency of classes.
         stan = os.path.join(DATAFILES_PATH, stanfile)
         bern_model = CmdStanModel(stan_file=stan)
 

--- a/test/test_variational.py
+++ b/test/test_variational.py
@@ -3,6 +3,7 @@
 import contextlib
 import io
 import os
+import pickle
 import shutil
 import unittest
 from math import fabs
@@ -296,6 +297,23 @@ class VariationalTest(unittest.TestCase):
         timeout_model = CmdStanModel(stan_file=stan)
         with self.assertRaises(TimeoutError):
             timeout_model.variational(timeout=0.1, data={'loop': 1})
+
+    def test_serialization(self):
+        stan = os.path.join(
+            DATAFILES_PATH, 'variational', 'eta_should_be_big.stan'
+        )
+        model = CmdStanModel(stan_file=stan)
+        variational1 = model.variational(algorithm='meanfield', seed=999999)
+        dumped = pickle.dumps(variational1)
+        shutil.rmtree(variational1.runset._output_dir)
+        variational2: CmdStanVB = pickle.loads(dumped)
+        np.testing.assert_array_equal(
+            variational1.variational_sample, variational2.variational_sample
+        )
+        self.assertEqual(
+            variational1.variational_params_dict,
+            variational2.variational_params_dict,
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

- add a call to `_assemble_draws` to the `__getstate__` magic function such that samples are included when a fit object is serialized with `pickle` or `dill`.
- remove checks before calling `_assemble_draws` because the function already performs this check internally.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Harvard University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

