### PR TITLE
Fix minor doc typos

### DIFF
--- a/docsrc/users-guide/workflow.rst
+++ b/docsrc/users-guide/workflow.rst
@@ -145,8 +145,8 @@ An example of each is provided in the `next section <examples.rst>`__.
 
   It returns a :class:`CmdStanVB` object which contains an approximation the posterior distribution.
 
-* The :meth:`~CmdStanModel.optimize` runs one of
-  `Stan's optimization algorithms <https://mc-stan.org/docs/reference-manual/optimization-algorithms-chapter.html>`__.
+* The :meth:`~CmdStanModel.optimize` runs one of Stan's
+  `optimization algorithms <https://mc-stan.org/docs/reference-manual/optimization-algorithms-chapter.html>`__
   to find a mode of the density specified by the Stan program.
 
   It returns a :class:`CmdStanMLE` object.


### PR DESCRIPTION
**Overview:** Two minor documentation changes on the CmdStanPy workflow documentation page

- remove period from middle of sentence
- make link formatting consistent

for the optimization inference algorithm.

**Details:** More specifically, the documentation for every Stan inference algorithm on this documentation page, follows the form of "Stan's *some algorithm*", with a link to the algorithm itself.

However, the optimization algorithm is the only type of inference algorithm that includes the word "Stan" as part of the link. No other inference algorithm does this.

#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

