### PR TITLE
Allow git:TAG as a version in install_cmdstan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
         run: python -m pip freeze
 
       - name: CmdStan installation cacheing
+        if: ${{ !startswith(needs.get-cmdstan-version.outputs.version, 'git:') }}
         uses: actions/cache@v3
         with:
           path: ~/.cmdstan

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -457,6 +457,8 @@ def is_version_available(version: str) -> bool:
 
 def retrieve_version(version: str, progress: bool = True) -> None:
     """Download specified CmdStan version."""
+    if version is None or version == '':
+        raise ValueError('Argument "version" unspecified.')
 
     if 'git:' in version:
         tag = version.split(':')[1]
@@ -478,8 +480,6 @@ def retrieve_version(version: str, progress: bool = True) -> None:
         )
         return
 
-    if version is None or version == '':
-        raise ValueError('Argument "version" unspecified.')
     print('Downloading CmdStan version {}'.format(version))
     url = get_download_url(version)
     for i in range(6):  # always retry to allow for transient URLErrors

--- a/cmdstanpy/utils/cmdstan.py
+++ b/cmdstanpy/utils/cmdstan.py
@@ -97,11 +97,13 @@ def get_latest_cmdstan(cmdstan_dir: str) -> Optional[str]:
         for name in os.listdir(cmdstan_dir)
         if os.path.isdir(os.path.join(cmdstan_dir, name))
         and name.startswith('cmdstan-')
-        and name[8].isdigit()
-        and len(name[8:].split('.')) == 3
     ]
     if len(versions) == 0:
         return None
+    if len(versions) == 1:
+        return 'cmdstan-' + versions[0]
+    # we can only compare numeric versions
+    versions = [v for v in versions if v[0].isdigit() and v.count('.') == 2]
     # munge rc for sort, e.g. 2.25.0-rc1 -> 2.25.-99
     for i in range(len(versions)):  # # pylint: disable=C0200
         if '-rc' in versions[i]:
@@ -442,6 +444,8 @@ def install_cmdstan(
 
     :param version: CmdStan version string, e.g. "2.29.2".
         Defaults to latest CmdStan release.
+        If ``git`` is installed, a git tag or branch of stan-dev/cmdstan
+        can be specified, e.g. "git:develop".
 
     :param dir: Path to install directory.  Defaults to hidden directory
         ``$HOME/.cmdstan``.

--- a/cmdstanpy/utils/cmdstan.py
+++ b/cmdstanpy/utils/cmdstan.py
@@ -520,7 +520,11 @@ def install_cmdstan(
         logger.warning('CmdStan installation failed.\n%s', str(e))
         return False
 
-    set_cmdstan_path(os.path.join(args.dir, f"cmdstan-{args.version}"))
+    if 'git:' in args.version:
+        folder = f"cmdstan-{args.version.replace(':', '-').replace('/', '_')}"
+    else:
+        folder = f"cmdstan-{args.version}"
+    set_cmdstan_path(os.path.join(args.dir, folder))
 
     return True
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Allows usage like `install_cmdstan --version=git:develop`. Note: released versions will still always be selected over git versions by the `cmdstan_path()` function unless manually set or only one version exists.

This is primarily for our own CI

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

