### PR TITLE
Fix different behavior for jupyter vs. terminal

### DIFF
--- a/cmdstanpy/utils/command.py
+++ b/cmdstanpy/utils/command.py
@@ -48,7 +48,7 @@ def do_command(
                 stderr=subprocess.STDOUT,  # avoid buffer overflow
                 env=os.environ,
                 universal_newlines=True,
-                encoding=locale.getencoding(),
+                encoding=locale.getdefaultlocale()[1],
             )
             while proc.poll() is None:
                 if proc.stdout is not None:

--- a/cmdstanpy/utils/command.py
+++ b/cmdstanpy/utils/command.py
@@ -4,6 +4,7 @@ Run commands and handle returncodes
 import os
 import subprocess
 import sys
+import locale
 from typing import Callable, List, Optional, TextIO
 
 from .filesystem import pushd
@@ -47,6 +48,7 @@ def do_command(
                 stderr=subprocess.STDOUT,  # avoid buffer overflow
                 env=os.environ,
                 universal_newlines=True,
+                encoding=locale.getencoding(),
             )
             while proc.poll() is None:
                 if proc.stdout is not None:


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

When run code in non-English system, jupyter would implicitly set encoding to 'utf-8', explicitly set the encoding here would make the behavior consistent.  
Fix downstream bug https://github.com/facebook/prophet/issues/2462

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

myself

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

