### PR TITLE
Add Python 3.11 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10.6"]
-        # more specific version of 3.10 due to https://github.com/python/mypy/issues/13627
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -60,7 +59,7 @@ jobs:
           pip install codecov
 
       - name: Run flake8, pylint, mypy
-        if: matrix.python-version == '3.10.6'
+        if: matrix.python-version == '3.11'
         run: |
           flake8 cmdstanpy test
           pylint -v cmdstanpy test


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This adds the newly released Python 3.11 to the CI we run. Python 3.7 can be removed in 7 months (https://endoflife.date/python)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

