### PR TITLE
Raise errors when `src_info` subprocess fails.

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -169,9 +169,19 @@ class CmdStanModel:
             if not cmdstan_version_before(
                 2, 27
             ):  # unknown end of version range
-                model_info = self.src_info()
-                if 'parameters' in model_info:
-                    self._fixed_param |= len(model_info['parameters']) == 0
+                try:
+                    model_info = self.src_info()
+                    if 'parameters' in model_info:
+                        self._fixed_param |= len(model_info['parameters']) == 0
+                except (
+                    ValueError,
+                    RuntimeError,
+                    OSError,
+                    subprocess.CalledProcessError,
+                ) as e:
+                    if compile:
+                        raise
+                    get_logger().debug(e)
 
         if exe_file is not None:
             self._exe_file = os.path.realpath(os.path.expanduser(exe_file))

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -173,12 +173,7 @@ class CmdStanModel:
                     model_info = self.src_info()
                     if 'parameters' in model_info:
                         self._fixed_param |= len(model_info['parameters']) == 0
-                except (
-                    ValueError,
-                    RuntimeError,
-                    OSError,
-                    subprocess.CalledProcessError,
-                ) as e:
+                except ValueError as e:
                     if compile:
                         raise
                     get_logger().debug(e)

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -287,8 +287,7 @@ class CmdStanModel:
             + self._compiler_options.compose_stanc()
             + ['--info', str(self.stan_file)]
         )
-        # pylint: disable=subprocess-run-check
-        proc = subprocess.run(cmd, capture_output=True, text=True)
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
         if proc.returncode:
             raise ValueError(
                 f"Failed to get source info for Stan model "

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -378,6 +378,10 @@ class CmdStanModelTest(CustomTestCase):
         with self.assertRaisesRegex(ValueError, r'.*Syntax error.*'):
             CmdStanModel(stan_file=stan)
 
+    def test_model_syntax_error_without_compile(self):
+        stan = os.path.join(DATAFILES_PATH, 'bad_syntax.stan')
+        CmdStanModel(stan_file=stan, compile=False)
+
     def test_repr(self):
         model = CmdStanModel(stan_file=BERN_STAN)
         model_repr = repr(model)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -207,6 +207,33 @@ class CmdStanModelTest(CustomTestCase):
         self.assertIn('theta', model_info_include['parameters'])
         self.assertIn('included_files', model_info_include)
 
+    def test_compile_with_bad_includes(self):
+        # Ensure compilation fails if we break an included file.
+        stan_file = os.path.join(DATAFILES_PATH, "add_one_model.stan")
+        exe_file = os.path.splitext(stan_file)[0] + EXTENSION
+        if os.path.isfile(exe_file):
+            os.unlink(exe_file)
+        with tempfile.TemporaryDirectory() as include_path:
+            include_source = os.path.join(
+                DATAFILES_PATH, "include-path", "add_one_function.stan"
+            )
+            include_target = os.path.join(include_path, "add_one_function.stan")
+            shutil.copy(include_source, include_target)
+            model = CmdStanModel(
+                stan_file=stan_file,
+                compile=False,
+                stanc_options={"include-paths": [include_path]},
+            )
+            with LogCapture(level=logging.INFO) as log:
+                model.compile()
+            log.check_present(
+                ('cmdstanpy', 'INFO', StringComparison('compiling stan file'))
+            )
+            with open(include_target, "w") as fd:
+                fd.write("gobbledygook")
+            with pytest.raises(ValueError, match="Failed to get source info"):
+                model.compile()
+
     def test_compile_with_includes(self):
         getmtime = os.path.getmtime
         configs = [
@@ -215,6 +242,9 @@ class CmdStanModelTest(CustomTestCase):
         ]
         for stan_file, include_paths in configs:
             stan_file = os.path.join(DATAFILES_PATH, stan_file)
+            exe_file = os.path.splitext(stan_file)[0] + EXTENSION
+            if os.path.isfile(exe_file):
+                os.unlink(exe_file)
             include_paths = [
                 os.path.join(DATAFILES_PATH, path) for path in include_paths
             ]


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR changes `src_info` from logging errors at `DEBUG` level to raising errors that can be caught by client code. It makes `cmdstanpy` somewhat more defensive but existing tests pass without error (at least on my machine). This PR is motivated by [discussion with @WardBrian](https://github.com/stan-dev/cmdstanpy/pull/627#issuecomment-1285714564) in #627.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Harvard University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

