### PR TITLE
fix install command for github install

### DIFF
--- a/docsrc/installation.rst
+++ b/docsrc/installation.rst
@@ -107,7 +107,7 @@ To install the current develop branch from GitHub:
 
 .. code-block:: bash
 
-    pip install -e git+https://github.com/stan-dev/cmdstanpy@/develop#egg=cmdstanpy
+    pip install -e git+https://github.com/stan-dev/cmdstanpy@develop#egg=cmdstanpy
 
 
 .. note::


### PR DESCRIPTION
#### Submission Checklist

- ~Run unit tests~
- [x] Declare copyright holder and open-source license: see below

#### Summary
There is one extra `/` in the github install command so pip tries to install the branch `/develop` instead of `develop`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): myself



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

