### PR TITLE
Handle tilde `~` in model paths.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.7.1 - 3.7.16", "3.8", "3.9", "3.10", "3.11"]
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -501,7 +501,8 @@ class CmdStanModel:
                 return
 
         compilation_failed = False
-        # if target path has space, use copy in a tmpdir (GNU-Make constraint)
+        # if target path has spaces or special characters, use a copy in a
+        # temporary directory (GNU-Make constraint)
         with SanitizedOrTmpFilePath(self._stan_file) as (stan_file, is_copied):
             exe_file = os.path.splitext(stan_file)[0] + EXTENSION
 

--- a/test/data/path~with~tilde/bernoulli_path_with_tilde.stan
+++ b/test/data/path~with~tilde/bernoulli_path_with_tilde.stan
@@ -1,0 +1,12 @@
+data {
+  int<lower=0> N;
+  int<lower=0,upper=1> y[N];
+}
+parameters {
+  real<lower=0,upper=1> theta;
+}
+model {
+  theta ~ beta(1,1);
+  for (n in 1:N)
+    y[n] ~ bernoulli(theta);
+}

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -426,16 +426,18 @@ def test_model_compile() -> None:
     assert exe_time == os.path.getmtime(model2.exe_file)
 
 
-def test_model_compile_space() -> None:
+@pytest.mark.parametrize("path", ["space in path", "tilde~in~path"])
+def test_model_compile_special_char(path: str) -> None:
     with tempfile.TemporaryDirectory(
         prefix="cmdstanpy_testfolder_"
     ) as tmp_path:
-        path_with_space = os.path.join(tmp_path, "space in path")
-        os.makedirs(path_with_space, exist_ok=True)
+        path_with_special_char = os.path.join(tmp_path, path)
+        os.makedirs(path_with_special_char, exist_ok=True)
         bern_stan_new = os.path.join(
-            path_with_space, os.path.split(BERN_STAN)[1]
+            path_with_special_char, os.path.split(BERN_STAN)[1]
         )
-        bern_exe_new = os.path.join(path_with_space, os.path.split(BERN_EXE)[1])
+        bern_exe_new = os.path.join(path_with_special_char,
+                                    os.path.split(BERN_EXE)[1])
         shutil.copyfile(BERN_STAN, bern_stan_new)
         model = CmdStanModel(stan_file=bern_stan_new)
 
@@ -451,7 +453,8 @@ def test_model_compile_space() -> None:
         assert exe_time == os.path.getmtime(model2.exe_file)
 
 
-def test_model_includes_space() -> None:
+@pytest.mark.parametrize("path", ["space in path", "tilde~in~path"])
+def test_model_includes_special_char(path: str) -> None:
     """Test model with include file in path with spaces."""
     stan = os.path.join(DATAFILES_PATH, 'bernoulli_include.stan')
     stan_divide = os.path.join(DATAFILES_PATH, 'divide_real_by_two.stan')
@@ -459,22 +462,23 @@ def test_model_includes_space() -> None:
     with tempfile.TemporaryDirectory(
         prefix="cmdstanpy_testfolder_"
     ) as tmp_path:
-        path_with_space = os.path.join(tmp_path, "space in path")
-        os.makedirs(path_with_space, exist_ok=True)
-        bern_stan_new = os.path.join(path_with_space, os.path.split(stan)[1])
+        path_with_special_char = os.path.join(tmp_path, path)
+        os.makedirs(path_with_special_char, exist_ok=True)
+        bern_stan_new = os.path.join(path_with_special_char,
+                                     os.path.split(stan)[1])
         stan_divide_new = os.path.join(
-            path_with_space, os.path.split(stan_divide)[1]
+            path_with_special_char, os.path.split(stan_divide)[1]
         )
         shutil.copyfile(stan, bern_stan_new)
         shutil.copyfile(stan_divide, stan_divide_new)
 
         model = CmdStanModel(
             stan_file=bern_stan_new,
-            stanc_options={'include-paths': path_with_space},
+            stanc_options={'include-paths': path_with_special_char},
         )
-        assert "space in path" in str(model.exe_file)
+        assert path in str(model.exe_file)
 
-        assert "space in path" in model.src_info()['included_files'][0]
+        assert path in model.src_info()['included_files'][0]
         assert (
             "divide_real_by_two.stan" in model.src_info()['included_files'][0]
         )

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -49,7 +49,8 @@ BERNOULLI_COLS = SAMPLER_STATE + ['theta']
     [
         'bernoulli.stan',
         'bernoulli with space in name.stan',
-        'path with space/' + 'bernoulli_path_with_space.stan',
+        'path with space/bernoulli_path_with_space.stan',
+        'path~with~tilde/bernoulli_path_with_tilde.stan',
     ],
 )
 def test_bernoulli_good(stanfile: str):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -75,7 +75,9 @@ def test_default_path() -> None:
         assert 'CMDSTAN' in os.environ
 
 
-def test_non_spaces_location() -> None:
+@pytest.mark.parametrize("bad_dir", ["bad dir", "bad~dir"])
+@pytest.mark.parametrize("bad_name", ["bad name", "bad~name"])
+def test_non_special_chars_location(bad_dir: str, bad_name: str) -> None:
     with tempfile.TemporaryDirectory(
         prefix="cmdstan_tests", dir=_TMPDIR
     ) as tmpdir:
@@ -86,10 +88,10 @@ def test_non_spaces_location() -> None:
             assert not is_changed
 
         # prepare files for test
-        bad_path = os.path.join(tmpdir, 'bad dir')
+        bad_path = os.path.join(tmpdir, bad_dir)
         os.makedirs(bad_path, exist_ok=True)
         stan = os.path.join(DATAFILES_PATH, 'bernoulli.stan')
-        stan_bad = os.path.join(bad_path, 'bad name.stan')
+        stan_bad = os.path.join(bad_path, bad_name)
         shutil.copy(stan, stan_bad)
 
         stan_copied = None
@@ -98,6 +100,7 @@ def test_non_spaces_location() -> None:
                 stan_copied = pth
                 assert os.path.exists(stan_copied)
                 assert ' ' not in stan_copied
+                assert platform.system() == 'Windows' or '~' not in stan_copied
                 assert is_changed
                 raise RuntimeError
         except RuntimeError:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -100,8 +100,20 @@ def test_non_special_chars_location(bad_dir: str, bad_name: str) -> None:
                 stan_copied = pth
                 assert os.path.exists(stan_copied)
                 assert ' ' not in stan_copied
-                assert platform.system() == 'Windows' or '~' not in stan_copied
-                assert is_changed
+
+                # Determine if the file should have been copied, i.e., we either
+                # are on a unix-ish system or on windows, the path contains a
+                # space, and there is no short path.
+                if platform.system() == 'Windows':
+                    should_change = ' ' in bad_name or (
+                        ' ' in bad_path
+                        and not os.path.exists(windows_short_path(bad_path))
+                    )
+                else:
+                    should_change = True
+                    assert '~' not in stan_copied
+
+                assert is_changed == should_change
                 raise RuntimeError
         except RuntimeError:
             pass


### PR DESCRIPTION
Apple uses tildes in some paths for files that are synced through iCloud (see [here](https://apple.stackexchange.com/q/280338/102603), for example). It's of course a somewhat questionable choice. This PR allows models in these iCloud folders to be compiled and used.

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Harvard University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

