### PR TITLE
Add `diagnose` method to `CmdStanModel`.

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -2221,6 +2221,8 @@ class CmdStanModel:
             * "model": Gradients evaluated using autodiff.
             * "finite_diff": Gradients evaluated using finite differences.
             * "error": Delta between autodiff and finite difference gradients.
+
+            Gradients are evaluated in the unconstrained space.
         """
 
         with temp_single_json(data) as _data, \
@@ -2237,7 +2239,7 @@ class CmdStanModel:
             if _data is not None:
                 cmd += ["data", f"file={_data}"]
             if _inits is not None:
-                cmd.append(f"inits={_inits}")
+                cmd.append(f"init={_inits}")
 
             output_dir = tempfile.mkdtemp(prefix=self.name, dir=_TMPDIR)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -12,6 +12,7 @@ from test import check_present, raises_nested
 from typing import List
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from cmdstanpy.model import CmdStanModel
@@ -596,3 +597,30 @@ def test_format_old_version() -> None:
         model.format(max_line_length=88)
 
     model.format(canonicalize=True)
+
+
+def test_diagnose():
+    # Check the gradients.
+    model = CmdStanModel(stan_file=BERN_STAN)
+    gradients = model.diagnose(data=BERN_DATA)
+
+    # Check we have the right columns.
+    assert set(gradients) == {
+        "param_idx",
+        "value",
+        "model",
+        "finite_diff",
+        "error",
+    }
+
+    # Simulate bad gradients by using large finite difference.
+    with pytest.raises(RuntimeError, match="may exceed the error threshold"):
+        model.diagnose(data=BERN_DATA, epsilon=3)
+
+    # Check we get the results if we set require_gradients_ok=False.
+    gradients = model.diagnose(
+        data=BERN_DATA,
+        epsilon=3,
+        require_gradients_ok=False,
+    )
+    assert np.abs(gradients["error"]).max() > 1e-3

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -613,6 +613,11 @@ def test_diagnose():
         "error",
     }
 
+    # Check gradients against the same value as in `log_prob`.
+    inits = {"theta": 0.34903938392023830482}
+    gradients = model.diagnose(data=BERN_DATA, inits=inits)
+    np.testing.assert_allclose(gradients.model.iloc[0], -1.18847)
+
     # Simulate bad gradients by using large finite difference.
     with pytest.raises(RuntimeError, match="may exceed the error threshold"):
         model.diagnose(data=BERN_DATA, epsilon=3)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR adds the `diagnose` method to `CmdStanModel` which can be used to verify gradients, e.g., explicit gradients for custom functions implemented in C++. Documentation is based on the [equivalent `cmdstanr` function](https://mc-stan.org/cmdstanr/reference/model-method-diagnose.html) and other methods, such as `CmdStanModel.variational`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Harvard University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

