### PR TITLE
Fix handling of `include-paths` in compiler options.

### DIFF
--- a/cmdstanpy/compiler_opts.py
+++ b/cmdstanpy/compiler_opts.py
@@ -5,7 +5,7 @@ Makefile options for stanc and C++ compilers
 import os
 from copy import copy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 from cmdstanpy.utils import get_logger
 
@@ -99,7 +99,7 @@ class CompilerOptions:
         )
 
     @property
-    def stanc_options(self) -> Dict[str, Union[bool, int, str]]:
+    def stanc_options(self) -> Dict[str, Union[bool, int, str, Iterable[str]]]:
         """Stanc compiler options."""
         return self._stanc_options
 
@@ -258,7 +258,12 @@ class CompilerOptions:
             else:
                 for key, val in new_opts.stanc_options.items():
                     if key == 'include-paths':
-                        self.add_include_path(str(val))
+                        if isinstance(val, Iterable) \
+                                and not isinstance(val, str):
+                            for path in val:
+                                self.add_include_path(str(path))
+                        else:
+                            self.add_include_path(str(val))
                     else:
                         self._stanc_options[key] = val
         if new_opts.cpp_options is not None:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -494,6 +494,18 @@ def test_model_includes_explicit() -> None:
     assert os.path.samefile(model.exe_file, BERN_EXE)
 
 
+def test_model_compile_with_explicit_includes() -> None:
+    stan_file = os.path.join(DATAFILES_PATH, "add_one_model.stan")
+    exe_file = os.path.splitext(stan_file)[0] + EXTENSION
+    if os.path.isfile(exe_file):
+        os.unlink(exe_file)
+
+    model = CmdStanModel(stan_file=stan_file, compile=False)
+    include_paths = [os.path.join(DATAFILES_PATH, "include-path")]
+    stanc_options = {"include-paths": include_paths}
+    model.compile(stanc_options=stanc_options)
+
+
 def test_model_includes_implicit() -> None:
     stan = os.path.join(DATAFILES_PATH, 'bernoulli_include.stan')
     exe = os.path.join(DATAFILES_PATH, 'bernoulli_include' + EXTENSION)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Including `include-paths` in the `stanc_options` passed to compile currently breaks compilation if `include-paths` is a list of paths rather than a string with comma-separated paths. This PR adds conditional handling based on the type.

Follow-up question: Calling `compile` extends `self._compiler_options` such that the call changes the state of `CmdStanModel` in addition to compiling the model. Is that intended? My gut feeling would've been that passing in `stanc_options` would only affect this one call but not future ones.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Harvard University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

