### PR TITLE
Stan 2.34: Fix parsing of unit_e output files

### DIFF
--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -441,6 +441,12 @@ class CmdStanMCMC:
                                 self._metric[chain, i, :] = [
                                     float(x) for x in xs
                                 ]
+                    else:  # unit_e changed in 2.34 to have an extra line
+                        pos = fd.tell()
+                        line = fd.readline().strip()
+                        if not line.startswith('#'):
+                            fd.seek(pos)
+
                 # process draws
                 for i in range(sampling_iter_start, num_draws):
                     line = fd.readline().strip()

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -289,10 +289,16 @@ def scan_hmc_params(
         raise ValueError(
             'line {}: invalid step size: {}'.format(lineno, step_size)
         ) from e
-    if metric == 'unit_e':
-        return lineno
+    before_metric = fd.tell()
     line = fd.readline().strip()
     lineno += 1
+    if metric == 'unit_e':
+        if line.startswith("# No free parameters"):
+            return lineno
+        else:
+            fd.seek(before_metric)
+            return lineno - 1
+
     if not (
         (
             metric == 'diag_e'


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

In Stan 2.34, the unit_e metric has an extra line in the CSV file:
```
# No free parameters for unit metric
```
which we need to skip over

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

