### PR TITLE
Stan 2.33: Move IO munging to external package, refactors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: ''
 
+# only run one copy per PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   get-cmdstan-version:
     # get the latest cmdstan version to use as part of the cache key

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7.1 - 3.7.16", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,7 @@ jobs:
             if [[ "${{ github.event.inputs.cmdstan-version }}" != "" ]]; then
               echo "version=${{ github.event.inputs.cmdstan-version }}" >> $GITHUB_OUTPUT
             else
-              echo "version=git:develop" >> $GITHUB_OUTPUT
-              # python -c 'import requests;print("version="+requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])' >> $GITHUB_OUTPUT
+              python -c 'import requests;print("version="+requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])' >> $GITHUB_OUTPUT
             fi
     outputs:
       version: ${{ steps.check-cmdstan.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,8 @@ jobs:
             if [[ "${{ github.event.inputs.cmdstan-version }}" != "" ]]; then
               echo "version=${{ github.event.inputs.cmdstan-version }}" >> $GITHUB_OUTPUT
             else
-                python -c 'import requests;print("version="+requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])' >> $GITHUB_OUTPUT
+              echo "version=git:develop" >> $GITHUB_OUTPUT
+              # python -c 'import requests;print("version="+requests.get("https://api.github.com/repos/stan-dev/cmdstan/releases/latest").json()["tag_name"][1:])' >> $GITHUB_OUTPUT
             fi
     outputs:
       version: ${{ steps.check-cmdstan.outputs.version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: isort
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.5.0
     hooks:
       - id: mypy
         # Copied from setup.cfg

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -299,7 +299,7 @@ class CompilerOptions:
                     opts.append(f'--{key}')
         return opts
 
-    def compose(self, filename_in_msg: Optional[str]) -> List[str]:
+    def compose(self, filename_in_msg: Optional[str] = None) -> List[str]:
         """Format makefile options as list of strings."""
         opts = [
             'STANCFLAGS+=' + flag.replace(" ", "\\ ")

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -300,7 +300,15 @@ class CompilerOptions:
         return opts
 
     def compose(self, filename_in_msg: Optional[str] = None) -> List[str]:
-        """Format makefile options as list of strings."""
+        """
+        Format makefile options as list of strings.
+
+        Parameters
+        ----------
+        filename_in_msg : str, optional
+            filename to be displayed in stanc3 error messages
+            (if different from actual filename on disk), by default None
+        """
         opts = [
             'STANCFLAGS+=' + flag.replace(" ", "\\ ")
             for flag in self.compose_stanc(filename_in_msg)

--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -275,8 +275,12 @@ class CompilerOptions:
         elif path not in self._stanc_options['include-paths']:
             self._stanc_options['include-paths'].append(path)
 
-    def compose_stanc(self) -> List[str]:
+    def compose_stanc(self, filename_in_msg: Optional[str]) -> List[str]:
         opts = []
+
+        if filename_in_msg is not None:
+            opts.append(f'--filename-in-msg={filename_in_msg}')
+
         if self._stanc_options is not None and len(self._stanc_options) > 0:
             for key, val in self._stanc_options.items():
                 if key == 'include-paths':
@@ -295,11 +299,11 @@ class CompilerOptions:
                     opts.append(f'--{key}')
         return opts
 
-    def compose(self) -> List[str]:
+    def compose(self, filename_in_msg: Optional[str]) -> List[str]:
         """Format makefile options as list of strings."""
         opts = [
             'STANCFLAGS+=' + flag.replace(" ", "\\ ")
-            for flag in self.compose_stanc()
+            for flag in self.compose_stanc(filename_in_msg)
         ]
         if self._cpp_options is not None and len(self._cpp_options) > 0:
             for key, val in self._cpp_options.items():

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -7,7 +7,7 @@ Currently implemented platforms (platform.system)
     Linux: Not implemented
 Optional command line arguments:
    -v, --version : version, defaults to latest
-   -d, --dir : install directory, defaults to '~/.cmdstan(py)
+   -d, --dir : install directory, defaults to '~/.cmdstan
    -s (--silent) : install with /VERYSILENT instead of /SILENT for RTools
    -m --no-make : don't install mingw32-make (Windows RTools 4.0 only)
    --progress : flag, when specified show progress bar for RTools download
@@ -333,7 +333,7 @@ def parse_cmdline_args() -> Dict[str, Any]:
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', '-v', help="version, defaults to latest")
     parser.add_argument(
-        '--dir', '-d', help="install directory, defaults to '~/.cmdstan(py)"
+        '--dir', '-d', help="install directory, defaults to '~/.cmdstan"
     )
     parser.add_argument(
         '--silent',

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -27,7 +27,7 @@ from cmdstanpy import _DOT_CMDSTAN
 from cmdstanpy.utils import pushd, validate_dir, wrap_url_progress_hook
 
 EXTENSION = '.exe' if platform.system() == 'Windows' else ''
-IS_64BITS = sys.maxsize > 2 ** 32
+IS_64BITS = sys.maxsize > 2**32
 
 
 def usage() -> None:

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -300,7 +300,7 @@ class CmdStanModel:
         cmd = (
             [os.path.join(cmdstan_path(), 'bin', 'stanc' + EXTENSION)]
             # handle include-paths, allow-undefined etc
-            + self._compiler_options.compose_stanc()
+            + self._compiler_options.compose_stanc(None)
             + ['--info', str(self.stan_file)]
         )
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
@@ -343,7 +343,7 @@ class CmdStanModel:
             cmd = (
                 [os.path.join(cmdstan_path(), 'bin', 'stanc' + EXTENSION)]
                 # handle include-paths, allow-undefined etc
-                + self._compiler_options.compose_stanc()
+                + self._compiler_options.compose_stanc(None)
                 + [str(self.stan_file)]
             )
 
@@ -528,7 +528,7 @@ class CmdStanModel:
             )
             cmd = [make]
             if self._compiler_options is not None:
-                cmd.extend(self._compiler_options.compose())
+                cmd.extend(self._compiler_options.compose(self._stan_file))
             cmd.append(Path(exe_file).as_posix())
 
             sout = io.StringIO()

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -22,6 +22,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
     Optional,
     TypeVar,
@@ -117,8 +118,7 @@ class CmdStanModel:
         model_name: Optional[str] = None,
         stan_file: OptionalPath = None,
         exe_file: OptionalPath = None,
-        # TODO should be Literal['force'] not str
-        compile: Union[bool, str] = True,
+        compile: Union[bool, Literal['force']] = True,
         stanc_options: Optional[Dict[str, Any]] = None,
         cpp_options: Optional[Dict[str, Any]] = None,
         user_header: OptionalPath = None,

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -979,10 +979,7 @@ class CmdStanModel:
             fixed_param = self._fixed_param
 
         if chains is None:
-            if fixed_param:
-                chains = 1
-            else:
-                chains = 4
+            chains = 4
         if chains < 1:
             raise ValueError(
                 'Chains must be a positive integer value, found {}.'.format(
@@ -1073,8 +1070,7 @@ class CmdStanModel:
             one_process_per_chain = True
             info_dict = self.exe_info()
             stan_threads = info_dict.get('STAN_THREADS', 'false').lower()
-            # run multi-chain sampler unless algo is fixed_param or 1 chain
-            if fixed_param or (chains == 1):
+            if chains == 1:
                 force_one_process_per_chain = True
 
             if (
@@ -1177,19 +1173,6 @@ class CmdStanModel:
                     get_logger().debug("Detected fixed param model")
                     sampler_args.fixed_param = True
                     runset._args.method_args = sampler_args
-
-            # if there was an exe-file only initialization,
-            # this could happen, so throw a nice error
-            if (
-                sampler_args.fixed_param
-                and not one_process_per_chain
-                and chains > 1
-            ):
-                raise RuntimeError(
-                    "Cannot use single-process multichain parallelism"
-                    " with algorithm fixed_param.\nTry setting argument"
-                    " force_one_process_per_chain to True"
-                )
 
             errors = runset.get_err_msgs()
             if not runset._check_retcodes():

--- a/cmdstanpy/stanfit/gq.py
+++ b/cmdstanpy/stanfit/gq.py
@@ -587,17 +587,14 @@ class CmdStanGQ(Generic[Fit]):
                 )
             elif isinstance(self.previous_fit, CmdStanMLE):
                 return np.atleast_1d(  # type: ignore
-                    np.asarray(
-                        self.previous_fit.stan_variable(
-                            var, inc_iterations=inc_warmup
-                        )
+                    self.previous_fit.stan_variable(
+                        var, inc_iterations=inc_warmup
                     )
                 )
             else:
                 return np.atleast_1d(  # type: ignore
-                    np.asarray(self.previous_fit.stan_variable(var))
+                    self.previous_fit.stan_variable(var)
                 )
-
         # is gq variable
         self._assemble_generated_quantities()
 

--- a/cmdstanpy/stanfit/gq.py
+++ b/cmdstanpy/stanfit/gq.py
@@ -37,7 +37,6 @@ from cmdstanpy.utils import (
     get_logger,
     scan_generated_quantities_csv,
 )
-from cmdstanpy.utils.data_munging import extract_reshape
 
 from .mcmc import CmdStanMCMC
 from .metadata import InferenceMetadata
@@ -242,7 +241,9 @@ class CmdStanGQ(Generic[Fit]):
             ]
             drop_cols: List[int] = []
             for dup in dups:
-                drop_cols.extend(self.previous_fit.metadata.stan_vars_cols[dup])
+                drop_cols.extend(
+                    self.previous_fit.metadata.stan_vars[dup].columns()
+                )
 
         start_idx, _ = self._draws_start(inc_warmup)
         previous_draws = self._previous_draws(True)
@@ -324,18 +325,22 @@ class CmdStanGQ(Generic[Fit]):
 
         self._assemble_generated_quantities()
 
-        gq_cols = []
-        mcmc_vars = []
+        gq_cols: List[str] = []
+        mcmc_vars: List[str] = []
         if vars is not None:
             for var in vars_list:
-                if var in self.metadata.stan_vars_cols:
-                    for idx in self.metadata.stan_vars_cols[var]:
-                        gq_cols.append(self.column_names[idx])
-                elif (
-                    inc_sample
-                    and var in self.previous_fit.metadata.stan_vars_cols
-                ):
-                    mcmc_vars.append(var)
+                if var in self.metadata.stan_vars:
+                    info = self._metadata.stan_vars[var]
+                    gq_cols.extend(
+                        self.column_names[info.start_idx : info.end_idx]
+                    )
+                elif inc_sample and var in self.previous_fit.metadata.stan_vars:
+                    info = self.previous_fit._metadata.stan_vars[var]
+                    mcmc_vars.extend(
+                        self.previous_fit.column_names[
+                            info.start_idx : info.end_idx
+                        ]
+                    )
                 else:
                     raise ValueError('Unknown variable: {}'.format(var))
         else:
@@ -463,18 +468,18 @@ class CmdStanGQ(Generic[Fit]):
             else:
                 vars_list = vars
             for var in vars_list:
-                if var not in self.metadata.stan_vars_cols:
+                if var not in self.metadata.stan_vars:
                     if inc_sample and (
-                        var in self.previous_fit.metadata.stan_vars_cols
+                        var in self.previous_fit.metadata.stan_vars
                     ):
                         mcmc_vars_list.append(var)
                         dup_vars.append(var)
                     else:
                         raise ValueError('Unknown variable: {}'.format(var))
         else:
-            vars_list = list(self.metadata.stan_vars_cols.keys())
+            vars_list = list(self.metadata.stan_vars.keys())
             if inc_sample:
-                for var in self.previous_fit.metadata.stan_vars_cols.keys():
+                for var in self.previous_fit.metadata.stan_vars.keys():
                     if var not in vars_list and var not in mcmc_vars_list:
                         mcmc_vars_list.append(var)
         for var in dup_vars:
@@ -504,23 +509,15 @@ class CmdStanGQ(Generic[Fit]):
         for var in vars_list:
             build_xarray_data(
                 data,
-                var,
-                self._metadata.stan_vars_dims[var],
-                self._metadata.stan_vars_cols[var],
-                0,
+                self._metadata.stan_vars[var],
                 self.draws(inc_warmup=inc_warmup),
-                self._metadata.stan_vars_types[var],
             )
         if inc_sample:
             for var in mcmc_vars_list:
                 build_xarray_data(
                     data,
-                    var,
-                    self.previous_fit.metadata.stan_vars_dims[var],
-                    self.previous_fit.metadata.stan_vars_cols[var],
-                    0,
+                    self.previous_fit._metadata.stan_vars[var],
                     self.previous_fit.draws(inc_warmup=inc_warmup),
-                    self.previous_fit._metadata.stan_vars_types[var],
                 )
 
         return xr.Dataset(data, coords=coordinates, attrs=attrs).transpose(
@@ -545,13 +542,13 @@ class CmdStanGQ(Generic[Fit]):
         the next M are from chain 2, and the last M elements are from chain N.
 
         * If the variable is a scalar variable, the return array has shape
-          ( draws X chains, 1).
+          ( draws * chains, 1).
         * If the variable is a vector, the return array has shape
-          ( draws X chains, len(vector))
+          ( draws * chains, len(vector))
         * If the variable is a matrix, the return array has shape
-          ( draws X chains, size(dim 1) X size(dim 2) )
+          ( draws * chains, size(dim 1), size(dim 2) )
         * If the variable is an array with N dimensions, the return array
-          has shape ( draws X chains, size(dim 1) X ... X size(dim N))
+          has shape ( draws * chains, size(dim 1), ..., size(dim N))
 
         For example, if the Stan program variable ``theta`` is a 3x3 matrix,
         and the sample consists of 4 chains with 1000 post-warmup draws,
@@ -573,8 +570,8 @@ class CmdStanGQ(Generic[Fit]):
         CmdStanMLE.stan_variable
         CmdStanVB.stan_variable
         """
-        model_var_names = self.previous_fit.metadata.stan_vars_cols.keys()
-        gq_var_names = self.metadata.stan_vars_cols.keys()
+        model_var_names = self.previous_fit._metadata.stan_vars.keys()
+        gq_var_names = self._metadata.stan_vars.keys()
         if not (var in model_var_names or var in gq_var_names):
             raise ValueError(
                 f'Unknown variable name: {var}\n'
@@ -601,17 +598,11 @@ class CmdStanGQ(Generic[Fit]):
 
         # is gq variable
         self._assemble_generated_quantities()
-        draw1, num_draws = self._draws_start(inc_warmup)
-        dims = (num_draws * self.chains,)
-        col_idxs = self._metadata.stan_vars_cols[var]
 
-        return extract_reshape(
-            dims=dims + self._metadata.stan_vars_dims[var],
-            col_idxs=col_idxs,
-            var_type=self._metadata.stan_vars_types[var],
-            start_row=draw1,
-            draws_in=self._draws,
-        )
+        draw1, _ = self._draws_start(inc_warmup)
+        draws = flatten_chains(self._draws[draw1:])
+        out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(draws)
+        return out
 
     def stan_variables(self, inc_warmup: bool = False) -> Dict[str, np.ndarray]:
         """
@@ -630,8 +621,8 @@ class CmdStanGQ(Generic[Fit]):
         CmdStanVB.stan_variables
         """
         result = {}
-        sample_var_names = self.previous_fit.metadata.stan_vars_cols.keys()
-        gq_var_names = self.metadata.stan_vars_cols.keys()
+        sample_var_names = self.previous_fit.metadata.stan_vars.keys()
+        gq_var_names = self.metadata.stan_vars.keys()
         for name in gq_var_names:
             result[name] = self.stan_variable(name, inc_warmup)
         for name in sample_var_names:
@@ -697,9 +688,9 @@ class CmdStanGQ(Generic[Fit]):
             if inc_warmup and p_fit._save_iterations:
                 return p_fit.optimized_iterations_np[:, None]  # type: ignore
 
-            return np.atleast_2d(p_fit.optimized_params_np,)[  # type: ignore
-                :, None
-            ]
+            return np.atleast_2d(  # type: ignore
+                p_fit.optimized_params_np,
+            )[:, None]
         else:  # CmdStanVB:
             if inc_warmup:
                 return np.vstack(

--- a/cmdstanpy/stanfit/laplace.py
+++ b/cmdstanpy/stanfit/laplace.py
@@ -24,7 +24,7 @@ except ImportError:
     XARRAY_INSTALLED = False
 
 from cmdstanpy.cmdstan_args import Method
-from cmdstanpy.utils.data_munging import build_xarray_data, extract_reshape
+from cmdstanpy.utils.data_munging import build_xarray_data
 from cmdstanpy.utils.stancsv import scan_laplace_csv
 
 from .metadata import InferenceMetadata
@@ -85,16 +85,18 @@ class CmdStanLaplace:
         CmdStanGQ.stan_variable
         """
         self._assemble_draws()
-        draws = self._draws
-        dims = (draws.shape[0],)
-        col_idxs = self._metadata.stan_vars_cols[var]
-        return extract_reshape(
-            dims=dims + self._metadata.stan_vars_dims[var],
-            col_idxs=col_idxs,
-            var_type=self._metadata.stan_vars_types[var],
-            start_row=0,
-            draws_in=draws,
-        )
+        try:
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                self._draws
+            )
+            return out
+        except KeyError:
+            # pylint: disable=raise-missing-from
+            raise ValueError(
+                f'Unknown variable name: {var}\n'
+                'Available variables are '
+                + ", ".join(self._metadata.stan_vars.keys())
+            )
 
     def stan_variables(self) -> Dict[str, np.ndarray]:
         """
@@ -113,7 +115,7 @@ class CmdStanLaplace:
         CmdStanVB.stan_variables
         """
         result = {}
-        for name in self._metadata.stan_vars_dims.keys():
+        for name in self._metadata.stan_vars:
             result[name] = self.stan_variable(name)
         return result
 
@@ -125,11 +127,11 @@ class CmdStanLaplace:
         Maps each column name to a numpy.ndarray (draws x chains x 1)
         containing per-draw diagnostic values.
         """
-        result = {}
         self._assemble_draws()
-        for name, idxs in self._metadata.method_vars_cols.items():
-            result[name] = self._draws[..., idxs[0]]
-        return result
+        return {
+            name: var.extract_reshape(self._draws)
+            for name, var in self._metadata.method_vars.items()
+        }
 
     def draws(self) -> np.ndarray:
         """
@@ -154,16 +156,16 @@ class CmdStanLaplace:
         cols = []
         if vars is not None:
             for var in dict.fromkeys(vars_list):
-                if (
-                    var not in self._metadata.method_vars_cols
-                    and var not in self._metadata.stan_vars_cols
-                ):
-                    raise ValueError('Unknown variable: {}'.format(var))
-                if var in self._metadata.method_vars_cols:
+                if var in self._metadata.method_vars:
                     cols.append(var)
+                elif var in self._metadata.stan_vars:
+                    info = self._metadata.stan_vars[var]
+                    cols.extend(
+                        self.column_names[info.start_idx : info.end_idx]
+                    )
                 else:
-                    for idx in self._metadata.stan_vars_cols[var]:
-                        cols.append(self.column_names[idx])
+                    raise ValueError(f'Unknown variable: {var}')
+
         else:
             cols = list(self.column_names)
 
@@ -189,7 +191,7 @@ class CmdStanLaplace:
             )
 
         if vars is None:
-            vars_list = list(self._metadata.stan_vars_cols.keys())
+            vars_list = list(self._metadata.stan_vars.keys())
         elif isinstance(vars, str):
             vars_list = [vars]
         else:
@@ -212,12 +214,8 @@ class CmdStanLaplace:
         for var in vars_list:
             build_xarray_data(
                 data,
-                var,
-                self._metadata.stan_vars_dims[var],
-                self._metadata.stan_vars_cols[var],
-                0,
+                self._metadata.stan_vars[var],
                 self._draws[:, np.newaxis, :],
-                self._metadata.stan_vars_types[var],
             )
         return (
             xr.Dataset(data, coords=coordinates, attrs=attrs)

--- a/cmdstanpy/stanfit/laplace.py
+++ b/cmdstanpy/stanfit/laplace.py
@@ -231,6 +231,13 @@ class CmdStanLaplace:
         """
         return self._mode
 
+    @property
+    def metadata(self) -> InferenceMetadata:
+        """
+        Return the inference metadata as an :class:`InferenceMetadata` object.
+        """
+        return self._metadata
+
     def __repr__(self) -> str:
         mode = '\n'.join(
             ['\t' + line for line in repr(self.mode).splitlines()]

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -351,7 +351,7 @@ class CmdStanMCMC:
         """
         if np.any(self._divergences) or np.any(self._max_treedepths):
             diagnostics = ['Some chains may have failed to converge.']
-            ct_iters = self.metadata.cmdstan_config['num_samples']
+            ct_iters = self._metadata.cmdstan_config['num_samples']
             for i in range(self.runset._chains):
                 if self._divergences[i] > 0:
                     diagnostics.append(
@@ -668,7 +668,7 @@ class CmdStanMCMC:
                 ' must run sampler with "save_warmup=True".'
             )
         if vars is None:
-            vars_list = list(self.metadata.stan_vars.keys())
+            vars_list = list(self._metadata.stan_vars.keys())
         elif isinstance(vars, str):
             vars_list = [vars]
         else:
@@ -792,7 +792,7 @@ class CmdStanMCMC:
         self._assemble_draws()
         return {
             name: var.extract_reshape(self._draws)
-            for name, var in self.metadata.method_vars.items()
+            for name, var in self._metadata.method_vars.items()
         }
 
     def save_csvfiles(self, dir: Optional[str] = None) -> None:

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -40,7 +40,6 @@ from cmdstanpy.utils import (
     flatten_chains,
     get_logger,
 )
-from cmdstanpy.utils.data_munging import extract_reshape
 
 from .metadata import InferenceMetadata
 from .runset import RunSet
@@ -602,16 +601,15 @@ class CmdStanMCMC:
         cols = []
         if vars is not None:
             for var in dict.fromkeys(vars_list):
-                if (
-                    var not in self.metadata.method_vars_cols
-                    and var not in self.metadata.stan_vars_cols
-                ):
-                    raise ValueError('Unknown variable: {}'.format(var))
-                if var in self.metadata.method_vars_cols:
+                if var in self._metadata.method_vars:
                     cols.append(var)
+                elif var in self._metadata.stan_vars:
+                    info = self._metadata.stan_vars[var]
+                    cols.extend(
+                        self.column_names[info.start_idx : info.end_idx]
+                    )
                 else:
-                    for idx in self.metadata.stan_vars_cols[var]:
-                        cols.append(self.column_names[idx])
+                    raise ValueError(f'Unknown variable: {var}')
         else:
             cols = list(self.column_names)
 
@@ -670,7 +668,7 @@ class CmdStanMCMC:
                 ' must run sampler with "save_warmup=True".'
             )
         if vars is None:
-            vars_list = list(self.metadata.stan_vars_cols.keys())
+            vars_list = list(self.metadata.stan_vars.keys())
         elif isinstance(vars, str):
             vars_list = [vars]
         else:
@@ -699,12 +697,8 @@ class CmdStanMCMC:
         for var in vars_list:
             build_xarray_data(
                 data,
-                var,
-                self._metadata.stan_vars_dims[var],
-                self._metadata.stan_vars_cols[var],
-                0,
+                self._metadata.stan_vars[var],
                 self.draws(inc_warmup=inc_warmup),
-                self._metadata.stan_vars_types[var],
             )
         return xr.Dataset(data, coords=coordinates, attrs=attrs).transpose(
             'chain', 'draw', ...
@@ -728,13 +722,13 @@ class CmdStanMCMC:
         the next M are from chain 2, and the last M elements are from chain N.
 
         * If the variable is a scalar variable, the return array has shape
-          ( draws X chains, 1).
+          ( draws * chains, 1).
         * If the variable is a vector, the return array has shape
-          ( draws X chains, len(vector))
+          ( draws * chains, len(vector))
         * If the variable is a matrix, the return array has shape
-          ( draws X chains, size(dim 1) X size(dim 2) )
+          ( draws * chains, size(dim 1), size(dim 2) )
         * If the variable is an array with N dimensions, the return array
-          has shape ( draws X chains, size(dim 1) X ... X size(dim N))
+          has shape ( draws * chains, size(dim 1), ..., size(dim N))
 
         For example, if the Stan program variable ``theta`` is a 3x3 matrix,
         and the sample consists of 4 chains with 1000 post-warmup draws,
@@ -756,24 +750,19 @@ class CmdStanMCMC:
         CmdStanVB.stan_variable
         CmdStanGQ.stan_variable
         """
-        if var not in self._metadata.stan_vars_dims:
+        try:
+            draws = self.draws(inc_warmup=inc_warmup, concat_chains=True)
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                draws
+            )
+            return out
+        except KeyError:
+            # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
                 'Available variables are '
-                + ", ".join(self._metadata.stan_vars_dims)
+                + ", ".join(self._metadata.stan_vars.keys())
             )
-
-        draws = self.draws(inc_warmup=inc_warmup)
-        dims = (draws.shape[0] * self.chains,)
-        col_idxs = self._metadata.stan_vars_cols[var]
-
-        return extract_reshape(
-            dims=dims + self._metadata.stan_vars_dims[var],
-            col_idxs=col_idxs,
-            var_type=self._metadata.stan_vars_types[var],
-            start_row=0,
-            draws_in=draws,
-        )
 
     def stan_variables(self) -> Dict[str, np.ndarray]:
         """
@@ -788,7 +777,7 @@ class CmdStanMCMC:
         CmdStanGQ.stan_variables
         """
         result = {}
-        for name in self._metadata.stan_vars_dims.keys():
+        for name in self._metadata.stan_vars:
             result[name] = self.stan_variable(name)
         return result
 
@@ -800,12 +789,11 @@ class CmdStanMCMC:
         Maps each column name to a numpy.ndarray (draws x chains x 1)
         containing per-draw diagnostic values.
         """
-        result = {}
         self._assemble_draws()
-        for idxs in self.metadata.method_vars_cols.values():
-            for idx in idxs:
-                result[self.column_names[idx]] = self._draws[:, :, idx]
-        return result
+        return {
+            name: var.extract_reshape(self._draws)
+            for name, var in self.metadata.method_vars.items()
+        }
 
     def save_csvfiles(self, dir: Optional[str] = None) -> None:
         """

--- a/cmdstanpy/stanfit/metadata.py
+++ b/cmdstanpy/stanfit/metadata.py
@@ -47,4 +47,7 @@ class InferenceMetadata:
 
     @property
     def stan_vars(self) -> Dict[str, stanio.Variable]:
+        """
+        These are the user-defined variables in the Stan program.
+        """
         return self._stan_vars

--- a/cmdstanpy/stanfit/metadata.py
+++ b/cmdstanpy/stanfit/metadata.py
@@ -1,9 +1,9 @@
 """Container for metadata parsed from the output of a CmdStan run"""
 
 import copy
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
-from cmdstanpy.utils import BaseType, parse_method_vars, parse_stan_vars
+import stanio
 
 
 class InferenceMetadata:
@@ -16,13 +16,14 @@ class InferenceMetadata:
     def __init__(self, config: Dict[str, Any]) -> None:
         """Initialize object from CSV headers"""
         self._cmdstan_config = config
-        self._method_vars_cols = parse_method_vars(names=config['column_names'])
-        stan_vars_dims, stan_vars_cols, stan_vars_types = parse_stan_vars(
-            names=config['column_names']
-        )
-        self._stan_vars_dims = stan_vars_dims
-        self._stan_vars_cols = stan_vars_cols
-        self._stan_vars_types = stan_vars_types
+        vars = stanio.parse_header(config['raw_header'])
+
+        self._method_vars = {
+            k: v for (k, v) in vars.items() if k.endswith('__')
+        }
+        self._stan_vars = {
+            k: v for (k, v) in vars.items() if not k.endswith('__')
+        }
 
     def __repr__(self) -> str:
         return 'Metadata:\n{}\n'.format(self._cmdstan_config)
@@ -38,40 +39,12 @@ class InferenceMetadata:
         return copy.deepcopy(self._cmdstan_config)
 
     @property
-    def method_vars_cols(self) -> Dict[str, Tuple[int, ...]]:
+    def method_vars(self) -> Dict[str, stanio.Parameter]:
         """
-        Returns a map from a Stan inference method variable to
-        a tuple of column indices in inference engine's output array.
         Method variable names always end in `__`, e.g. `lp__`.
-        Uses deepcopy for immutability.
         """
-        return copy.deepcopy(self._method_vars_cols)
+        return self._method_vars
 
     @property
-    def stan_vars_cols(self) -> Dict[str, Tuple[int, ...]]:
-        """
-        Returns a map from a Stan program variable name to a
-        tuple of the column indices in the vector or matrix of
-        estimates produced by a CmdStan inference method.
-        Uses deepcopy for immutability.
-        """
-        return copy.deepcopy(self._stan_vars_cols)
-
-    @property
-    def stan_vars_dims(self) -> Dict[str, Tuple[int, ...]]:
-        """
-        Returns map from Stan program variable names to variable dimensions.
-        Scalar types are mapped to the empty tuple, e.g.,
-        program variable ``int foo`` has dimension ``()`` and
-        program variable ``vector[10] bar`` has single dimension ``(10)``.
-        Uses deepcopy for immutability.
-        """
-        return copy.deepcopy(self._stan_vars_dims)
-
-    @property
-    def stan_vars_types(self) -> Dict[str, BaseType]:
-        """
-        Returns map from Stan program variable names to variable base type.
-        Uses deepcopy for immutability.
-        """
-        return copy.deepcopy(self._stan_vars_types)
+    def stan_vars(self) -> Dict[str, stanio.Parameter]:
+        return self._stan_vars

--- a/cmdstanpy/stanfit/metadata.py
+++ b/cmdstanpy/stanfit/metadata.py
@@ -39,12 +39,12 @@ class InferenceMetadata:
         return copy.deepcopy(self._cmdstan_config)
 
     @property
-    def method_vars(self) -> Dict[str, stanio.Parameter]:
+    def method_vars(self) -> Dict[str, stanio.Variable]:
         """
         Method variable names always end in `__`, e.g. `lp__`.
         """
         return self._method_vars
 
     @property
-    def stan_vars(self) -> Dict[str, stanio.Parameter]:
+    def stan_vars(self) -> Dict[str, stanio.Variable]:
         return self._stan_vars

--- a/cmdstanpy/stanfit/mle.py
+++ b/cmdstanpy/stanfit/mle.py
@@ -209,11 +209,11 @@ class CmdStanMLE:
         if inc_iterations and self._save_iterations:
             data = self._all_iters
         else:
-            data = np.atleast_2d(self._mle)
+            data = self._mle
 
         try:
-            out: np.ndarray = (
-                self._metadata.stan_vars[var].extract_reshape(data).squeeze()
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                data
             )
             return out
         except KeyError:

--- a/cmdstanpy/stanfit/mle.py
+++ b/cmdstanpy/stanfit/mle.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from cmdstanpy.cmdstan_args import Method, OptimizeArgs
-from cmdstanpy.utils import BaseType, get_logger, scan_optimize_csv
+from cmdstanpy.utils import get_logger, scan_optimize_csv
 
 from .metadata import InferenceMetadata
 from .runset import RunSet
@@ -169,7 +169,7 @@ class CmdStanMLE:
         *,
         inc_iterations: bool = False,
         warn: bool = True,
-    ) -> Union[np.ndarray, float]:
+    ) -> np.ndarray:
         """
         Return a numpy.ndarray which contains the estimates for the
         for the named Stan program variable where the dimensions of the
@@ -192,11 +192,11 @@ class CmdStanMLE:
         CmdStanVB.stan_variable
         CmdStanGQ.stan_variable
         """
-        if var not in self._metadata.stan_vars_dims:
+        # TODO XXX replace with faster O(1) lookup for all usages
+        if var not in self._metadata.stan_vars:
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are '
-                + ", ".join(self._metadata.stan_vars_dims)
+                'Available variables are ' + ", ".join(self._metadata.stan_vars)
             )
         if warn and inc_iterations and not self._save_iterations:
             get_logger().warning(
@@ -207,40 +207,27 @@ class CmdStanMLE:
             get_logger().warning(
                 'Invalid estimate, optimization failed to converge.'
             )
-
-        col_idxs = list(self._metadata.stan_vars_cols[var])
         if inc_iterations and self._save_iterations:
-            num_rows = self._all_iters.shape[0]
+            data = self._all_iters
         else:
-            num_rows = 1
+            data = np.atleast_2d(self._mle)
 
-        if len(col_idxs) > 1:  # container var
-            dims = (num_rows,) + self._metadata.stan_vars_dims[var]
-            # pylint: disable=redundant-keyword-arg
-            if num_rows > 1:
-                result = self._all_iters[:, col_idxs]
-            else:
-                result = self._mle[col_idxs]
-                dims = dims[1:]
-
-            if self._metadata.stan_vars_types[var] == BaseType.COMPLEX:
-                result = result[..., ::2] + 1j * result[..., 1::2]
-                dims = dims[:-1]
-
-            result = result.reshape(dims, order='F')
-
-            return result
-
-        else:  # scalar var
-            col_idx = col_idxs[0]
-            if num_rows > 1:
-                return self._all_iters[:, col_idx]
-            else:
-                return float(self._mle[col_idx])
+        try:
+            out: np.ndarray = (
+                self._metadata.stan_vars[var].extract_reshape(data).squeeze()
+            )
+            return out
+        except KeyError:
+            # pylint: disable=raise-missing-from
+            raise ValueError(
+                f'Unknown variable name: {var}\n'
+                'Available variables are '
+                + ", ".join(self._metadata.stan_vars.keys())
+            )
 
     def stan_variables(
         self, inc_iterations: bool = False
-    ) -> Dict[str, Union[np.ndarray, float]]:
+    ) -> Dict[str, np.ndarray]:
         """
         Return a dictionary mapping Stan program variables names
         to the corresponding numpy.ndarray containing the inferred values.
@@ -263,7 +250,7 @@ class CmdStanMLE:
                 'Invalid estimate, optimization failed to converge.'
             )
         result = {}
-        for name in self._metadata.stan_vars_dims.keys():
+        for name in self._metadata.stan_vars:
             result[name] = self.stan_variable(
                 name, inc_iterations=inc_iterations, warn=False
             )

--- a/cmdstanpy/stanfit/mle.py
+++ b/cmdstanpy/stanfit/mle.py
@@ -192,7 +192,6 @@ class CmdStanMLE:
         CmdStanVB.stan_variable
         CmdStanGQ.stan_variable
         """
-        # TODO XXX replace with faster O(1) lookup for all usages
         if var not in self._metadata.stan_vars:
             raise ValueError(
                 f'Unknown variable name: {var}\n'

--- a/cmdstanpy/stanfit/vb.py
+++ b/cmdstanpy/stanfit/vb.py
@@ -117,7 +117,9 @@ class CmdStanVB:
         """
         Return a numpy.ndarray which contains the estimates for the
         for the named Stan program variable where the dimensions of the
-        numpy.ndarray match the shape of the Stan program variable.
+        numpy.ndarray match the shape of the Stan program variable, with
+        a leading axis added for the number of draws from the variational
+        approximation.
 
         This functionaltiy is also available via a shortcut using ``.`` -
         writing ``fit.a`` is a synonym for ``fit.stan_variable("a")``

--- a/cmdstanpy/stanfit/vb.py
+++ b/cmdstanpy/stanfit/vb.py
@@ -121,6 +121,15 @@ class CmdStanVB:
         a leading axis added for the number of draws from the variational
         approximation.
 
+        * If the variable is a scalar variable, the return array has shape
+          ( draws, ).
+        * If the variable is a vector, the return array has shape
+          ( draws, len(vector))
+        * If the variable is a matrix, the return array has shape
+          ( draws, size(dim 1), size(dim 2) )
+        * If the variable is an array with N dimensions, the return array
+          has shape ( draws, size(dim 1), ..., size(dim N))
+
         This functionaltiy is also available via a shortcut using ``.`` -
         writing ``fit.a`` is a synonym for ``fit.stan_variable("a")``
 

--- a/cmdstanpy/utils/__init__.py
+++ b/cmdstanpy/utils/__init__.py
@@ -31,11 +31,8 @@ from .filesystem import (
 from .json import write_stan_json
 from .logging import get_logger
 from .stancsv import (
-    BaseType,
     check_sampler_csv,
-    parse_method_vars,
     parse_rdump_value,
-    parse_stan_vars,
     read_metric,
     rload,
     scan_column_names,
@@ -114,7 +111,6 @@ def show_versions(output: bool = True) -> str:
 
 
 __all__ = [
-    'BaseType',
     'EXTENSION',
     'MaybeDictToFilePath',
     'SanitizedOrTmpFilePath',
@@ -130,9 +126,7 @@ __all__ = [
     'get_latest_cmdstan',
     'get_logger',
     'install_cmdstan',
-    'parse_method_vars',
     'parse_rdump_value',
-    'parse_stan_vars',
     'pushd',
     'read_metric',
     'returncode_msg',

--- a/cmdstanpy/utils/data_munging.py
+++ b/cmdstanpy/utils/data_munging.py
@@ -4,8 +4,7 @@ Common functions for reshaping numpy arrays
 from typing import Hashable, MutableMapping, Tuple
 
 import numpy as np
-
-from .stancsv import BaseType
+import stanio
 
 
 def flatten_chains(draws_array: np.ndarray) -> np.ndarray:
@@ -29,64 +28,17 @@ def flatten_chains(draws_array: np.ndarray) -> np.ndarray:
 
 def build_xarray_data(
     data: MutableMapping[Hashable, Tuple[Tuple[str, ...], np.ndarray]],
-    var_name: str,
-    dims: Tuple[int, ...],
-    col_idxs: Tuple[int, ...],
-    start_row: int,
+    var: stanio.Parameter,
     drawset: np.ndarray,
-    var_type: BaseType,
 ) -> None:
     """
     Adds Stan variable name, labels, and values to a dictionary
     that will be used to construct an xarray DataSet.
     """
     var_dims: Tuple[str, ...] = ('draw', 'chain')
-    if dims:
-        var_dims += tuple(f"{var_name}_dim_{i}" for i in range(len(dims)))
+    var_dims += tuple(f"{var.name}_dim_{i}" for i in range(len(var.dimensions)))
 
-        draws = drawset[start_row:, :, col_idxs]
-
-        if var_type == BaseType.COMPLEX:
-            draws = draws[..., ::2] + 1j * draws[..., 1::2]
-            var_dims = var_dims[:-1]
-            dims = dims[:-1]
-
-        draws = draws.reshape(*drawset.shape[:2], *dims, order="F")
-
-        data[var_name] = (
-            var_dims,
-            draws,
-        )
-
-    else:
-        data[var_name] = (
-            var_dims,
-            np.squeeze(drawset[start_row:, :, col_idxs], axis=2),
-        )
-
-
-def extract_reshape(
-    *,
-    dims: Tuple[int, ...],
-    col_idxs: Tuple[int, ...],
-    var_type: BaseType,
-    start_row: int,
-    draws_in: np.ndarray,
-) -> np.ndarray:
-    """
-    Helper to turn a draws table into a numpy array of draws.
-    Includes special handling for complex numbers.
-    """
-    # TODO also use in MLE, VB
-    if dims:
-        draws = draws_in[start_row:, ..., col_idxs]
-
-        if var_type == BaseType.COMPLEX:
-            draws = draws[..., ::2] + 1j * draws[..., 1::2]
-            dims = dims[:-1]
-
-        draws = draws.reshape(*dims, order="F")
-
-        return draws
-    else:
-        return np.squeeze(draws_in[start_row:, :, col_idxs], axis=2)
+    data[var.name] = (
+        var_dims,
+        var.extract_reshape(drawset),
+    )

--- a/cmdstanpy/utils/data_munging.py
+++ b/cmdstanpy/utils/data_munging.py
@@ -28,7 +28,7 @@ def flatten_chains(draws_array: np.ndarray) -> np.ndarray:
 
 def build_xarray_data(
     data: MutableMapping[Hashable, Tuple[Tuple[str, ...], np.ndarray]],
-    var: stanio.Parameter,
+    var: stanio.Variable,
     drawset: np.ndarray,
 ) -> None:
     """

--- a/cmdstanpy/utils/filesystem.py
+++ b/cmdstanpy/utils/filesystem.py
@@ -173,6 +173,7 @@ class SanitizedOrTmpFilePath:
     """
     Context manager for tmpfiles, handles special characters in filepath.
     """
+
     UNIXISH_PATTERN = re.compile(r"[\s~]")
     WINDOWS_PATTERN = re.compile(r"\s")
 

--- a/cmdstanpy/utils/json.py
+++ b/cmdstanpy/utils/json.py
@@ -1,60 +1,6 @@
 """
-Utilities for writing Stan Json files
+Delegated to stanio - https://github.com/WardBrian/stanio
 """
-import json
-from typing import Any, Mapping
+from stanio import write_stan_json
 
-import numpy as np
-
-
-def process_dictionary(d: Mapping[str, Any]) -> Mapping[str, Any]:
-    return {k: process_value(v) for k, v in d.items()}
-
-
-# pylint: disable=too-many-return-statements
-def process_value(val: Any) -> Any:
-    if val is None:
-        return None
-    if isinstance(val, bool):  # stan uses 0, 1
-        return int(val)
-    if isinstance(val, complex):  # treat as 2-long array
-        return [val.real, val.imag]
-    if isinstance(val, dict):  # if a tuple was manually specified
-        return process_dictionary(val)
-    if isinstance(val, tuple):  # otherwise, turn a tuple into a dict
-        return dict(zip(range(1, len(val) + 1), map(process_value, val)))
-    if isinstance(val, list):
-        return [process_value(i) for i in val]
-    original_module = getattr(type(val), '__module__', '')
-    if (
-        'numpy' in original_module
-        or 'xarray' in original_module
-        or 'pandas' in original_module
-    ):
-        return process_value(np.asanyarray(val).tolist())
-
-    return val
-
-
-def write_stan_json(path: str, data: Mapping[str, Any]) -> None:
-    """
-    Dump a mapping of strings to data to a JSON file.
-
-    Values can be any numeric type, a boolean (converted to int),
-    or any collection compatible with :func:`numpy.asarray`, e.g a
-    :class:`pandas.Series`.
-
-    Produces a file compatible with the
-    `Json Format for Cmdstan
-    <https://mc-stan.org/docs/cmdstan-guide/json.html>`__
-
-    :param path: File path for the created json. Will be overwritten if
-        already in existence.
-
-    :param data: A mapping from strings to values. This can be a dictionary
-        or something more exotic like an :class:`xarray.Dataset`. This will be
-        copied before type conversion, not modified
-    """
-    with open(path, 'w') as fd:
-        for chunk in json.JSONEncoder().iterencode(process_dictionary(data)):
-            fd.write(chunk)
+__all__ = ['write_stan_json']

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -257,6 +257,23 @@ def scan_column_names(
     return lineno
 
 
+def munge_varname(name: str) -> str:
+    if '.' not in name and ':' not in name:
+        return name
+
+    tuple_parts = name.split(':')
+    print(tuple_parts)
+    for i, part in enumerate(tuple_parts):
+        if '.' not in part:
+            continue
+        part = part.replace('.', '[', 1)
+        part = part.replace('.', ',')
+        part += ']'
+        tuple_parts[i] = part
+
+    return '.'.join(tuple_parts)
+
+
 def munge_varnames(names: List[str]) -> List[str]:
     """
     Change formatting for indices of container var elements
@@ -265,14 +282,7 @@ def munge_varnames(names: List[str]) -> List[str]:
     """
     if names is None:
         raise ValueError('missing argument "names"')
-    result = []
-    for name in names:
-        if '.' not in name:
-            result.append(name)
-        else:
-            head, *rest = name.split('.')
-            result.append(''.join([head, '[', ','.join(rest), ']']))
-    return result
+    return [munge_varname(name) for name in names]
 
 
 def parse_method_vars(names: Tuple[str, ...]) -> Dict[str, Tuple[int, ...]]:
@@ -309,7 +319,7 @@ def parse_stan_vars(
     types_map: Dict[str, BaseType] = {}
     idxs = []
     dims: Union[List[str], List[int]]
-    for (idx, name) in enumerate(names):
+    for idx, name in enumerate(names):
         if name.endswith('real]') or name.endswith('imag]'):
             basetype = BaseType.COMPLEX
         else:

--- a/docsrc/api.rst
+++ b/docsrc/api.rst
@@ -62,6 +62,11 @@ CmdStanVB
 .. autoclass:: cmdstanpy.CmdStanVB
    :members:
 
+CmdStanLaplace
+==============
+
+.. autoclass:: cmdstanpy.CmdStanLaplace
+   :members:
 
 *********
 Functions

--- a/docsrc/users-guide/examples/MCMC Sampling.ipynb
+++ b/docsrc/users-guide/examples/MCMC Sampling.ipynb
@@ -1527,8 +1527,8 @@
     }
    ],
    "source": [
-    "print('sample method variables:\\n{}\\n'.format(fit.metadata.method_vars_cols.keys()))\n",
-    "print('stan model variables:\\n{}'.format(fit.metadata.stan_vars_cols.keys()))"
+    "print('sample method variables:\\n{}\\n'.format(fit.metadata.method_vars.keys()))\n",
+    "print('stan model variables:\\n{}'.format(fit.metadata.stan_vars.keys()))"
    ]
   },
   {

--- a/docsrc/users-guide/examples/VI as Sampler Inits.ipynb
+++ b/docsrc/users-guide/examples/VI as Sampler Inits.ipynb
@@ -64,7 +64,8 @@
     "The ADVI algorithm provides estimates of all model parameters.\n",
     "\n",
     "The `variational` method returns a `CmdStanVB` object, with method `stan_variables`, which\n",
-    "returns the approximate estimates of all model parameters as a Python dictionary."
+    "returns the approximat posterior samples of all model parameters as a Python dictionary. \n",
+    "Here, we report the approximate posterior mean."
    ]
   },
   {
@@ -73,7 +74,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(vb_fit.stan_variables())"
+    "vb_mean = {var: samples.mean(axis=0) for var, samples in vb_fit.stan_variables().items()}\n",
+    "print(vb_mean)"
    ]
   },
   {
@@ -93,9 +95,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vb_vars = vb_fit.stan_variables()\n",
     "mcmc_vb_inits_fit = model.sample(\n",
-    "    data=data_file, inits=vb_vars, iter_warmup=75, seed=12345\n",
+    "    data=data_file, inits=vb_mean, iter_warmup=75, seed=12345\n",
     ")"
    ]
   },

--- a/docsrc/users-guide/hello_world.rst
+++ b/docsrc/users-guide/hello_world.rst
@@ -162,7 +162,7 @@ The `CmdStanMCMC` object provides the following accessor methods:
     print(f'numpy.ndarray of draws: {fit.draws().shape}')
     fit.draws_pd()
 
-    
+
 In addition to the MCMC sample itself, the CmdStanMCMC object provides
 access to the the per-chain HMC tuning parameters from the NUTS-HMC adaptive sampler,
 (if present).
@@ -180,12 +180,6 @@ The CmdStanMCMC object also provides access to metadata about the model and the 
 
     print(fit.metadata.cmdstan_config['model'])
     print(fit.metadata.cmdstan_config['seed'])
-
-    print(fit.metadata.stan_vars_cols.keys())
-    print(fit.metadata.method_vars_cols.keys())
-
-
-
 
 
 CmdStan utilities:  ``stansummary``, ``diagnose``

--- a/docsrc/users-guide/workflow.rst
+++ b/docsrc/users-guide/workflow.rst
@@ -165,31 +165,6 @@ and the location of all output files produced.
 The provide a common set methods for accessing the inference results and metadata,
 as well as method-specific informational properties and methods.objects
 
-Metadata
---------
-
-By `metadata` we mean the information parsed from the header comments and header row of the
-`Stan CSV files <https://mc-stan.org/docs/cmdstan-guide/stan-csv.html>`_
-into a :class:`InferenceMetadata` object which is exposed via
-the object's :attr:`~CmdStanMCMC.metadata` property.
-
-* The metadata :attr:`~InferenceMetadata.cmdstan_config`
-  property provides the CmdStan configuration information parsed out
-  of the Stan CSV file header.
-
-* The metadata :attr:`~InferenceMetadata.method_vars_cols`
-  property returns the names, column indices of the inference engine method variables,
-  e.g.,
-  `the NUTS-HMC sampler output variables <https://mc-stan.org/docs/cmdstan-guide/mcmc-intro.html#mcmc_output_csv>`_
-  are ``lp__``, ..., ``energy__``.
-
-* The metadata :attr:`~InferenceMetadata.stan_vars_cols`
-  property returns the names, column indices of all Stan model variables.
-  Container variables will span as many columns, one column per element.
-
-* The metadata :attr:`~InferenceMetadata.stan_vars_dims`
-  property specifies the names, dimensions of the Stan model variables.
-
 Output data
 -----------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 numpy>=1.21
 tqdm
+stanio~=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 numpy>=1.21
 tqdm
-stanio~=0.1.0
+stanio~=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
         ]
     },
     install_requires=INSTALL_REQUIRES,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     extras_require=EXTRAS_REQUIRE,
     classifiers=_classifiers.strip().split('\n'),
 )

--- a/test/data/bernoulli with space in name.stan
+++ b/test/data/bernoulli with space in name.stan
@@ -1,12 +1,13 @@
 data {
   int<lower=0> N;
-  int<lower=0,upper=1> y[N];
+  array[N] int<lower=0, upper=1> y;
 }
 parameters {
-  real<lower=0,upper=1> theta;
+  real<lower=0, upper=1> theta;
 }
 model {
-  theta ~ beta(1,1);
-  for (n in 1:N)
+  theta ~ beta(1, 1);
+  for (n in 1 : N) 
     y[n] ~ bernoulli(theta);
 }
+

--- a/test/data/bernoulli_include.stan
+++ b/test/data/bernoulli_include.stan
@@ -3,7 +3,7 @@ functions {
 }
 data {
   int<lower=0> N;
-  int<lower=0,upper=1> y[N];
+  array[N] int<lower=0,upper=1> y;
 }
 parameters {
   real<lower=0,upper=1> theta;

--- a/test/data/path with space/bernoulli_path_with_space.stan
+++ b/test/data/path with space/bernoulli_path_with_space.stan
@@ -5,9 +5,10 @@ data {
 parameters {
   real<lower=0, upper=1> theta;
 }
+;
 model {
   theta ~ beta(1, 1);
-  for (n in 1 : N) 
+  for (n in 1 : N)
     y[n] ~ bernoulli(theta);
 }
 

--- a/test/data/path with space/bernoulli_path_with_space.stan
+++ b/test/data/path with space/bernoulli_path_with_space.stan
@@ -1,12 +1,13 @@
 data {
   int<lower=0> N;
-  int<lower=0,upper=1> y[N];
+  array[N] int<lower=0, upper=1> y;
 }
 parameters {
-  real<lower=0,upper=1> theta;
+  real<lower=0, upper=1> theta;
 }
 model {
-  theta ~ beta(1,1);
-  for (n in 1:N)
+  theta ~ beta(1, 1);
+  for (n in 1 : N) 
     y[n] ~ bernoulli(theta);
 }
+

--- a/test/data/path with space/bernoulli_path_with_space.stan
+++ b/test/data/path with space/bernoulli_path_with_space.stan
@@ -5,7 +5,6 @@ data {
 parameters {
   real<lower=0, upper=1> theta;
 }
-;
 model {
   theta ~ beta(1, 1);
   for (n in 1 : N)

--- a/test/data/path~with~tilde/bernoulli_path_with_tilde.stan
+++ b/test/data/path~with~tilde/bernoulli_path_with_tilde.stan
@@ -1,12 +1,13 @@
 data {
   int<lower=0> N;
-  int<lower=0,upper=1> y[N];
+  array[N] int<lower=0, upper=1> y;
 }
 parameters {
-  real<lower=0,upper=1> theta;
+  real<lower=0, upper=1> theta;
 }
 model {
-  theta ~ beta(1,1);
-  for (n in 1:N)
+  theta ~ beta(1, 1);
+  for (n in 1 : N) 
     y[n] ~ bernoulli(theta);
 }
+

--- a/test/data/timeout.stan
+++ b/test/data/timeout.stan
@@ -1,21 +1,19 @@
 data {
-    // Indicator for endless looping.
-    int loop;
+  // Indicator for endless looping.
+  int loop;
 }
-
 transformed data {
-    // Maybe loop forever so the model times out.
-    real y = 1;
-    while(loop && y) {
-        y += 1;
-    }
+  // Maybe loop forever so the model times out.
+  real y = 1;
+  while (loop && (y != 0.0)) {
+    y += 1;
+  }
 }
-
 parameters {
-    real x;
+  real x;
+}
+model {
+  // A nice model so we can get a fit for the `generated_quantities` call.
+  x ~ normal(0, 1);
 }
 
-model {
-    // A nice model so we can get a fit for the `generated_quantities` call.
-    x ~ normal(0, 1);
-}

--- a/test/data/tuple_data.stan
+++ b/test/data/tuple_data.stan
@@ -1,0 +1,8 @@
+data {
+  tuple(real, int, real) x;
+  array[3] tuple(real, matrix[4, 5]) y;
+}
+transformed data {
+  print("x: ", x);
+  print("y: ", y[1]);
+}

--- a/test/test_generate_quantities.py
+++ b/test/test_generate_quantities.py
@@ -254,9 +254,9 @@ def test_from_previous_fit_variables() -> None:
         bern_gqs.stan_variable(var='lp__')
 
     vars_dict = bern_gqs.stan_variables()
-    var_names = list(
-        bern_gqs.previous_fit.metadata.stan_vars_cols.keys()
-    ) + list(bern_gqs.metadata.stan_vars_cols.keys())
+    var_names = list(bern_gqs.previous_fit.metadata.stan_vars.keys()) + list(
+        bern_gqs.metadata.stan_vars.keys()
+    )
     assert set(var_names) == set(list(vars_dict.keys()))
 
 
@@ -329,9 +329,9 @@ def test_save_warmup(caplog: pytest.LogCaptureFixture) -> None:
         bern_gqs.stan_variable(var='lp__')
 
     vars_dict = bern_gqs.stan_variables()
-    var_names = list(
-        bern_gqs.previous_fit.metadata.stan_vars_cols.keys()
-    ) + list(bern_gqs.metadata.stan_vars_cols.keys())
+    var_names = list(bern_gqs.previous_fit.metadata.stan_vars.keys()) + list(
+        bern_gqs.metadata.stan_vars.keys()
+    )
     assert set(var_names) == set(list(vars_dict.keys()))
 
     xr_data = bern_gqs.draws_xr()
@@ -717,8 +717,7 @@ def test_from_vb():
 
     # stan_variable
     theta = bern_gqs.stan_variable(var='theta')
-    # VB behavior is weird: it draws from mean by default?
-    assert theta.shape == (1,)
+    assert theta.shape == (1000,)
     y_rep = bern_gqs.stan_variable(var='y_rep')
     assert y_rep.shape == (1000, 10)
 

--- a/test/test_laplace.py
+++ b/test/test_laplace.py
@@ -31,7 +31,7 @@ def test_laplace_runs_opt():
     assert isinstance(fit1.mode, cmdstanpy.CmdStanMLE)
 
     assert fit1.mode.metadata.cmdstan_config['seed'] == 1234
-    assert fit1._metadata.cmdstan_config['seed'] == 1234
+    assert fit1.metadata.cmdstan_config['seed'] == 1234
     assert fit1.mode.metadata.cmdstan_config['iter'] == 1003
 
 

--- a/test/test_log_prob.py
+++ b/test/test_log_prob.py
@@ -39,6 +39,6 @@ def test_lp_bad(
         (
             'cmdstanpy',
             'ERROR',
-            re.compile(r"(?s).*parameter theta not found.*"),
+            re.compile(r"(?s).*variable does not exist.*name=theta.*"),
         ),
     )

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -64,10 +64,7 @@ def test_good() -> None:
         'energy__',
     }
 
-    method_vars_cols = metadata.method_vars_cols
+    method_vars_cols = metadata.method_vars
     assert hmc_vars == method_vars_cols.keys()
     bern_model_vars = {'theta'}
-    assert bern_model_vars == metadata.stan_vars_dims.keys()
-    assert () == metadata.stan_vars_dims['theta']
-    assert bern_model_vars == metadata.stan_vars_cols.keys()
-    assert metadata.stan_vars_cols['theta'] == (7,)
+    assert bern_model_vars == metadata.stan_vars.keys()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -514,19 +514,11 @@ def test_model_format_deprecations() -> None:
 
     sys_stdout = io.StringIO()
     with contextlib.redirect_stdout(sys_stdout):
-        model.format()
+        model.format(canonicalize=True)
 
     formatted = sys_stdout.getvalue()
     assert "//" in formatted
     assert "#" not in formatted
-    assert formatted.count('(') == 5
-
-    sys_stdout = io.StringIO()
-    with contextlib.redirect_stdout(sys_stdout):
-        model.format(canonicalize=True)
-
-    formatted = sys_stdout.getvalue()
-    print(formatted)
     assert "<-" not in formatted
     assert formatted.count('(') == 0
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -137,7 +137,6 @@ def test_model_bad() -> None:
 
 
 def test_stanc_options() -> None:
-
     allowed_optims = ("", "0", "1", "experimental")
     for optim in allowed_optims:
         opts = {
@@ -323,8 +322,7 @@ def test_compile_force() -> None:
     model.compile(force=True, cpp_options=override_opts, override_options=True)
     info_dict3 = model.exe_info()
     assert info_dict3['STAN_THREADS'].lower() == 'false'
-    # cmdstan#1056
-    # assert info_dict3['STAN_NO_RANGE_CHECKS'].lower() == 'true'
+    assert info_dict3['STAN_NO_RANGE_CHECKS'].lower() == 'true'
 
     model.compile(force=True, cpp_options=more_opts)
     info_dict4 = model.exe_info()
@@ -436,8 +434,9 @@ def test_model_compile_special_char(path: str) -> None:
         bern_stan_new = os.path.join(
             path_with_special_char, os.path.split(BERN_STAN)[1]
         )
-        bern_exe_new = os.path.join(path_with_special_char,
-                                    os.path.split(BERN_EXE)[1])
+        bern_exe_new = os.path.join(
+            path_with_special_char, os.path.split(BERN_EXE)[1]
+        )
         shutil.copyfile(BERN_STAN, bern_stan_new)
         model = CmdStanModel(stan_file=bern_stan_new)
 
@@ -464,8 +463,9 @@ def test_model_includes_special_char(path: str) -> None:
     ) as tmp_path:
         path_with_special_char = os.path.join(tmp_path, path)
         os.makedirs(path_with_special_char, exist_ok=True)
-        bern_stan_new = os.path.join(path_with_special_char,
-                                     os.path.split(stan)[1])
+        bern_stan_new = os.path.join(
+            path_with_special_char, os.path.split(stan)[1]
+        )
         stan_divide_new = os.path.join(
             path_with_special_char, os.path.split(stan_divide)[1]
         )

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -197,11 +197,11 @@ def test_variable_bern() -> None:
         tol_param=1e-8,
         history_size=5,
     )
-    assert 1 == len(bern_mle.metadata.stan_vars_dims)
-    assert 'theta' in bern_mle.metadata.stan_vars_dims
-    assert bern_mle.metadata.stan_vars_dims['theta'] == ()
+    assert 1 == len(bern_mle.metadata.stan_vars)
+    assert 'theta' in bern_mle.metadata.stan_vars
+    assert bern_mle.metadata.stan_vars['theta'].dimensions == ()
     theta = bern_mle.stan_variable(var='theta')
-    assert isinstance(theta, float)
+    assert theta.shape == ()
     with pytest.raises(ValueError):
         bern_mle.stan_variable(var='eta')
     with pytest.raises(ValueError):
@@ -225,23 +225,23 @@ def test_variables_3d() -> None:
         tol_param=1e-8,
         history_size=5,
     )
-    assert 3 == len(multidim_mle.metadata.stan_vars_dims)
-    assert 'y_rep' in multidim_mle.metadata.stan_vars_dims
-    assert multidim_mle.metadata.stan_vars_dims['y_rep'] == (5, 4, 3)
+    assert 3 == len(multidim_mle.metadata.stan_vars)
+    assert 'y_rep' in multidim_mle.metadata.stan_vars
+    assert multidim_mle.metadata.stan_vars['y_rep'].dimensions == (5, 4, 3)
     var_y_rep = multidim_mle.stan_variable(var='y_rep')
     assert var_y_rep.shape == (5, 4, 3)
     var_beta = multidim_mle.stan_variable(var='beta')
-    assert var_beta.shape == (2,)  # 1-element tuple
+    assert var_beta.shape == (2,)
     var_frac_60 = multidim_mle.stan_variable(var='frac_60')
-    assert isinstance(var_frac_60, float)
+    assert var_frac_60.shape == ()
     vars = multidim_mle.stan_variables()
-    assert len(vars) == len(multidim_mle.metadata.stan_vars_dims)
+    assert len(vars) == len(multidim_mle.metadata.stan_vars)
     assert 'y_rep' in vars
     assert vars['y_rep'].shape == (5, 4, 3)
     assert 'beta' in vars
     assert vars['beta'].shape == (2,)
     assert 'frac_60' in vars
-    assert isinstance(vars['frac_60'], float)
+    assert vars['frac_60'].shape == ()
 
     multidim_mle_iters = multidim_model.optimize(
         data=jdata,
@@ -258,7 +258,7 @@ def test_variables_3d() -> None:
         save_iterations=True,
     )
     vars_iters = multidim_mle_iters.stan_variables(inc_iterations=True)
-    assert len(vars_iters) == len(multidim_mle_iters.metadata.stan_vars_dims)
+    assert len(vars_iters) == len(multidim_mle_iters.metadata.stan_vars)
     assert 'y_rep' in vars_iters
     assert vars_iters['y_rep'].shape == (8, 5, 4, 3)
     assert 'beta' in vars_iters
@@ -560,7 +560,7 @@ def test_single_row_csv() -> None:
     stan = os.path.join(DATAFILES_PATH, 'matrix_var.stan')
     model = CmdStanModel(stan_file=stan)
     mle = model.optimize()
-    assert isinstance(mle.stan_variable('theta'), float)
+    assert mle.stan_variable('theta').shape == ()
     z_as_ndarray = mle.stan_variable(var="z")
     assert z_as_ndarray.shape == (4, 3)
     for i in range(4):
@@ -621,7 +621,7 @@ def test_attrs() -> None:
 
     assert fit.a == 4.5
     assert fit.b.shape == (3,)
-    assert isinstance(fit.theta, float)
+    assert fit.theta.shape == ()
 
     assert fit.stan_variable('thin') == 3.5
 

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1938,6 +1938,24 @@ def test_json_edges() -> None:
     assert np.isinf(fit.stan_variable("inf_out")[0])
 
 
+def test_json_junk_alongside_data() -> None:
+    stan = os.path.join(DATAFILES_PATH, 'data-test.stan')
+    data_model = CmdStanModel(stan_file=stan)
+    data = {
+        "inf": float("inf"),
+        "nan": float("NaN"),
+        "_foo": "this should be harmless!",
+    }
+    data_model.sample(data, chains=1, iter_warmup=1, iter_sampling=1)
+
+
+def test_tuple_data_in() -> None:
+    stan = os.path.join(DATAFILES_PATH, 'tuple_data.stan')
+    data_model = CmdStanModel(stan_file=stan)
+    data = {"x": (1, 2, 3), 'y': [(i, np.random.randn(4, 5)) for i in range(3)]}
+    data_model.sample(data, chains=1, iter_warmup=1, iter_sampling=1)
+
+
 @pytest.mark.order(before="test_no_xarray")
 def test_serialization(stanfile='bernoulli.stan'):
     # This test must before any test that uses the `without_import` context

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -816,7 +816,7 @@ def test_validate_big_run() -> None:
     ]
     fit = CmdStanMCMC(runset)
     phis = ['phi[{}]'.format(str(x + 1)) for x in range(2095)]
-    column_names = list(fit.metadata.method_vars_cols.keys()) + phis
+    column_names = list(fit.metadata.method_vars.keys()) + phis
     assert fit.num_draws_sampling == 1000
     assert fit.column_names == tuple(column_names)
     assert fit.metric_type == 'diag_e'
@@ -1435,9 +1435,9 @@ def test_variable_bern() -> None:
     bern_fit = bern_model.sample(
         data=jdata, chains=2, seed=12345, iter_warmup=100, iter_sampling=100
     )
-    assert 1 == len(bern_fit.metadata.stan_vars_dims)
-    assert 'theta' in bern_fit.metadata.stan_vars_dims
-    assert bern_fit.metadata.stan_vars_dims['theta'] == ()
+    assert 1 == len(bern_fit.metadata.stan_vars)
+    assert 'theta' in bern_fit.metadata.stan_vars
+    assert bern_fit.metadata.stan_vars['theta'].dimensions == ()
     assert bern_fit.stan_variable(var='theta').shape == (200,)
     with pytest.raises(ValueError):
         bern_fit.stan_variable(var='eta')
@@ -1449,11 +1449,11 @@ def test_variables_2d() -> None:
     csvfiles_path = os.path.join(DATAFILES_PATH, 'lotka-volterra.csv')
     fit = from_csv(path=csvfiles_path)
     assert 20 == fit.num_draws_sampling
-    assert 8 == len(fit.metadata.stan_vars_dims)
-    assert 'z' in fit.metadata.stan_vars_dims
-    assert fit.metadata.stan_vars_dims['z'] == (20, 2)
+    assert 8 == len(fit.metadata.stan_vars)
+    assert 'z' in fit.metadata.stan_vars
+    assert fit.metadata.stan_vars['z'].dimensions == (20, 2)
     vars = fit.stan_variables()
-    assert len(vars) == len(fit.metadata.stan_vars_dims)
+    assert len(vars) == len(fit.metadata.stan_vars)
     assert 'z' in vars
     assert vars['z'].shape == (20, 20, 2)
     assert 'theta' in vars
@@ -1465,9 +1465,9 @@ def test_variables_3d() -> None:
     csvfiles_path = os.path.join(DATAFILES_PATH, 'multidim_vars.csv')
     fit = from_csv(path=csvfiles_path)
     assert 20 == fit.num_draws_sampling
-    assert 3 == len(fit.metadata.stan_vars_dims)
-    assert 'y_rep' in fit.metadata.stan_vars_dims
-    assert fit.metadata.stan_vars_dims['y_rep'] == (5, 4, 3)
+    assert 3 == len(fit.metadata.stan_vars)
+    assert 'y_rep' in fit.metadata.stan_vars
+    assert fit.metadata.stan_vars['y_rep'].dimensions == (5, 4, 3)
     var_y_rep = fit.stan_variable(var='y_rep')
     assert var_y_rep.shape == (20, 5, 4, 3)
     var_beta = fit.stan_variable(var='beta')
@@ -1475,7 +1475,7 @@ def test_variables_3d() -> None:
     var_frac_60 = fit.stan_variable(var='frac_60')
     assert var_frac_60.shape == (20,)
     vars = fit.stan_variables()
-    assert len(vars) == len(fit.metadata.stan_vars_dims)
+    assert len(vars) == len(fit.metadata.stan_vars)
     assert 'y_rep' in vars
     assert vars['y_rep'].shape == (20, 5, 4, 3)
     assert 'beta' in vars
@@ -1525,8 +1525,7 @@ def test_validate() -> None:
     assert bern_fit.num_draws_warmup == 100
     assert bern_fit.num_draws_sampling == 50
     assert len(bern_fit.column_names) == 8
-    assert len(bern_fit.metadata.stan_vars_dims) == 1
-    assert len(bern_fit.metadata.stan_vars_cols.keys()) == 1
+    assert len(bern_fit.metadata.stan_vars) == 1
     assert bern_fit.metric_type == 'diag_e'
 
 
@@ -1672,14 +1671,13 @@ def test_metadata() -> None:
     assert fit.metadata.cmdstan_config['metric'] == 'diag_e'
     np.testing.assert_almost_equal(fit.metadata.cmdstan_config['delta'], 0.80)
 
-    assert 'n_leapfrog__' in fit.metadata.method_vars_cols
-    assert 'energy__' in fit.metadata.method_vars_cols
-    assert 'beta' not in fit.metadata.method_vars_cols
-    assert 'energy__' not in fit.metadata.stan_vars_dims
-    assert 'beta' in fit.metadata.stan_vars_dims
-    assert 'beta' in fit.metadata.stan_vars_cols
-    assert fit.metadata.stan_vars_dims['beta'] == (2,)
-    assert fit.metadata.stan_vars_cols['beta'] == (7, 8)
+    assert 'n_leapfrog__' in fit.metadata.method_vars
+    assert 'energy__' in fit.metadata.method_vars
+    assert 'beta' not in fit.metadata.method_vars
+    assert 'energy__' not in fit.metadata.stan_vars
+    assert 'beta' in fit.metadata.stan_vars
+    assert fit.metadata.stan_vars['beta'].dimensions == (2,)
+    assert tuple(fit.metadata.stan_vars['beta'].columns()) == (7, 8)
 
 
 def test_save_latent_dynamics() -> None:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,5 @@
 """utils test"""
 
-import collections.abc
 import contextlib
 import io
 import json
@@ -18,7 +17,6 @@ from test import check_present, mark_windows_only, raises_nested
 from unittest import mock
 
 import numpy as np
-import pandas as pd
 import pytest
 
 from cmdstanpy import _DOT_CMDSTAN, _TMPDIR
@@ -26,7 +24,6 @@ from cmdstanpy.model import CmdStanModel
 from cmdstanpy.progress import _disable_progress, allow_show_progress
 from cmdstanpy.utils import (
     EXTENSION,
-    BaseType,
     MaybeDictToFilePath,
     SanitizedOrTmpFilePath,
     check_sampler_csv,
@@ -37,9 +34,7 @@ from cmdstanpy.utils import (
     flatten_chains,
     get_latest_cmdstan,
     install_cmdstan,
-    parse_method_vars,
     parse_rdump_value,
-    parse_stan_vars,
     pushd,
     read_metric,
     rload,
@@ -48,7 +43,6 @@ from cmdstanpy.utils import (
     validate_cmdstan_path,
     validate_dir,
     windows_short_path,
-    write_stan_json,
 )
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -262,148 +256,6 @@ def test_dict_to_file() -> None:
     with pytest.raises(ValueError):
         with MaybeDictToFilePath(123, dict_good) as (fg1, fg2):
             pass
-
-
-def test_write_stan_json() -> None:
-    def cmp(d1, d2):
-        assert d1.keys() == d2.keys()
-        for k in d1:
-            data_1 = d1[k]
-            data_2 = d2[k]
-            if isinstance(data_1, dict):
-                cmp(data_1, data_2)
-                continue
-
-            if isinstance(data_2, collections.abc.Collection):
-                data_2 = np.asarray(data_2).tolist()
-            # np properly handles NaN equality
-            np.testing.assert_equal(data_1, data_2)
-
-    dict_list = {'a': [1.0, 2.0, 3.0]}
-    file_list = os.path.join(_TMPDIR, 'list.json')
-    write_stan_json(file_list, dict_list)
-    with open(file_list) as fd:
-        cmp(json.load(fd), dict_list)
-
-    arr = np.repeat(3, 4)
-    dict_vec = {'a': arr}
-    file_vec = os.path.join(_TMPDIR, 'vec.json')
-    write_stan_json(file_vec, dict_vec)
-    with open(file_vec) as fd:
-        cmp(json.load(fd), dict_vec)
-
-    dict_bool = {'a': False}
-    file_bool = os.path.join(_TMPDIR, 'bool.json')
-    write_stan_json(file_bool, dict_bool)
-    with open(file_bool) as fd:
-        res = json.load(fd)
-        assert isinstance(res['a'], int)
-        assert not isinstance(res['a'], bool)
-        cmp(res, {'a': 0})
-
-    dict_none = {'a': None}
-    file_none = os.path.join(_TMPDIR, 'none.json')
-    write_stan_json(file_none, dict_none)
-    with open(file_none) as fd:
-        cmp(json.load(fd), dict_none)
-
-    series = pd.Series(arr)
-    dict_vec_pd = {'a': series}
-    file_vec_pd = os.path.join(_TMPDIR, 'vec_pd.json')
-    write_stan_json(file_vec_pd, dict_vec_pd)
-    with open(file_vec_pd) as fd:
-        cmp(json.load(fd), dict_vec_pd)
-
-    df_vec = pd.DataFrame(dict_list)
-    file_pd = os.path.join(_TMPDIR, 'pd.json')
-    write_stan_json(file_pd, df_vec)
-    with open(file_pd) as fd:
-        cmp(json.load(fd), dict_list)
-
-    dict_zero_vec = {'a': []}
-    file_zero_vec = os.path.join(_TMPDIR, 'empty_vec.json')
-    write_stan_json(file_zero_vec, dict_zero_vec)
-    with open(file_zero_vec) as fd:
-        cmp(json.load(fd), dict_zero_vec)
-
-    dict_zero_matrix = {'a': [[], [], []]}
-    file_zero_matrix = os.path.join(_TMPDIR, 'empty_matrix.json')
-    write_stan_json(file_zero_matrix, dict_zero_matrix)
-    with open(file_zero_matrix) as fd:
-        cmp(json.load(fd), dict_zero_matrix)
-
-    arr = np.zeros(shape=(5, 0))
-    dict_zero_matrix = {'a': arr}
-    file_zero_matrix = os.path.join(_TMPDIR, 'empty_matrix.json')
-    write_stan_json(file_zero_matrix, dict_zero_matrix)
-    with open(file_zero_matrix) as fd:
-        cmp(json.load(fd), dict_zero_matrix)
-
-    arr = np.zeros(shape=(2, 3, 4))
-    assert isinstance(arr, np.ndarray)
-    assert arr.shape == (2, 3, 4)
-
-    dict_3d_matrix = {'a': arr}
-    file_3d_matrix = os.path.join(_TMPDIR, '3d_matrix.json')
-    write_stan_json(file_3d_matrix, dict_3d_matrix)
-    with open(file_3d_matrix) as fd:
-        cmp(json.load(fd), dict_3d_matrix)
-
-    scalr = np.int32(1)
-    assert type(scalr).__module__ == 'numpy'
-    dict_scalr = {'a': scalr}
-    file_scalr = os.path.join(_TMPDIR, 'scalr.json')
-    write_stan_json(file_scalr, dict_scalr)
-    with open(file_scalr) as fd:
-        cmp(json.load(fd), dict_scalr)
-
-    # custom Stan serialization
-    dict_inf_nan = {
-        'a': np.array(
-            [
-                [-np.inf, np.inf, np.NaN],
-                [-float('inf'), float('inf'), float('NaN')],
-                [
-                    np.float32(-np.inf),
-                    np.float32(np.inf),
-                    np.float32(np.NaN),
-                ],
-                [1e200 * -1e200, 1e220 * 1e200, -np.nan],
-            ]
-        )
-    }
-    dict_inf_nan_exp = {'a': [[-np.inf, np.inf, np.nan]] * 4}
-    file_fin = os.path.join(_TMPDIR, 'inf.json')
-    write_stan_json(file_fin, dict_inf_nan)
-    with open(file_fin) as fd:
-        cmp(
-            json.load(fd),
-            dict_inf_nan_exp,
-        )
-
-    dict_complex = {'a': np.array([np.complex64(3), 3 + 4j])}
-    dict_complex_exp = {'a': [[3, 0], [3, 4]]}
-    file_complex = os.path.join(_TMPDIR, 'complex.json')
-    write_stan_json(file_complex, dict_complex)
-    with open(file_complex) as fd:
-        cmp(json.load(fd), dict_complex_exp)
-
-    dict_tuples = {
-        'a': (1, 2, 3),
-        'b': [(1, [2, 3]), (4, [5, 6])],
-        'c': ((1, np.array([1, 2.0, 3])), (3, np.array([1, 2, 3]))),
-        'm': {'1': 1, '2': [2, 3]},
-    }
-    dict_tuple_exp = {
-        "a": {"1": 1, "2": 2, "3": 3},
-        "b": [{"1": 1, "2": [2, 3]}, {"1": 4, "2": [5, 6]}],
-        "c": {"1": {"1": 1, "2": [1, 2.0, 3]}, "2": {"1": 3, "2": [1, 2, 3]}},
-        "m": {"1": 1, "2": [2, 3]},
-    }
-    file_tuple = os.path.join(_TMPDIR, 'tuple.json')
-    write_stan_json(file_tuple, dict_tuples)
-    with open(file_tuple) as fd:
-        cmp(json.load(fd), dict_tuple_exp)
 
 
 def test_check_sampler_csv_1() -> None:
@@ -692,128 +544,6 @@ def test_parse_rdump_value() -> None:
     assert v_struct3[7, 0] == 8
     assert v_struct3[0, 1] == 9
     assert v_struct3[6, 1] == 15
-
-
-def test_parse_empty() -> None:
-    x = []
-    sampler_vars = parse_method_vars(x)
-    assert len(sampler_vars) == 0
-    stan_vars_dims, stan_vars_cols, stan_var_types = parse_stan_vars(x)
-    assert len(stan_vars_dims) == 0
-    assert len(stan_vars_cols) == 0
-    assert len(stan_var_types) == 0
-
-
-def test_parse_missing() -> None:
-    with pytest.raises(ValueError):
-        parse_method_vars(None)
-    with pytest.raises(ValueError):
-        parse_stan_vars(None)
-
-
-def test_parse_method_vars() -> None:
-    x = [
-        'lp__',
-        'accept_stat__',
-        'stepsize__',
-        'treedepth__',
-        'n_leapfrog__',
-        'divergent__',
-        'energy__',
-        'theta[1]',
-        'theta[2]',
-        'theta[3]',
-        'theta[4]',
-        'z_init[1]',
-        'z_init[2]',
-    ]
-    vars_dict = parse_method_vars(x)
-    assert len(vars_dict) == 7
-    assert vars_dict['lp__'] == (0,)
-    assert vars_dict['stepsize__'] == (2,)
-
-
-def test_parse_scalars() -> None:
-    x = ['lp__', 'foo']
-    dims_map, cols_map, _ = parse_stan_vars(x)
-    assert len(dims_map) == 1
-    assert dims_map['foo'] == ()
-    assert len(cols_map) == 1
-    assert cols_map['foo'] == (1,)
-
-    dims_map = {}
-    cols_map = {}
-    x = ['lp__', 'foo1', 'foo2']
-    dims_map, cols_map, _ = parse_stan_vars(x)
-    assert len(dims_map) == 2
-    assert dims_map['foo1'] == ()
-    assert dims_map['foo2'] == ()
-    assert len(cols_map) == 2
-    assert cols_map['foo1'] == (1,)
-    assert cols_map['foo2'] == (2,)
-
-    dims_map = {}
-    cols_map = {}
-    x = ['lp__', 'z[real]', 'z[imag]']
-    dims_map, cols_map, types_map = parse_stan_vars(x)
-    assert len(dims_map) == 1
-    assert dims_map['z'] == (2,)
-    assert types_map['z'] == BaseType.COMPLEX
-
-
-def test_parse_containers() -> None:
-    # demonstrates flaw in shortcut to get container dims
-    x = [
-        'lp__',
-        'accept_stat__',
-        'foo',
-        'phi[1]',
-        'phi[2]',
-        'phi[3]',
-        'phi[10]',
-        'bar',
-    ]
-    dims_map, cols_map, _ = parse_stan_vars(x)
-    assert len(dims_map) == 3
-    assert dims_map['foo'] == ()
-    assert dims_map['phi'] == (10,)  # sic
-    assert dims_map['bar'] == ()
-    assert len(cols_map) == 3
-    assert cols_map['foo'] == (2,)
-    assert cols_map['phi'] == (3, 4, 5, 6)
-    assert cols_map['bar'] == (7,)
-
-    x = [
-        'lp__',
-        'accept_stat__',
-        'foo',
-        'phi[1]',
-        'phi[2]',
-        'phi[3]',
-        'phi[10,10]',
-        'bar',
-    ]
-    dims_map = {}
-    cols_map = {}
-    dims_map, cols_map, _ = parse_stan_vars(x)
-    assert len(dims_map) == 3
-    assert dims_map['phi'] == (10, 10)
-    assert len(cols_map) == 3
-    assert cols_map['phi'] == (3, 4, 5, 6)
-
-    x = [
-        'lp__',
-        'accept_stat__',
-        'foo',
-        'phi[10,10,10]',
-    ]
-    dims_map = {}
-    cols_map = {}
-    dims_map, cols_map, _ = parse_stan_vars(x)
-    assert len(dims_map) == 2
-    assert dims_map['phi'] == (10, 10, 10)
-    assert len(cols_map) == 2
-    assert cols_map['phi'] == (3,)
 
 
 def test_capture_console() -> None:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -44,6 +44,7 @@ from cmdstanpy.utils import (
     read_metric,
     rload,
     set_cmdstan_path,
+    stancsv,
     validate_cmdstan_path,
     validate_dir,
     windows_short_path,
@@ -920,3 +921,24 @@ def test_show_progress_fns(caplog: pytest.LogCaptureFixture) -> None:
     # msg should only be printed once per session - check not found
     assert 'Disabling progress bars for this session' not in msgs
     assert not allow_show_progress()
+
+
+def test_munge_varnames() -> None:
+    var = 'y'
+    assert stancsv.munge_varname(var) == 'y'
+    var = 'y.2'
+    assert stancsv.munge_varname(var) == 'y[2]'
+    var = 'y.2.3'
+    assert stancsv.munge_varname(var) == 'y[2,3]'
+
+    var = 'y:2'
+    assert stancsv.munge_varname(var) == 'y.2'
+    var = 'y:2:3'
+    assert stancsv.munge_varname(var) == 'y.2.3'
+    var = 'y:2.1'
+    assert stancsv.munge_varname(var) == 'y.2[1]'
+    var = 'y.1:2'
+    assert stancsv.munge_varname(var) == 'y[1].2'
+
+    var = 'y.2.3:1.2:5:6'
+    assert stancsv.munge_varname(var) == 'y[2,3].1[2].5.6'


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

IO changes for 2.33 (tuple support).

- use https://github.com/WardBrian/stanio (tbd: will this move under stan-dev?)
  - support writing tuples to json
  - support reading/extracting tuples from draws array 
- breaking changes:
  - internals of `InferenceMetadata` changed (not technically part of our public API, but it was mentioned some places in our docs) 
  - VB's `.stan_variable` function now returns the varational draws, not the mean approximation (same as #652)
  - MLE and VB always return a np.ndarray from `.stan_variable`, never just a Python float

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

