### PR TITLE
Fix tests for new cmdstan

### DIFF
--- a/cmdstanpy/stanfit/pathfinder.py
+++ b/cmdstanpy/stanfit/pathfinder.py
@@ -214,8 +214,10 @@ class CmdStanPathfinder:
         """
         return (  # type: ignore
             self._metadata.cmdstan_config.get("num_paths", 4) > 1
-            and self._metadata.cmdstan_config.get('psis_resample', 1) == 1
-            and self._metadata.cmdstan_config.get('calculate_lp', 1) == 1
+            and self._metadata.cmdstan_config.get('psis_resample', 1)
+            in (1, 'true')
+            and self._metadata.cmdstan_config.get('calculate_lp', 1)
+            in (1, 'true')
         )
 
     def save_csvfiles(self, dir: Optional[str] = None) -> None:

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -52,7 +52,7 @@ def check_sampler_csv(
             )
         )
     if save_warmup:
-        if not ('save_warmup' in meta and meta['save_warmup'] == 1):
+        if not ('save_warmup' in meta and meta['save_warmup'] in (1, 'true')):
             raise ValueError(
                 'bad Stan CSV file {}, '
                 'config error, expected save_warmup = 1'.format(path)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -262,12 +262,13 @@ def test_variables_3d() -> None:
     )
     vars_iters = multidim_mle_iters.stan_variables(inc_iterations=True)
     assert len(vars_iters) == len(multidim_mle_iters.metadata.stan_vars)
-    assert 'y_rep' in vars_iters
-    assert vars_iters['y_rep'].shape == (8, 5, 4, 3)
-    assert 'beta' in vars_iters
-    assert vars_iters['beta'].shape == (8, 2)
     assert 'frac_60' in vars_iters
-    assert vars_iters['frac_60'].shape == (8,)
+    n_iter = vars_iters['frac_60'].shape[0]
+    assert n_iter > 1
+    assert 'y_rep' in vars_iters
+    assert vars_iters['y_rep'].shape == (n_iter, 5, 4, 3)
+    assert 'beta' in vars_iters
+    assert vars_iters['beta'].shape == (n_iter, 2)
 
 
 def test_optimize_good() -> None:


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [ ] Declare copyright holder and open-source license: see below

#### Summary

Two changes in cmdstan: 

1. The CSV files now report booleans as `true` or `false`
2. RNG updates invalidated old seeds, which changed some tests

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

