### PR TITLE
Implementation of faster MCMC CSV parsing and Stan CSV utilities

### DIFF
--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -441,30 +441,30 @@ class CmdStanMCMC:
         )
         self._step_size = np.empty(self.chains, dtype=float)
 
+        mass_matrix_per_chain = []
         for chain in range(self.chains):
-            parsed_csv = stancsv.StanCsvMCMC.from_csv(
-                self.runset.csv_files[chain],
-                is_fixed_param=self._is_fixed_param,
+            with open(self.runset.csv_files[chain], "rb") as f:
+                comments, draws = stancsv.parse_stan_csv_comments_and_draws(f)
+
+            self._draws[:, chain, :] = stancsv.csv_bytes_list_to_numpy(draws)
+
+            if not self._is_fixed_param:
+                (
+                    self._step_size[chain],
+                    mass_matrix,
+                ) = stancsv.parse_hmc_adaptation_lines(comments)
+                mass_matrix_per_chain.append(mass_matrix)
+
+        if mass_matrix_per_chain[0] is not None:
+            mm_shape = mass_matrix_per_chain[0].shape
+            if self.metric_type == "diag_e":
+                mm_shape = mm_shape[1:]
+            self._metric = np.empty(
+                (self.chains, *mm_shape),
+                dtype=np.float32,
             )
-            self._step_size[chain] = parsed_csv.step_size
-            if self._save_warmup and parsed_csv.warmup_draws is not None:
-                self._draws[:, chain, :] = np.concatenate(
-                    [parsed_csv.warmup_draws, parsed_csv.sampling_draws]
-                )
-            else:
-                self._draws[:, chain, :] = parsed_csv.sampling_draws
-
-            if parsed_csv.mass_matrix is not None:
-                if chain == 0:
-                    mm_shape = parsed_csv.mass_matrix.shape
-                    if self.metric_type == "diag_e":
-                        mm_shape = mm_shape[1:]
-                    self._metric = np.empty(
-                        (self.chains, *mm_shape),
-                        dtype=np.float32,
-                    )
-
-                self._metric[chain] = parsed_csv.mass_matrix
+            for chain in range(self.chains):
+                self._metric[chain] = mass_matrix_per_chain[chain]
 
         assert self._draws is not None
 

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -39,6 +39,7 @@ from cmdstanpy.utils import (
     do_command,
     flatten_chains,
     get_logger,
+    stancsv,
 )
 
 from .metadata import InferenceMetadata
@@ -429,83 +430,42 @@ class CmdStanMCMC:
         """
         if self._draws.shape != (0,):
             return
+
         num_draws = self.num_draws_sampling
-        sampling_iter_start = 0
         if self._save_warmup:
             num_draws += self.num_draws_warmup
-            sampling_iter_start = self.num_draws_warmup
         self._draws = np.empty(
             (num_draws, self.chains, len(self.column_names)),
             dtype=float,
             order='F',
         )
         self._step_size = np.empty(self.chains, dtype=float)
-        for chain in range(self.chains):
-            with open(self.runset.csv_files[chain], 'r') as fd:
-                line = fd.readline().strip()
-                # read initial comments, CSV header row
-                while len(line) > 0 and line.startswith('#'):
-                    line = fd.readline().strip()
-                if not self._is_fixed_param:
-                    # handle warmup draws, if any
-                    if self._save_warmup:
-                        for i in range(self.num_draws_warmup):
-                            line = fd.readline().strip()
-                            xs = line.split(',')
-                            self._draws[i, chain, :] = [float(x) for x in xs]
-                    line = fd.readline().strip()
-                    if line != '# Adaptation terminated':  # shouldn't happen?
-                        while line != '# Adaptation terminated':
-                            line = fd.readline().strip()
-                    # step_size, metric (diag_e and dense_e only)
-                    line = fd.readline().strip()
-                    _, step_size = line.split('=')
-                    self._step_size[chain] = float(step_size.strip())
-                    if self._metadata.cmdstan_config['metric'] != 'unit_e':
-                        line = fd.readline().strip()  # metric type
-                        line = fd.readline().lstrip(' #\t').rstrip()
-                        num_unconstrained_params = len(line.split(','))
-                        if chain == 0:  # can't allocate w/o num params
-                            if self.metric_type == 'diag_e':
-                                self._metric = np.empty(
-                                    (self.chains, num_unconstrained_params),
-                                    dtype=float,
-                                )
-                            else:
-                                self._metric = np.empty(
-                                    (
-                                        self.chains,
-                                        num_unconstrained_params,
-                                        num_unconstrained_params,
-                                    ),
-                                    dtype=float,
-                                )
-                        if line:
-                            if self.metric_type == 'diag_e':
-                                xs = line.split(',')
-                                self._metric[chain, :] = [float(x) for x in xs]
-                            else:
-                                xs = line.strip().split(',')
-                                self._metric[chain, 0, :] = [
-                                    float(x) for x in xs
-                                ]
-                                for i in range(1, num_unconstrained_params):
-                                    line = fd.readline().lstrip(' #\t').rstrip()
-                                    xs = line.split(',')
-                                    self._metric[chain, i, :] = [
-                                        float(x) for x in xs
-                                    ]
-                    else:  # unit_e changed in 2.34 to have an extra line
-                        pos = fd.tell()
-                        line = fd.readline().strip()
-                        if not line.startswith('#'):
-                            fd.seek(pos)
 
-                # process draws
-                for i in range(sampling_iter_start, num_draws):
-                    line = fd.readline().strip()
-                    xs = line.split(',')
-                    self._draws[i, chain, :] = [float(x) for x in xs]
+        for chain in range(self.chains):
+            parsed_csv = stancsv.StanCsvMCMC.from_csv(
+                self.runset.csv_files[chain],
+                is_fixed_param=self._is_fixed_param,
+            )
+            self._step_size[chain] = parsed_csv.step_size
+            if self._save_warmup and parsed_csv.warmup_draws is not None:
+                self._draws[:, chain, :] = np.concat(
+                    [parsed_csv.warmup_draws, parsed_csv.sampling_draws]
+                )
+            else:
+                self._draws[:, chain, :] = parsed_csv.sampling_draws
+
+            if parsed_csv.mass_matrix is not None:
+                if chain == 0:
+                    mm_shape = parsed_csv.mass_matrix.shape
+                    if self.metric_type == "diag_e":
+                        mm_shape = mm_shape[1:]
+                    self._metric = np.empty(
+                        (self.chains, *mm_shape),
+                        dtype=np.float32,
+                    )
+
+                self._metric[chain] = parsed_csv.mass_matrix
+
         assert self._draws is not None
 
     def summary(

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -436,10 +436,10 @@ class CmdStanMCMC:
             num_draws += self.num_draws_warmup
         self._draws = np.empty(
             (num_draws, self.chains, len(self.column_names)),
-            dtype=float,
+            dtype=np.float32,
             order='F',
         )
-        self._step_size = np.empty(self.chains, dtype=float)
+        self._step_size = np.empty(self.chains, dtype=np.float32)
 
         mass_matrix_per_chain = []
         for chain in range(self.chains):
@@ -455,7 +455,7 @@ class CmdStanMCMC:
                 ) = stancsv.parse_hmc_adaptation_lines(comments)
                 mass_matrix_per_chain.append(mass_matrix)
 
-        if mass_matrix_per_chain[0] is not None:
+        if not self._is_fixed_param and mass_matrix_per_chain[0] is not None:
             mm_shape = mass_matrix_per_chain[0].shape
             if self.metric_type == "diag_e":
                 mm_shape = mm_shape[1:]

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -444,8 +444,9 @@ class CmdStanMCMC:
 
         mass_matrix_per_chain: List[Optional[npt.NDArray[np.float64]]] = []
         for chain in range(self.chains):
-            with open(self.runset.csv_files[chain], "rb") as f:
-                comments, draws = stancsv.parse_stan_csv_comments_and_draws(f)
+            comments, draws = stancsv.parse_stan_csv_comments_and_draws(
+                self.runset.csv_files[chain]
+            )
 
             self._draws[:, chain, :] = stancsv.csv_bytes_list_to_numpy(draws)
 

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -444,18 +444,25 @@ class CmdStanMCMC:
 
         mass_matrix_per_chain: List[Optional[npt.NDArray[np.float64]]] = []
         for chain in range(self.chains):
-            comments, draws = stancsv.parse_stan_csv_comments_and_draws(
-                self.runset.csv_files[chain]
-            )
+            try:
+                comments, draws = stancsv.parse_stan_csv_comments_and_draws(
+                    self.runset.csv_files[chain]
+                )
 
-            self._draws[:, chain, :] = stancsv.csv_bytes_list_to_numpy(draws)
+                self._draws[:, chain, :] = stancsv.csv_bytes_list_to_numpy(
+                    draws
+                )
 
-            if not self._is_fixed_param:
-                (
-                    self._step_size[chain],
-                    mass_matrix,
-                ) = stancsv.parse_hmc_adaptation_lines(comments)
-                mass_matrix_per_chain.append(mass_matrix)
+                if not self._is_fixed_param:
+                    (
+                        self._step_size[chain],
+                        mass_matrix,
+                    ) = stancsv.parse_hmc_adaptation_lines(comments)
+                    mass_matrix_per_chain.append(mass_matrix)
+            except Exception as exc:
+                raise ValueError(
+                    f"Parsing output from {self.runset.csv_files[chain]} failed"
+                ) from exc
 
         if all(mm is not None for mm in mass_matrix_per_chain):
             if self.metric_type == "diag_e":

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 try:
@@ -436,12 +437,12 @@ class CmdStanMCMC:
             num_draws += self.num_draws_warmup
         self._draws = np.empty(
             (num_draws, self.chains, len(self.column_names)),
-            dtype=np.float32,
+            dtype=np.float64,
             order='F',
         )
-        self._step_size = np.empty(self.chains, dtype=np.float32)
+        self._step_size = np.empty(self.chains, dtype=np.float64)
 
-        mass_matrix_per_chain = []
+        mass_matrix_per_chain: List[Optional[npt.NDArray[np.float64]]] = []
         for chain in range(self.chains):
             with open(self.runset.csv_files[chain], "rb") as f:
                 comments, draws = stancsv.parse_stan_csv_comments_and_draws(f)
@@ -455,16 +456,14 @@ class CmdStanMCMC:
                 ) = stancsv.parse_hmc_adaptation_lines(comments)
                 mass_matrix_per_chain.append(mass_matrix)
 
-        if not self._is_fixed_param and mass_matrix_per_chain[0] is not None:
-            mm_shape = mass_matrix_per_chain[0].shape
+        if all(mm is not None for mm in mass_matrix_per_chain):
             if self.metric_type == "diag_e":
-                mm_shape = mm_shape[1:]
-            self._metric = np.empty(
-                (self.chains, *mm_shape),
-                dtype=np.float32,
-            )
-            for chain in range(self.chains):
-                self._metric[chain] = mass_matrix_per_chain[chain]
+                # Mass matrix will have shape (1, num_params)
+                self._metric = np.array(
+                    [mm[0] for mm in mass_matrix_per_chain]  # type: ignore
+                )
+            else:
+                self._metric = np.array(mass_matrix_per_chain)
 
         assert self._draws is not None
 

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -448,7 +448,7 @@ class CmdStanMCMC:
             )
             self._step_size[chain] = parsed_csv.step_size
             if self._save_warmup and parsed_csv.warmup_draws is not None:
-                self._draws[:, chain, :] = np.concat(
+                self._draws[:, chain, :] = np.concatenate(
                     [parsed_csv.warmup_draws, parsed_csv.sampling_draws]
                 )
             else:

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 
 try:
@@ -442,7 +441,7 @@ class CmdStanMCMC:
         )
         self._step_size = np.empty(self.chains, dtype=np.float64)
 
-        mass_matrix_per_chain: List[Optional[npt.NDArray[np.float64]]] = []
+        mass_matrix_per_chain = []
         for chain in range(self.chains):
             try:
                 comments, draws = stancsv.parse_stan_csv_comments_and_draws(
@@ -465,13 +464,7 @@ class CmdStanMCMC:
                 ) from exc
 
         if all(mm is not None for mm in mass_matrix_per_chain):
-            if self.metric_type == "diag_e":
-                # Mass matrix will have shape (1, num_params)
-                self._metric = np.array(
-                    [mm[0] for mm in mass_matrix_per_chain]  # type: ignore
-                )
-            else:
-                self._metric = np.array(mass_matrix_per_chain)
+            self._metric = np.array(mass_matrix_per_chain)
 
         assert self._draws is not None
 

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -26,6 +26,7 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+import polars as pl
 
 from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
 
@@ -75,10 +76,13 @@ def csv_bytes_list_to_numpy(
     """Efficiently converts a list of bytes representing whose concatenation
     represents a CSV file into a numpy array. Includes header specifies
     whether the bytes contains an initial header line."""
-    header = 0 if includes_header else None
-    out = pd.read_csv(
-        io.BytesIO(b"".join(csv_bytes_list)), engine="pyarrow", header=header
-    ).to_numpy(dtype=np.float32)
+    out = (
+        pl.read_csv(
+            io.BytesIO(b"".join(csv_bytes_list)), has_header=includes_header
+        )
+        .to_numpy()
+        .astype(np.float32)
+    )
     # Telling the type checker we know the type is correct
     return cast(npt.NDArray[np.float32], out)
 

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -54,7 +54,7 @@ def csv_bytes_list_to_numpy(
         import polars as pl
 
         try:
-            out = (
+            out: npt.NDArray[np.float64] = (
                 pl.read_csv(
                     io.BytesIO(b"".join(csv_bytes_list)),
                     has_header=includes_header,
@@ -81,7 +81,7 @@ def csv_bytes_list_to_numpy(
         if len(out.shape) == 1:
             out = out.reshape(1, -1)
 
-    return out  # type: ignore
+    return out
 
 
 def parse_hmc_adaptation_lines(

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -67,7 +67,7 @@ def csv_bytes_list_to_numpy(
                 raise ValueError("No data found to parse")
         except pl.exceptions.NoDataError as exc:
             raise ValueError("No data found to parse") from exc
-    except ImportError as exc:
+    except ImportError:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             out = np.loadtxt(
@@ -78,7 +78,7 @@ def csv_bytes_list_to_numpy(
                 ndmin=1,
             )
         if out.shape == (0,):
-            raise ValueError("No data found to parse") from exc
+            raise ValueError("No data found to parse")  # pylint: disable=W0707
         if len(out.shape) == 1:
             out = out.reshape(1, -1)
 

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -33,8 +33,84 @@ from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
 
 @dataclass
 class ParsingRule:
+    """Defines a rule for parsing a Stan CSV file. The parser transitions
+    between two states: either in or out of a comment section. Each section
+    is associated with one of these rules. On each line within a section,
+    the action is called. If an alternative action should be taken when
+    entering a section, the entry_action should be specified."""
+
     action: Callable[[bytes], None]
     entry_action: Optional[Callable[[bytes], None]] = None
+
+
+@dataclass
+class StanCsvMCMC:
+    """Class containing the parsed output of a Stan CSV file sourced
+    from the `sample` inference method."""
+
+    config: Dict[str, Union[int, float, str]]
+    warmup_draws: Optional[npt.NDArray[np.float32]]
+    step_size: Optional[float]
+    mass_matrix: Optional[npt.NDArray[np.float32]]
+    sampling_draws: npt.NDArray[np.float32]
+    timings: Dict[str, float]
+
+    @classmethod
+    def from_csv(
+        cls, path: Union[os.PathLike, Path, str], is_fixed_param: bool = False
+    ) -> "StanCsvMCMC":
+        config_lines: List[bytes] = []
+        warmup_lines: List[bytes] = []
+        adaptation_lines: List[bytes] = []
+        sampling_lines: List[bytes] = []
+        timing_lines: List[bytes] = []
+
+        def add_header(line: bytes) -> None:
+            warmup_lines.append(line)
+            sampling_lines.append(line)
+
+        rules: Tuple[ParsingRule, ...] = tuple()
+        if is_fixed_param:
+            rules = (
+                ParsingRule(action=config_lines.append),
+                ParsingRule(action=sampling_lines.append),
+                ParsingRule(action=timing_lines.append),
+            )
+        else:
+            rules = (
+                ParsingRule(action=config_lines.append),
+                ParsingRule(
+                    entry_action=add_header, action=warmup_lines.append
+                ),
+                ParsingRule(action=adaptation_lines.append),
+                ParsingRule(action=sampling_lines.append),
+                ParsingRule(action=timing_lines.append),
+            )
+        with open(path, "rb") as f:
+            parse_general_stan_csv_from_lines(f, rules)
+
+        sampling_draws = csv_bytes_list_to_numpy(sampling_lines)
+        config_dict: Dict[str, Union[str, int, float]] = {}
+        scan_config(
+            io.StringIO("".join(ln.decode() for ln in config_lines)),
+            config_dict,
+            0,
+        )
+        if is_fixed_param:
+            warmup_draws, step_size, mass_matrix = None, None, None
+        else:
+            warmup_draws = csv_bytes_list_to_numpy(warmup_lines)
+            step_size, mass_matrix = parse_hmc_adaptation_lines(
+                adaptation_lines
+            )
+        return cls(
+            config_dict,
+            warmup_draws,
+            step_size,
+            mass_matrix,
+            sampling_draws,
+            parse_timing_lines(timing_lines),
+        )
 
 
 def parse_general_stan_csv_from_lines(
@@ -133,73 +209,6 @@ def parse_timing_lines(
             phase = match[0][1]
             out[phase] = seconds
     return out
-
-
-@dataclass
-class StanCsvMCMC:
-    config: Dict[str, Union[int, float, str]]
-    warmup_draws: Optional[npt.NDArray[np.float32]]
-    step_size: Optional[float]
-    mass_matrix: Optional[npt.NDArray[np.float32]]
-    sampling_draws: npt.NDArray[np.float32]
-    timings: Dict[str, float]
-
-    @classmethod
-    def from_csv(
-        cls, path: Union[os.PathLike, Path, str], is_fixed_param: bool = False
-    ) -> "StanCsvMCMC":
-        config_lines: List[bytes] = []
-        warmup_lines: List[bytes] = []
-        adaptation_lines: List[bytes] = []
-        sampling_lines: List[bytes] = []
-        timing_lines: List[bytes] = []
-
-        def add_header(line: bytes) -> None:
-            warmup_lines.append(line)
-            sampling_lines.append(line)
-
-        rules: Tuple[ParsingRule, ...] = tuple()
-        if is_fixed_param:
-            rules = (
-                ParsingRule(action=config_lines.append),
-                ParsingRule(action=sampling_lines.append),
-                ParsingRule(action=timing_lines.append),
-            )
-        else:
-            rules = (
-                ParsingRule(action=config_lines.append),
-                ParsingRule(
-                    entry_action=add_header, action=warmup_lines.append
-                ),
-                ParsingRule(action=adaptation_lines.append),
-                ParsingRule(action=sampling_lines.append),
-                ParsingRule(action=timing_lines.append),
-            )
-        with open(path, "rb") as f:
-            parse_general_stan_csv_from_lines(f, rules)
-
-        sampling_draws = csv_bytes_list_to_numpy(sampling_lines)
-        config_dict: Dict[str, Union[str, int, float]] = {}
-        scan_config(
-            io.StringIO("".join(ln.decode() for ln in config_lines)),
-            config_dict,
-            0,
-        )
-        if is_fixed_param:
-            warmup_draws, step_size, mass_matrix = None, None, None
-        else:
-            warmup_draws = csv_bytes_list_to_numpy(warmup_lines)
-            step_size, mass_matrix = parse_hmc_adaptation_lines(
-                adaptation_lines
-            )
-        return cls(
-            config_dict,
-            warmup_draws,
-            step_size,
-            mass_matrix,
-            sampling_draws,
-            parse_timing_lines(timing_lines),
-        )
 
 
 def check_sampler_csv(

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -85,7 +85,7 @@ def csv_bytes_list_to_numpy(
 
 def parse_hmc_adaptation_lines(
     adaptation_lines: List[bytes],
-) -> Tuple[float, npt.NDArray[np.float32] | None]:
+) -> Tuple[float, Optional[npt.NDArray[np.float32]]]:
     """Extracts step size/mass matrix information from the adaptation
     section of the Stan CSV. If unit metric is used, the mass matrix
     field will be None, otherwise an appropriate numpy array.

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -141,30 +141,6 @@ def parse_hmc_adaptation_lines(
     return step_size, mass_matrix
 
 
-def parse_timing_lines(
-    comment_lines: List[bytes],
-) -> Dict[str, float]:
-    """Parse the timing lines into a dictionary with key corresponding
-    to the phase, e.g. Warm-up, Sampling, Total, and value the elapsed seconds
-    """
-    out: Dict[str, float] = {}
-
-    cleaned_lines = (ln.lstrip(b"# ") for ln in comment_lines)
-    in_timing_block = False
-    for line in cleaned_lines:
-        if line.startswith(b"Elapsed Time") and not in_timing_block:
-            in_timing_block = True
-
-        if not in_timing_block:
-            continue
-        match = re.findall(r"([\d\.]+) seconds \((.+)\)", str(line))
-        if match:
-            seconds = float(match[0][0])
-            phase = match[0][1]
-            out[phase] = seconds
-    return out
-
-
 def check_sampler_csv(
     path: str,
     is_fixed_param: bool = False,

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -5,14 +5,10 @@ Utility functions for reading the Stan CSV format
 import io
 import json
 import math
-import os
 import re
 import warnings
-from dataclasses import dataclass
-from pathlib import Path
 from typing import (
     Any,
-    Callable,
     Dict,
     Iterator,
     List,
@@ -31,119 +27,22 @@ import pandas as pd
 from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
 
 
-@dataclass
-class ParsingRule:
-    """Defines a rule for parsing a Stan CSV file. The parser transitions
-    between two states: either in or out of a comment section. Each section
-    is associated with one of these rules. On each line within a section,
-    the action is called. If an alternative action should be taken when
-    entering a section, the entry_action should be specified."""
-
-    action: Callable[[bytes], None]
-    entry_action: Optional[Callable[[bytes], None]] = None
-
-
-@dataclass
-class StanCsvMCMC:
-    """Class containing the parsed output of a Stan CSV file sourced
-    from the `sample` inference method."""
-
-    config: Dict[str, Union[int, float, str]]
-    warmup_draws: Optional[npt.NDArray[np.float32]]
-    step_size: Optional[float]
-    mass_matrix: Optional[npt.NDArray[np.float32]]
-    sampling_draws: npt.NDArray[np.float32]
-    timings: Dict[str, float]
-
-    @classmethod
-    def from_csv(
-        cls, path: Union[os.PathLike, Path, str], is_fixed_param: bool = False
-    ) -> "StanCsvMCMC":
-        config_lines: List[bytes] = []
-        warmup_lines: List[bytes] = []
-        adaptation_lines: List[bytes] = []
-        sampling_lines: List[bytes] = []
-        timing_lines: List[bytes] = []
-
-        def add_header(line: bytes) -> None:
-            warmup_lines.append(line)
-            sampling_lines.append(line)
-
-        rules: Tuple[ParsingRule, ...] = tuple()
-        if is_fixed_param:
-            rules = (
-                ParsingRule(action=config_lines.append),
-                ParsingRule(action=sampling_lines.append),
-                ParsingRule(action=timing_lines.append),
-            )
-        else:
-            rules = (
-                ParsingRule(action=config_lines.append),
-                ParsingRule(
-                    entry_action=add_header, action=warmup_lines.append
-                ),
-                ParsingRule(action=adaptation_lines.append),
-                ParsingRule(action=sampling_lines.append),
-                ParsingRule(action=timing_lines.append),
-            )
-        with open(path, "rb") as f:
-            parse_general_stan_csv_from_lines(f, rules)
-
-        sampling_draws = csv_bytes_list_to_numpy(sampling_lines)
-        config_dict: Dict[str, Union[str, int, float]] = {}
-        scan_config(
-            io.StringIO("".join(ln.decode() for ln in config_lines)),
-            config_dict,
-            0,
-        )
-        if is_fixed_param:
-            warmup_draws, step_size, mass_matrix = None, None, None
-        else:
-            warmup_draws = csv_bytes_list_to_numpy(warmup_lines)
-            step_size, mass_matrix = parse_hmc_adaptation_lines(
-                adaptation_lines
-            )
-        return cls(
-            config_dict,
-            warmup_draws,
-            step_size,
-            mass_matrix,
-            sampling_draws,
-            parse_timing_lines(timing_lines),
-        )
-
-
-def parse_general_stan_csv_from_lines(
+def parse_stan_csv_comments_and_draws(
     lines: Iterator[bytes],
-    rules: Tuple[ParsingRule, ...],
-    start_in_comment: bool = True,
-) -> None:
-    """Parses a generalized Stan CSV structure via provided rules.
-    The core idea is that Stan CSV files can be partitioned into coherent
-    sections based on the order of commented/non-commented lines in the file.
-    The rules define actions to be taken while within a given section and
-    transitioning between them. For example, in the MCMC Stan CSV files
-    an initial commented config section is followed by uncommented lines
-    that represent the warmup draws."""
-    current_rule_idx = 0
-    in_comment = start_in_comment
+) -> Tuple[List[bytes], List[bytes]]:
+    """Parses lines of a Stan CSV file into comment lines and draws lines, where
+    a draws line is just a non-commented line.
+
+    Returns a (comment_lines, draws_lines) tuple.
+    """
+    comment_lines, draws_lines = [], []
 
     for line in lines:
-        is_comment = line.startswith(b"#")
-        if is_comment == in_comment:
-            rules[current_rule_idx].action(line)
+        if line.startswith(b"#"):  # is comment line
+            comment_lines.append(line)
         else:
-            current_rule_idx += 1
-            if len(rules) == current_rule_idx:
-                raise IndexError(
-                    "Insufficient parsing rules to parse provided csv"
-                )
-            in_comment = is_comment
-            next_entry_action = rules[current_rule_idx].entry_action
-            if next_entry_action is not None:
-                next_entry_action(line)
-            else:  # If no entry_action defined, run normal action
-                rules[current_rule_idx].action(line)
+            draws_lines.append(line)
+    return comment_lines, draws_lines
 
 
 def csv_bytes_list_to_numpy(
@@ -185,19 +84,23 @@ def csv_bytes_list_to_numpy(
 
 
 def parse_hmc_adaptation_lines(
-    adaptation_lines: List[bytes],
+    comment_lines: List[bytes],
 ) -> Tuple[float, Optional[npt.NDArray[np.float32]]]:
-    """Extracts step size/mass matrix information from the adaptation
-    section of the Stan CSV. If unit metric is used, the mass matrix
-    field will be None, otherwise an appropriate numpy array.
+    """Extracts step size/mass matrix information from the Stan CSV comment
+    lines by parsing the adaptation section. If unit metric is used, the mass
+    matrix field will be None, otherwise an appropriate numpy array.
 
     Returns a (step_size, mass_matrix) tuple"""
     step_size, mass_matrix = None, None
-    lines_without_comments = (ln.lstrip(b"# ") for ln in adaptation_lines)
+
+    cleaned_lines = (ln.lstrip(b"# ") for ln in comment_lines)
     in_matrix_block = False
     matrix_lines = []
-    for line in lines_without_comments:
+    for line in cleaned_lines:
         if in_matrix_block and line.strip():
+            # Stop when we get to timing block
+            if line.startswith(b"Elapsed Time"):
+                break
             matrix_lines.append(line)
         elif line.startswith(b"Step size"):
             _, ss_str = line.split(b" = ")
@@ -216,14 +119,21 @@ def parse_hmc_adaptation_lines(
 
 
 def parse_timing_lines(
-    timing_lines: List[bytes],
+    comment_lines: List[bytes],
 ) -> Dict[str, float]:
     """Parse the timing lines into a dictionary with key corresponding
     to the phase, e.g. Warm-up, Sampling, Total, and value the elapsed seconds
     """
     out: Dict[str, float] = {}
-    lines_without_comments = (ln.lstrip(b"# ") for ln in timing_lines)
-    for line in lines_without_comments:
+
+    cleaned_lines = (ln.lstrip(b"# ") for ln in comment_lines)
+    in_timing_block = False
+    for line in cleaned_lines:
+        if line.startswith(b"Elapsed Time") and not in_timing_block:
+            in_timing_block = True
+
+        if not in_timing_block:
+            continue
         match = re.findall(r"([\d\.]+) seconds \((.+)\)", str(line))
         if match:
             seconds = float(match[0][0])

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -75,9 +75,12 @@ def csv_bytes_list_to_numpy(
                 skiprows=int(includes_header),
                 delimiter=",",
                 dtype=np.float32,
+                ndmin=1,
             )
         if out.shape == (0,):
             raise ValueError("No data found to parse") from exc
+        if len(out.shape) == 1:
+            out = out.reshape(1, -1)
 
     # Telling the type checker we know the type is correct
     return cast(npt.NDArray[np.float32], out)

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -98,14 +98,17 @@ def parse_hmc_adaptation_lines(
     comment_lines: List[bytes],
 ) -> Tuple[float, Optional[npt.NDArray[np.float64]]]:
     """Extracts step size/mass matrix information from the Stan CSV comment
-    lines by parsing the adaptation section. If unit metric is used, the mass
-    matrix field will be None, otherwise an appropriate numpy array.
+    lines by parsing the adaptation section. If the diag_e metric is used,
+    the returned mass matrix will be a 1D array of the diagnoal elements,
+    if the dense_e metric is used, it will be a 2D array representing the
+    entire matrix, and if unit_e is used then None will be returned.
 
     Returns a (step_size, mass_matrix) tuple"""
     step_size, mass_matrix = None, None
 
     cleaned_lines = (ln.lstrip(b"# ") for ln in comment_lines)
     in_matrix_block = False
+    diag_e_metric = False
     matrix_lines = []
     for line in cleaned_lines:
         if in_matrix_block and line.strip():
@@ -120,12 +123,16 @@ def parse_hmc_adaptation_lines(
             in_matrix_block = True
         elif line.startswith(b"No free"):
             break
+        elif b"diag_e" in line:
+            diag_e_metric = True
     if step_size is None:
         raise ValueError("Unable to parse adapated step size")
     if matrix_lines:
         mass_matrix = csv_bytes_list_to_numpy(
             matrix_lines, includes_header=False
         )
+        if diag_e_metric and mass_matrix.shape[0] == 1:
+            mass_matrix = mass_matrix[0]
     return step_size, mass_matrix
 
 

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -1,15 +1,201 @@
 """
 Utility functions for reading the Stan CSV format
 """
+
+import io
 import json
 import math
+import os
 import re
-from typing import Any, Dict, List, MutableMapping, Optional, TextIO, Union
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    MutableMapping,
+    Optional,
+    TextIO,
+    Tuple,
+    Union,
+    cast,
+)
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
+
+
+@dataclass
+class ParsingRule:
+    action: Callable[[bytes], None]
+    entry_action: Optional[Callable[[bytes], None]] = None
+
+
+def parse_general_stan_csv_from_lines(
+    lines: Iterator[bytes],
+    rules: Tuple[ParsingRule, ...],
+    start_in_comment: bool = True,
+) -> None:
+    """Parses a generalized Stan CSV structure via provided rules.
+    The core idea is that Stan CSV files can be partitioned into coherent
+    sections based on the order of commented/non-commented lines in the file.
+    The rules define actions to be taken while within a given section and
+    transitioning between them. For example, in the MCMC Stan CSV files
+    an initial commented config section is followed by uncommented lines
+    that represent the warmup draws."""
+    current_rule_idx = 0
+    in_comment = start_in_comment
+
+    for line in lines:
+        is_comment = line.startswith(b"#")
+        if is_comment == in_comment:
+            rules[current_rule_idx].action(line)
+        else:
+            current_rule_idx += 1
+            if len(rules) == current_rule_idx:
+                raise IndexError(
+                    "Insufficient parsing rules to parse provided csv"
+                )
+            in_comment = is_comment
+            next_entry_action = rules[current_rule_idx].entry_action
+            if next_entry_action is not None:
+                next_entry_action(line)
+            else:  # If no entry_action defined, run normal action
+                rules[current_rule_idx].action(line)
+
+
+def csv_bytes_list_to_numpy(
+    csv_bytes_list: List[bytes], includes_header: bool = True
+) -> npt.NDArray[np.float32]:
+    """Efficiently converts a list of bytes representing whose concatenation
+    represents a CSV file into a numpy array. Includes header specifies
+    whether the bytes contains an initial header line."""
+    header = 0 if includes_header else None
+    out = pd.read_csv(
+        io.BytesIO(b"".join(csv_bytes_list)), engine="pyarrow", header=header
+    ).to_numpy(dtype=np.float32)
+    # Telling the type checker we know the type is correct
+    return cast(npt.NDArray[np.float32], out)
+
+
+def parse_hmc_adaptation_lines(
+    adaptation_lines: List[bytes],
+) -> Tuple[float, npt.NDArray[np.float32] | None]:
+    """Extracts step size/mass matrix information from the adaptation
+    section of the Stan CSV. If unit metric is used, the mass matrix
+    field will be None, otherwise an appropriate numpy array.
+
+    Returns a (step_size, mass_matrix) tuple"""
+    step_size, mass_matrix = None, None
+    lines_without_comments = (ln.lstrip(b"# ") for ln in adaptation_lines)
+    in_matrix_block = False
+    matrix_lines = []
+    for line in lines_without_comments:
+        if in_matrix_block:
+            matrix_lines.append(line)
+        elif line.startswith(b"Step size"):
+            _, ss_str = line.split(b" = ")
+            step_size = float(ss_str)
+        elif line.startswith(b"Diagonal") or line.startswith(b"Elements"):
+            in_matrix_block = True
+        elif line.startswith(b"No free"):
+            break
+    if step_size is None:
+        raise ValueError("Unable to parse adapated step size")
+    if matrix_lines:
+        mass_matrix = csv_bytes_list_to_numpy(
+            matrix_lines, includes_header=False
+        )
+    return step_size, mass_matrix
+
+
+def parse_timing_lines(
+    timing_lines: List[bytes],
+) -> Dict[str, float]:
+    """Parse the timing lines into a dictionary with key corresponding
+    to the phase, e.g. Warm-up, Sampling, Total, and value the elapsed seconds
+    """
+    out: Dict[str, float] = {}
+    lines_without_comments = (ln.lstrip(b"# ") for ln in timing_lines)
+    for line in lines_without_comments:
+        match = re.findall(r"([\d\.]+) seconds \((.+)\)", str(line))
+        if match:
+            seconds = float(match[0][0])
+            phase = match[0][1]
+            out[phase] = seconds
+    return out
+
+
+@dataclass
+class StanCsvMCMC:
+    config: Dict[str, Union[int, float, str]]
+    warmup_draws: Optional[npt.NDArray[np.float32]]
+    step_size: Optional[float]
+    mass_matrix: Optional[npt.NDArray[np.float32]]
+    sampling_draws: npt.NDArray[np.float32]
+    timings: Dict[str, float]
+
+    @classmethod
+    def from_csv(
+        cls, path: Union[os.PathLike, Path], is_fixed_param: bool = False
+    ) -> "StanCsvMCMC":
+        config_lines: List[bytes] = []
+        warmup_lines: List[bytes] = []
+        adaptation_lines: List[bytes] = []
+        sampling_lines: List[bytes] = []
+        timing_lines: List[bytes] = []
+
+        def add_header(line: bytes) -> None:
+            warmup_lines.append(line)
+            sampling_lines.append(line)
+
+        rules: Tuple[ParsingRule, ...] = tuple()
+        if is_fixed_param:
+            rules = (
+                ParsingRule(action=config_lines.append),
+                ParsingRule(action=sampling_lines.append),
+                ParsingRule(action=timing_lines.append),
+            )
+        else:
+            rules = (
+                ParsingRule(action=config_lines.append),
+                ParsingRule(
+                    entry_action=add_header, action=warmup_lines.append
+                ),
+                ParsingRule(action=adaptation_lines.append),
+                ParsingRule(action=sampling_lines.append),
+                ParsingRule(action=timing_lines.append),
+            )
+        with open(path, "rb") as f:
+            parse_general_stan_csv_from_lines(f, rules)
+
+        sampling_draws = csv_bytes_list_to_numpy(sampling_lines)
+        config_dict: Dict[str, Union[str, int, float]] = {}
+        scan_config(
+            io.StringIO("".join(ln.decode() for ln in config_lines)),
+            config_dict,
+            0,
+        )
+        if is_fixed_param:
+            warmup_draws, step_size, mass_matrix = None, None, None
+        else:
+            warmup_draws = csv_bytes_list_to_numpy(warmup_lines)
+            step_size, mass_matrix = parse_hmc_adaptation_lines(
+                adaptation_lines
+            )
+        return cls(
+            config_dict,
+            warmup_draws,
+            step_size,
+            mass_matrix,
+            sampling_draws,
+            parse_timing_lines(timing_lines),
+        )
 
 
 def check_sampler_csv(

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -26,7 +27,6 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-import polars as pl
 
 from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
 
@@ -152,13 +152,34 @@ def csv_bytes_list_to_numpy(
     """Efficiently converts a list of bytes representing whose concatenation
     represents a CSV file into a numpy array. Includes header specifies
     whether the bytes contains an initial header line."""
-    out = (
-        pl.read_csv(
-            io.BytesIO(b"".join(csv_bytes_list)), has_header=includes_header
-        )
-        .to_numpy()
-        .astype(np.float32)
-    )
+    try:
+        import polars as pl
+
+        try:
+            out = (
+                pl.read_csv(
+                    io.BytesIO(b"".join(csv_bytes_list)),
+                    has_header=includes_header,
+                )
+                .to_numpy()
+                .astype(np.float32)
+            )
+            if out.shape[0] == 0:
+                raise ValueError("No data found to parse")
+        except pl.exceptions.NoDataError as exc:
+            raise ValueError("No data found to parse") from exc
+    except ImportError as exc:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            out = np.loadtxt(
+                csv_bytes_list,
+                skiprows=int(includes_header),
+                delimiter=",",
+                dtype=np.float32,
+            )
+        if out.shape == (0,):
+            raise ValueError("No data found to parse") from exc
+
     # Telling the type checker we know the type is correct
     return cast(npt.NDArray[np.float32], out)
 

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -64,10 +64,13 @@ def csv_bytes_list_to_numpy(
         import polars as pl
 
         try:
+            num_cols = csv_bytes_list[0].count(b",") + 1
             out: npt.NDArray[np.float64] = (
                 pl.read_csv(
                     io.BytesIO(b"".join(csv_bytes_list)),
                     has_header=includes_header,
+                    schema_overrides=[pl.Float64] * num_cols,
+                    infer_schema=False,
                 )
                 .to_numpy()
                 .astype(np.float64)

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -64,6 +64,8 @@ def csv_bytes_list_to_numpy(
         import polars as pl
 
         try:
+            if not csv_bytes_list:
+                raise ValueError("No data found to parse")
             num_cols = csv_bytes_list[0].count(b",") + 1
             out: npt.NDArray[np.float64] = (
                 pl.read_csv(

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -17,7 +17,6 @@ from typing import (
     TextIO,
     Tuple,
     Union,
-    cast,
 )
 
 import numpy as np
@@ -47,7 +46,7 @@ def parse_stan_csv_comments_and_draws(
 
 def csv_bytes_list_to_numpy(
     csv_bytes_list: List[bytes], includes_header: bool = True
-) -> npt.NDArray[np.float32]:
+) -> npt.NDArray[np.float64]:
     """Efficiently converts a list of bytes representing whose concatenation
     represents a CSV file into a numpy array. Includes header specifies
     whether the bytes contains an initial header line."""
@@ -61,7 +60,7 @@ def csv_bytes_list_to_numpy(
                     has_header=includes_header,
                 )
                 .to_numpy()
-                .astype(np.float32)
+                .astype(np.float64)
             )
             if out.shape[0] == 0:
                 raise ValueError("No data found to parse")
@@ -74,7 +73,7 @@ def csv_bytes_list_to_numpy(
                 csv_bytes_list,
                 skiprows=int(includes_header),
                 delimiter=",",
-                dtype=np.float32,
+                dtype=np.float64,
                 ndmin=1,
             )
         if out.shape == (0,):
@@ -82,13 +81,12 @@ def csv_bytes_list_to_numpy(
         if len(out.shape) == 1:
             out = out.reshape(1, -1)
 
-    # Telling the type checker we know the type is correct
-    return cast(npt.NDArray[np.float32], out)
+    return out  # type: ignore
 
 
 def parse_hmc_adaptation_lines(
     comment_lines: List[bytes],
-) -> Tuple[float, Optional[npt.NDArray[np.float32]]]:
+) -> Tuple[float, Optional[npt.NDArray[np.float64]]]:
     """Extracts step size/mass matrix information from the Stan CSV comment
     lines by parsing the adaptation section. If unit metric is used, the mass
     matrix field will be None, otherwise an appropriate numpy array.

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -96,7 +96,7 @@ def parse_hmc_adaptation_lines(
     in_matrix_block = False
     matrix_lines = []
     for line in lines_without_comments:
-        if in_matrix_block:
+        if in_matrix_block and line.strip():
             matrix_lines.append(line)
         elif line.startswith(b"Step size"):
             _, ss_str = line.split(b" = ")
@@ -142,7 +142,7 @@ class StanCsvMCMC:
 
     @classmethod
     def from_csv(
-        cls, path: Union[os.PathLike, Path], is_fixed_param: bool = False
+        cls, path: Union[os.PathLike, Path, str], is_fixed_param: bool = False
     ) -> "StanCsvMCMC":
         config_lines: List[bytes] = []
         warmup_lines: List[bytes] = []

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -7,6 +7,7 @@ import json
 import math
 import re
 import warnings
+from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -27,21 +28,30 @@ from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
 
 
 def parse_stan_csv_comments_and_draws(
-    lines: Iterator[bytes],
+    stan_csv: Union[str, Path, Iterator[bytes]],
 ) -> Tuple[List[bytes], List[bytes]]:
     """Parses lines of a Stan CSV file into comment lines and draws lines, where
     a draws line is just a non-commented line.
 
     Returns a (comment_lines, draws_lines) tuple.
     """
-    comment_lines, draws_lines = [], []
 
-    for line in lines:
-        if line.startswith(b"#"):  # is comment line
-            comment_lines.append(line)
-        else:
-            draws_lines.append(line)
-    return comment_lines, draws_lines
+    def split_comments_and_draws(
+        lines: Iterator[bytes],
+    ) -> Tuple[List[bytes], List[bytes]]:
+        comment_lines, draws_lines = [], []
+        for line in lines:
+            if line.startswith(b"#"):  # is comment line
+                comment_lines.append(line)
+            else:
+                draws_lines.append(line)
+        return comment_lines, draws_lines
+
+    if isinstance(stan_csv, (str, Path)):
+        with open(stan_csv, "rb") as f:
+            return split_comments_and_draws(f)
+    else:
+        return split_comments_and_draws(stan_csv)
 
 
 def csv_bytes_list_to_numpy(

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -5,9 +5,9 @@ Utility functions for reading the Stan CSV format
 import io
 import json
 import math
+import os
 import re
 import warnings
-from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -28,7 +28,7 @@ from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
 
 
 def parse_stan_csv_comments_and_draws(
-    stan_csv: Union[str, Path, Iterator[bytes]],
+    stan_csv: Union[str, os.PathLike, Iterator[bytes]],
 ) -> Tuple[List[bytes], List[bytes]]:
     """Parses lines of a Stan CSV file into comment lines and draws lines, where
     a draws line is just a non-commented line.
@@ -47,7 +47,7 @@ def parse_stan_csv_comments_and_draws(
                 draws_lines.append(line)
         return comment_lines, draws_lines
 
-    if isinstance(stan_csv, (str, Path)):
+    if isinstance(stan_csv, (str, os.PathLike)):
         with open(stan_csv, "rb") as f:
             return split_comments_and_draws(f)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text = "BSD-3-Clause" }
 authors = [{ name = "Stan Dev Team" }]
 requires-python = ">=3.8"
-dependencies = ["pandas", "numpy>=1.21", "tqdm", "stanio>=0.4.0,<2.0.0"]
+dependencies = ["pandas", "numpy>=1.21", "tqdm", "stanio>=0.4.0,<2.0.0", "polars>=1.8.2"]
 dynamic = ["version"]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text = "BSD-3-Clause" }
 authors = [{ name = "Stan Dev Team" }]
 requires-python = ">=3.8"
-dependencies = ["pandas", "numpy>=1.21", "tqdm", "stanio>=0.4.0,<2.0.0", "polars>=1.8.2"]
+dependencies = ["pandas", "numpy>=1.21", "tqdm", "stanio>=0.4.0,<2.0.0"]
 dynamic = ["version"]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -40,7 +40,7 @@ packages = ["cmdstanpy", "cmdstanpy.stanfit", "cmdstanpy.utils"]
 "cmdstanpy" = ["py.typed"]
 
 [project.optional-dependencies]
-all = ["xarray"]
+all = ["xarray", "polars>=1.8.2"]
 test = [
     "flake8",
     "pylint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pytest-order",
     "mypy",
     "xarray",
+    "polars>=1.8.2"
 ]
 docs = [
     "sphinx>5,<6",

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -204,6 +204,7 @@ def test_bernoulli_unit_e(
         show_progress=False,
     )
     assert bern_fit.metric_type == 'unit_e'
+    assert bern_fit.metric is None
     assert bern_fit.step_size.shape == (2,)
     with caplog.at_level(logging.INFO):
         logging.getLogger()
@@ -2127,3 +2128,13 @@ def test_mcmc_init_sampling():
 
     assert fit.chains == 4
     assert fit.draws().shape == (1000, 4, 9)
+
+
+def test_sample_dense_mass_matrix():
+    stan = os.path.join(DATAFILES_PATH, 'linear_regression.stan')
+    jdata = os.path.join(DATAFILES_PATH, 'linear_regression.data.json')
+    linear_model = CmdStanModel(stan_file=stan)
+
+    fit = linear_model.sample(data=jdata, metric="dense_e", chains=2)
+    assert fit.metric is not None
+    assert fit.metric.shape == (2, 3, 3)

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -1,11 +1,12 @@
 """testing stancsv parsing"""
 
+from test import without_import
 from typing import List
-from unittest import mock
 
 import numpy as np
 import pytest
 
+import cmdstanpy
 from cmdstanpy.utils import stancsv
 
 
@@ -46,7 +47,7 @@ def test_csv_bytes_to_numpy_no_header_no_polars():
         ],
         dtype=np.float64,
     )
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
         assert np.array_equal(arr_out, expected)
         assert arr_out[0].dtype == np.float64
@@ -100,7 +101,7 @@ def test_csv_bytes_to_numpy_single_element_no_polars():
         ],
         dtype=np.float64,
     )
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
         assert np.array_equal(arr_out, expected)
 
@@ -125,7 +126,7 @@ def test_csv_bytes_to_numpy_with_header_no_polars():
         ],
         dtype=np.float64,
     )
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=True)
         assert np.array_equal(arr_out, expected)
 
@@ -138,7 +139,7 @@ def test_csv_bytes_to_numpy_empty():
 
 def test_csv_bytes_to_numpy_empty_no_polars():
     lines = [b""]
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         with pytest.raises(ValueError):
             stancsv.csv_bytes_list_to_numpy(lines)
 
@@ -161,7 +162,7 @@ def test_csv_bytes_to_numpy_header_no_draws_no_polars():
             b"n_leapfrog__,divergent__,energy__,theta\n"
         ),
     ]
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         with pytest.raises(ValueError):
             stancsv.csv_bytes_list_to_numpy(lines)
 
@@ -272,7 +273,7 @@ def test_csv_polars_and_numpy_equiv():
     arr_out_polars = stancsv.csv_bytes_list_to_numpy(
         lines, includes_header=False
     )
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
             lines, includes_header=False
         )
@@ -286,7 +287,7 @@ def test_csv_polars_and_numpy_equiv_one_line():
     arr_out_polars = stancsv.csv_bytes_list_to_numpy(
         lines, includes_header=False
     )
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
             lines, includes_header=False
         )
@@ -300,7 +301,7 @@ def test_csv_polars_and_numpy_equiv_one_element():
     arr_out_polars = stancsv.csv_bytes_list_to_numpy(
         lines, includes_header=False
     )
-    with mock.patch.dict("sys.modules", {"polars": None}):
+    with without_import("polars", cmdstanpy.utils.stancsv):
         arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
             lines, includes_header=False
         )

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -212,6 +212,7 @@ def test_parsing_adaptation_lines():
 
 def test_parsing_adaptation_lines_diagonal():
     lines = [
+        b"diag_e",  # Will be present in the Stan CSV config
         b"# Adaptation terminated\n",
         b"# Step size = 0.787025\n",
         b"# Diagonal elements of inverse mass matrix:\n",
@@ -220,7 +221,7 @@ def test_parsing_adaptation_lines_diagonal():
     step_size, mass_matrix = stancsv.parse_hmc_adaptation_lines(lines)
     assert step_size == 0.787025
     assert mass_matrix is not None
-    assert np.array_equal(mass_matrix, np.array([[1, 2, 3]]))
+    assert np.array_equal(mass_matrix, np.array([1, 2, 3]))
 
 
 def test_parsing_adaptation_lines_dense():

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -1,9 +1,9 @@
 """testing stancsv parsing"""
 
 from typing import List
+from unittest import mock
 
 import numpy as np
-import polars as pl
 import pytest
 
 from cmdstanpy.utils import stancsv
@@ -30,6 +30,28 @@ def test_csv_bytes_to_numpy_no_header():
     assert arr_out[0].dtype == np.float32
 
 
+def test_csv_bytes_to_numpy_no_header_no_polars():
+    lines = [
+        b"-6.76206,1,0.787025,1,1,0,6.81411,0.229458\n",
+        b"-6.81411,0.983499,0.787025,1,1,0,6.8147,0.20649\n",
+        b"-6.85511,0.994945,0.787025,2,3,0,6.85536,0.310589\n",
+        b"-6.85511,0.812189,0.787025,1,1,0,7.16517,0.310589\n",
+    ]
+    expected = np.array(
+        [
+            [-6.76206, 1, 0.787025, 1, 1, 0, 6.81411, 0.229458],
+            [-6.81411, 0.983499, 0.787025, 1, 1, 0, 6.8147, 0.20649],
+            [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
+            [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
+        ],
+        dtype=np.float32,
+    )
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
+        assert np.array_equiv(arr_out, expected)
+        assert arr_out[0].dtype == np.float32
+
+
 def test_csv_bytes_to_numpy_with_header():
     lines = [
         (
@@ -54,10 +76,42 @@ def test_csv_bytes_to_numpy_with_header():
     assert np.array_equiv(arr_out, expected)
 
 
+def test_csv_bytes_to_numpy_with_header_no_polars():
+    lines = [
+        (
+            b"lp__,accept_stat__,stepsize__,treedepth__,"
+            b"n_leapfrog__,divergent__,energy__,theta\n"
+        ),
+        b"-6.76206,1,0.787025,1,1,0,6.81411,0.229458\n",
+        b"-6.81411,0.983499,0.787025,1,1,0,6.8147,0.20649\n",
+        b"-6.85511,0.994945,0.787025,2,3,0,6.85536,0.310589\n",
+        b"-6.85511,0.812189,0.787025,1,1,0,7.16517,0.310589\n",
+    ]
+    expected = np.array(
+        [
+            [-6.76206, 1, 0.787025, 1, 1, 0, 6.81411, 0.229458],
+            [-6.81411, 0.983499, 0.787025, 1, 1, 0, 6.8147, 0.20649],
+            [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
+            [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
+        ],
+        dtype=np.float32,
+    )
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=True)
+        assert np.array_equiv(arr_out, expected)
+
+
 def test_csv_bytes_to_numpy_empty():
     lines = [b""]
-    with pytest.raises(pl.exceptions.NoDataError):
+    with pytest.raises(ValueError):
         stancsv.csv_bytes_list_to_numpy(lines)
+
+
+def test_csv_bytes_to_numpy_empty_no_polars():
+    lines = [b""]
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        with pytest.raises(ValueError):
+            stancsv.csv_bytes_list_to_numpy(lines)
 
 
 def test_csv_bytes_to_numpy_header_no_draws():
@@ -67,8 +121,20 @@ def test_csv_bytes_to_numpy_header_no_draws():
             b"n_leapfrog__,divergent__,energy__,theta\n"
         ),
     ]
-    arr_out = stancsv.csv_bytes_list_to_numpy(lines)
-    assert arr_out.shape == (0, 8)
+    with pytest.raises(ValueError):
+        stancsv.csv_bytes_list_to_numpy(lines)
+
+
+def test_csv_bytes_to_numpy_header_no_draws_no_polars():
+    lines = [
+        (
+            b"lp__,accept_stat__,stepsize__,treedepth__,"
+            b"n_leapfrog__,divergent__,energy__,theta\n"
+        ),
+    ]
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        with pytest.raises(ValueError):
+            stancsv.csv_bytes_list_to_numpy(lines)
 
 
 def test_parsing_with_rules():

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -23,11 +23,11 @@ def test_csv_bytes_to_numpy_no_header():
             [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
             [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
     assert np.array_equal(arr_out, expected)
-    assert arr_out[0].dtype == np.float32
+    assert arr_out[0].dtype == np.float64
 
 
 def test_csv_bytes_to_numpy_no_header_no_polars():
@@ -44,12 +44,12 @@ def test_csv_bytes_to_numpy_no_header_no_polars():
             [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
             [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     with mock.patch.dict("sys.modules", {"polars": None}):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
         assert np.array_equal(arr_out, expected)
-        assert arr_out[0].dtype == np.float32
+        assert arr_out[0].dtype == np.float64
 
 
 def test_csv_bytes_to_numpy_with_header():
@@ -70,7 +70,7 @@ def test_csv_bytes_to_numpy_with_header():
             [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
             [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=True)
     assert np.array_equal(arr_out, expected)
@@ -84,7 +84,7 @@ def test_csv_bytes_to_numpy_single_element():
         [
             [-6.76206],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
     assert np.array_equal(arr_out, expected)
@@ -98,7 +98,7 @@ def test_csv_bytes_to_numpy_single_element_no_polars():
         [
             [-6.76206],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     with mock.patch.dict("sys.modules", {"polars": None}):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
@@ -123,7 +123,7 @@ def test_csv_bytes_to_numpy_with_header_no_polars():
             [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
             [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     with mock.patch.dict("sys.modules", {"polars": None}):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=True)
@@ -233,7 +233,7 @@ def test_parsing_adaptation_lines_dense():
             [0.230843, 3.92459, 0.126989],
             [0.0509365, 0.126989, 3.82718],
         ],
-        dtype=np.float32,
+        dtype=np.float64,
     )
     assert step_size == 0.775147
     assert mass_matrix is not None

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -182,21 +182,6 @@ def test_parse_comments_and_draws():
     assert draws_lines == [b"2\n", b"3\n"]
 
 
-def test_parsing_timing_lines():
-    lines = [
-        b"# \n",
-        b"#  Elapsed Time: 0.001332 seconds (Warm-up)\n",
-        b"#                0.000249 seconds (Sampling)\n",
-        b"#                0.001581 seconds (Total)\n",
-        b"# \n",
-    ]
-    out = stancsv.parse_timing_lines(lines)
-    assert len(out) == 3
-    assert out['Warm-up'] == 0.001332
-    assert out['Sampling'] == 0.000249
-    assert out['Total'] == 0.001581
-
-
 def test_parsing_adaptation_lines():
     lines = [
         b"# Adaptation terminated\n",

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -26,7 +26,7 @@ def test_csv_bytes_to_numpy_no_header():
         dtype=np.float32,
     )
     arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
-    assert np.array_equiv(arr_out, expected)
+    assert np.array_equal(arr_out, expected)
     assert arr_out[0].dtype == np.float32
 
 
@@ -48,7 +48,7 @@ def test_csv_bytes_to_numpy_no_header_no_polars():
     )
     with mock.patch.dict("sys.modules", {"polars": None}):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
-        assert np.array_equiv(arr_out, expected)
+        assert np.array_equal(arr_out, expected)
         assert arr_out[0].dtype == np.float32
 
 
@@ -73,7 +73,7 @@ def test_csv_bytes_to_numpy_with_header():
         dtype=np.float32,
     )
     arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=True)
-    assert np.array_equiv(arr_out, expected)
+    assert np.array_equal(arr_out, expected)
 
 
 def test_csv_bytes_to_numpy_single_element():
@@ -87,7 +87,7 @@ def test_csv_bytes_to_numpy_single_element():
         dtype=np.float32,
     )
     arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
-    assert np.array_equiv(arr_out, expected)
+    assert np.array_equal(arr_out, expected)
 
 
 def test_csv_bytes_to_numpy_single_element_no_polars():
@@ -102,7 +102,7 @@ def test_csv_bytes_to_numpy_single_element_no_polars():
     )
     with mock.patch.dict("sys.modules", {"polars": None}):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
-        assert np.array_equiv(arr_out, expected)
+        assert np.array_equal(arr_out, expected)
 
 
 def test_csv_bytes_to_numpy_with_header_no_polars():
@@ -127,7 +127,7 @@ def test_csv_bytes_to_numpy_with_header_no_polars():
     )
     with mock.patch.dict("sys.modules", {"polars": None}):
         arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=True)
-        assert np.array_equiv(arr_out, expected)
+        assert np.array_equal(arr_out, expected)
 
 
 def test_csv_bytes_to_numpy_empty():
@@ -214,7 +214,7 @@ def test_parsing_adaptation_lines_diagonal():
     step_size, mass_matrix = stancsv.parse_hmc_adaptation_lines(lines)
     assert step_size == 0.787025
     assert mass_matrix is not None
-    assert np.array_equiv(mass_matrix, np.array([1, 2, 3]))
+    assert np.array_equal(mass_matrix, np.array([[1, 2, 3]]))
 
 
 def test_parsing_adaptation_lines_dense():
@@ -237,7 +237,7 @@ def test_parsing_adaptation_lines_dense():
     )
     assert step_size == 0.775147
     assert mass_matrix is not None
-    assert np.array_equiv(mass_matrix, expected)
+    assert np.array_equal(mass_matrix, expected)
 
 
 def test_parsing_adaptation_lines_missing_step_size():
@@ -276,7 +276,7 @@ def test_csv_polars_and_numpy_equiv():
         arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
             lines, includes_header=False
         )
-    assert np.array_equiv(arr_out_polars, arr_out_numpy)
+    assert np.array_equal(arr_out_polars, arr_out_numpy)
 
 
 def test_csv_polars_and_numpy_equiv_one_line():
@@ -290,7 +290,7 @@ def test_csv_polars_and_numpy_equiv_one_line():
         arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
             lines, includes_header=False
         )
-    assert np.array_equiv(arr_out_polars, arr_out_numpy)
+    assert np.array_equal(arr_out_polars, arr_out_numpy)
 
 
 def test_csv_polars_and_numpy_equiv_one_element():
@@ -304,4 +304,4 @@ def test_csv_polars_and_numpy_equiv_one_element():
         arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
             lines, includes_header=False
         )
-    assert np.array_equiv(arr_out_polars, arr_out_numpy)
+    assert np.array_equal(arr_out_polars, arr_out_numpy)

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -137,57 +137,14 @@ def test_csv_bytes_to_numpy_header_no_draws_no_polars():
             stancsv.csv_bytes_list_to_numpy(lines)
 
 
-def test_parsing_with_rules():
+def test_parse_comments_and_draws():
     lines: List[bytes] = [b"# 1\n", b"2\n", b"3\n", b"# 4\n"]
-    comment_lines = []
-    non_comment_lines = []
-    rules = (
-        stancsv.ParsingRule(action=comment_lines.append),
-        stancsv.ParsingRule(action=non_comment_lines.append),
-        stancsv.ParsingRule(action=comment_lines.append),
+    comment_lines, draws_lines = stancsv.parse_stan_csv_comments_and_draws(
+        iter(lines)
     )
-    stancsv.parse_general_stan_csv_from_lines(iter(lines), rules)
+
     assert comment_lines == [b"# 1\n", b"# 4\n"]
-    assert non_comment_lines == [b"2\n", b"3\n"]
-
-
-def test_parsing_with_rules_not_start_in_comment():
-    lines: List[bytes] = [b"1\n", b"2\n", b"3\n", b"# 4\n"]
-    comment_lines = []
-    non_comment_lines = []
-    rules = (
-        stancsv.ParsingRule(action=non_comment_lines.append),
-        stancsv.ParsingRule(action=comment_lines.append),
-    )
-    stancsv.parse_general_stan_csv_from_lines(
-        iter(lines), rules, start_in_comment=False
-    )
-    assert comment_lines == [b"# 4\n"]
-    assert non_comment_lines == [b"1\n", b"2\n", b"3\n"]
-
-
-def test_parsing_with_rules_entry_action():
-    lines: List[bytes] = [b"# 1\n", b"2\n", b"# 4\n"]
-    parsed, entry = [], []
-    rules = (
-        stancsv.ParsingRule(action=parsed.append),
-        stancsv.ParsingRule(action=parsed.append, entry_action=entry.append),
-        stancsv.ParsingRule(action=parsed.append),
-    )
-    stancsv.parse_general_stan_csv_from_lines(iter(lines), rules)
-    assert parsed == [b"# 1\n", b"# 4\n"]
-    assert entry == [b"2\n"]
-
-
-def test_parsing_insufficient_rules():
-    lines: List[bytes] = [b"# 1\n", b"2\n", b"# 4\n"]
-    parsed = []
-    rules = (
-        stancsv.ParsingRule(action=parsed.append),
-        stancsv.ParsingRule(action=parsed.append),
-    )
-    with pytest.raises(IndexError):
-        stancsv.parse_general_stan_csv_from_lines(iter(lines), rules)
+    assert draws_lines == [b"2\n", b"3\n"]
 
 
 def test_parsing_timing_lines():

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -260,3 +260,48 @@ def test_parsing_adaptation_lines_no_free_params():
     ]
     _, mass_matrix = stancsv.parse_hmc_adaptation_lines(lines)
     assert mass_matrix is None
+
+
+def test_csv_polars_and_numpy_equiv():
+    lines = [
+        b"-6.76206,1,0.787025,1,1,0,6.81411,0.229458\n",
+        b"-6.81411,0.983499,0.787025,1,1,0,6.8147,0.20649\n",
+        b"-6.85511,0.994945,0.787025,2,3,0,6.85536,0.310589\n",
+        b"-6.85511,0.812189,0.787025,1,1,0,7.16517,0.310589\n",
+    ]
+    arr_out_polars = stancsv.csv_bytes_list_to_numpy(
+        lines, includes_header=False
+    )
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
+            lines, includes_header=False
+        )
+    assert np.array_equiv(arr_out_polars, arr_out_numpy)
+
+
+def test_csv_polars_and_numpy_equiv_one_line():
+    lines = [
+        b"-6.76206,1,0.787025,1,1,0,6.81411,0.229458\n",
+    ]
+    arr_out_polars = stancsv.csv_bytes_list_to_numpy(
+        lines, includes_header=False
+    )
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
+            lines, includes_header=False
+        )
+    assert np.array_equiv(arr_out_polars, arr_out_numpy)
+
+
+def test_csv_polars_and_numpy_equiv_one_element():
+    lines = [
+        b"-6.76206\n",
+    ]
+    arr_out_polars = stancsv.csv_bytes_list_to_numpy(
+        lines, includes_header=False
+    )
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        arr_out_numpy = stancsv.csv_bytes_list_to_numpy(
+            lines, includes_header=False
+        )
+    assert np.array_equiv(arr_out_polars, arr_out_numpy)

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -1,5 +1,7 @@
 """testing stancsv parsing"""
 
+import os
+from pathlib import Path
 from test import without_import
 from typing import List
 
@@ -8,6 +10,9 @@ import pytest
 
 import cmdstanpy
 from cmdstanpy.utils import stancsv
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DATAFILES_PATH = os.path.join(HERE, 'data')
 
 
 def test_csv_bytes_to_numpy_no_header():
@@ -306,3 +311,23 @@ def test_csv_polars_and_numpy_equiv_one_element():
             lines, includes_header=False
         )
     assert np.array_equal(arr_out_polars, arr_out_numpy)
+
+
+def test_parse_stan_csv_from_file():
+    csv_path = os.path.join(DATAFILES_PATH, "bernoulli_output_1.csv")
+
+    comment_lines, draws_lines = stancsv.parse_stan_csv_comments_and_draws(
+        csv_path
+    )
+    assert all(ln.startswith(b"#") for ln in comment_lines)
+    assert all(not ln.startswith(b"#") for ln in draws_lines)
+
+    (
+        comment_lines_path,
+        draws_lines_path,
+    ) = stancsv.parse_stan_csv_comments_and_draws(Path(csv_path))
+    assert all(ln.startswith(b"#") for ln in comment_lines)
+    assert all(not ln.startswith(b"#") for ln in draws_lines)
+
+    assert comment_lines == comment_lines_path
+    assert draws_lines == draws_lines_path

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -1,0 +1,210 @@
+"""testing stancsv parsing"""
+
+from typing import List
+
+import numpy as np
+import polars as pl
+import pytest
+
+from cmdstanpy.utils import stancsv
+
+
+def test_csv_bytes_to_numpy_no_header():
+    lines = [
+        b"-6.76206,1,0.787025,1,1,0,6.81411,0.229458\n",
+        b"-6.81411,0.983499,0.787025,1,1,0,6.8147,0.20649\n",
+        b"-6.85511,0.994945,0.787025,2,3,0,6.85536,0.310589\n",
+        b"-6.85511,0.812189,0.787025,1,1,0,7.16517,0.310589\n",
+    ]
+    expected = np.array(
+        [
+            [-6.76206, 1, 0.787025, 1, 1, 0, 6.81411, 0.229458],
+            [-6.81411, 0.983499, 0.787025, 1, 1, 0, 6.8147, 0.20649],
+            [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
+            [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
+        ],
+        dtype=np.float32,
+    )
+    arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
+    assert np.array_equiv(arr_out, expected)
+    assert arr_out[0].dtype == np.float32
+
+
+def test_csv_bytes_to_numpy_with_header():
+    lines = [
+        (
+            b"lp__,accept_stat__,stepsize__,treedepth__,"
+            b"n_leapfrog__,divergent__,energy__,theta\n"
+        ),
+        b"-6.76206,1,0.787025,1,1,0,6.81411,0.229458\n",
+        b"-6.81411,0.983499,0.787025,1,1,0,6.8147,0.20649\n",
+        b"-6.85511,0.994945,0.787025,2,3,0,6.85536,0.310589\n",
+        b"-6.85511,0.812189,0.787025,1,1,0,7.16517,0.310589\n",
+    ]
+    expected = np.array(
+        [
+            [-6.76206, 1, 0.787025, 1, 1, 0, 6.81411, 0.229458],
+            [-6.81411, 0.983499, 0.787025, 1, 1, 0, 6.8147, 0.20649],
+            [-6.85511, 0.994945, 0.787025, 2, 3, 0, 6.85536, 0.310589],
+            [-6.85511, 0.812189, 0.787025, 1, 1, 0, 7.16517, 0.310589],
+        ],
+        dtype=np.float32,
+    )
+    arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=True)
+    assert np.array_equiv(arr_out, expected)
+
+
+def test_csv_bytes_to_numpy_empty():
+    lines = [b""]
+    with pytest.raises(pl.exceptions.NoDataError):
+        stancsv.csv_bytes_list_to_numpy(lines)
+
+
+def test_csv_bytes_to_numpy_header_no_draws():
+    lines = [
+        (
+            b"lp__,accept_stat__,stepsize__,treedepth__,"
+            b"n_leapfrog__,divergent__,energy__,theta\n"
+        ),
+    ]
+    arr_out = stancsv.csv_bytes_list_to_numpy(lines)
+    assert arr_out.shape == (0, 8)
+
+
+def test_parsing_with_rules():
+    lines: List[bytes] = [b"# 1\n", b"2\n", b"3\n", b"# 4\n"]
+    comment_lines = []
+    non_comment_lines = []
+    rules = (
+        stancsv.ParsingRule(action=comment_lines.append),
+        stancsv.ParsingRule(action=non_comment_lines.append),
+        stancsv.ParsingRule(action=comment_lines.append),
+    )
+    stancsv.parse_general_stan_csv_from_lines(iter(lines), rules)
+    assert comment_lines == [b"# 1\n", b"# 4\n"]
+    assert non_comment_lines == [b"2\n", b"3\n"]
+
+
+def test_parsing_with_rules_not_start_in_comment():
+    lines: List[bytes] = [b"1\n", b"2\n", b"3\n", b"# 4\n"]
+    comment_lines = []
+    non_comment_lines = []
+    rules = (
+        stancsv.ParsingRule(action=non_comment_lines.append),
+        stancsv.ParsingRule(action=comment_lines.append),
+    )
+    stancsv.parse_general_stan_csv_from_lines(
+        iter(lines), rules, start_in_comment=False
+    )
+    assert comment_lines == [b"# 4\n"]
+    assert non_comment_lines == [b"1\n", b"2\n", b"3\n"]
+
+
+def test_parsing_with_rules_entry_action():
+    lines: List[bytes] = [b"# 1\n", b"2\n", b"# 4\n"]
+    parsed, entry = [], []
+    rules = (
+        stancsv.ParsingRule(action=parsed.append),
+        stancsv.ParsingRule(action=parsed.append, entry_action=entry.append),
+        stancsv.ParsingRule(action=parsed.append),
+    )
+    stancsv.parse_general_stan_csv_from_lines(iter(lines), rules)
+    assert parsed == [b"# 1\n", b"# 4\n"]
+    assert entry == [b"2\n"]
+
+
+def test_parsing_insufficient_rules():
+    lines: List[bytes] = [b"# 1\n", b"2\n", b"# 4\n"]
+    parsed = []
+    rules = (
+        stancsv.ParsingRule(action=parsed.append),
+        stancsv.ParsingRule(action=parsed.append),
+    )
+    with pytest.raises(IndexError):
+        stancsv.parse_general_stan_csv_from_lines(iter(lines), rules)
+
+
+def test_parsing_timing_lines():
+    lines = [
+        b"# \n",
+        b"#  Elapsed Time: 0.001332 seconds (Warm-up)\n",
+        b"#                0.000249 seconds (Sampling)\n",
+        b"#                0.001581 seconds (Total)\n",
+        b"# \n",
+    ]
+    out = stancsv.parse_timing_lines(lines)
+    assert len(out) == 3
+    assert out['Warm-up'] == 0.001332
+    assert out['Sampling'] == 0.000249
+    assert out['Total'] == 0.001581
+
+
+def test_parsing_adaptation_lines():
+    lines = [
+        b"# Adaptation terminated\n",
+        b"# Step size = 0.787025\n",
+        b"# Diagonal elements of inverse mass matrix:\n",
+        b"# 1\n",
+    ]
+    step_size, mass_matrix = stancsv.parse_hmc_adaptation_lines(lines)
+    assert step_size == 0.787025
+    print(mass_matrix)
+    assert mass_matrix == 1
+
+
+def test_parsing_adaptation_lines_diagonal():
+    lines = [
+        b"# Adaptation terminated\n",
+        b"# Step size = 0.787025\n",
+        b"# Diagonal elements of inverse mass matrix:\n",
+        b"# 1,2,3\n",
+    ]
+    step_size, mass_matrix = stancsv.parse_hmc_adaptation_lines(lines)
+    assert step_size == 0.787025
+    assert mass_matrix is not None
+    assert np.array_equiv(mass_matrix, np.array([1, 2, 3]))
+
+
+def test_parsing_adaptation_lines_dense():
+    lines = [
+        b"# Adaptation terminated\n",
+        b"# Step size = 0.775147\n",
+        b"# Elements of inverse mass matrix:\n",
+        b"# 2.84091, 0.230843, 0.0509365\n",
+        b"# 0.230843, 3.92459, 0.126989\n",
+        b"# 0.0509365, 0.126989, 3.82718\n",
+    ]
+    step_size, mass_matrix = stancsv.parse_hmc_adaptation_lines(lines)
+    expected = np.array(
+        [
+            [2.84091, 0.230843, 0.0509365],
+            [0.230843, 3.92459, 0.126989],
+            [0.0509365, 0.126989, 3.82718],
+        ],
+        dtype=np.float32,
+    )
+    assert step_size == 0.775147
+    assert mass_matrix is not None
+    assert np.array_equiv(mass_matrix, expected)
+
+
+def test_parsing_adaptation_lines_missing_step_size():
+    lines = [
+        b"# Adaptation terminated\n",
+        b"# Elements of inverse mass matrix:\n",
+        b"# 2.84091, 0.230843, 0.0509365\n",
+        b"# 0.230843, 3.92459, 0.126989\n",
+        b"# 0.0509365, 0.126989, 3.82718\n",
+    ]
+    with pytest.raises(ValueError):
+        stancsv.parse_hmc_adaptation_lines(lines)
+
+
+def test_parsing_adaptation_lines_no_free_params():
+    lines = [
+        b"# Adaptation terminated\n",
+        b"# Step size = 1.77497\n",
+        b"# No free parameters for unit metric\n",
+    ]
+    _, mass_matrix = stancsv.parse_hmc_adaptation_lines(lines)
+    assert mass_matrix is None

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -76,6 +76,35 @@ def test_csv_bytes_to_numpy_with_header():
     assert np.array_equiv(arr_out, expected)
 
 
+def test_csv_bytes_to_numpy_single_element():
+    lines = [
+        b"-6.76206\n",
+    ]
+    expected = np.array(
+        [
+            [-6.76206],
+        ],
+        dtype=np.float32,
+    )
+    arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
+    assert np.array_equiv(arr_out, expected)
+
+
+def test_csv_bytes_to_numpy_single_element_no_polars():
+    lines = [
+        b"-6.76206\n",
+    ]
+    expected = np.array(
+        [
+            [-6.76206],
+        ],
+        dtype=np.float32,
+    )
+    with mock.patch.dict("sys.modules", {"polars": None}):
+        arr_out = stancsv.csv_bytes_list_to_numpy(lines, includes_header=False)
+        assert np.array_equiv(arr_out, expected)
+
+
 def test_csv_bytes_to_numpy_with_header_no_polars():
     lines = [
         (


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is in an initial PR that addresses parts of #785. This introduces some general utilities for parsing Stan CSV files and uses some of those changes within `CmdStanMCMC`. 

Some key ideas:

* In an attempt to generalize some of the CSV parsing across different inference methods, this change uses the fact that the CSV outputs are made up of an sequences of commented/uncommented lines that correspond to different sections. The parser logic used here is state-based where a new parsing rule is used each time a transition occurs between a commented and un-commented section.
For example in the standard MCMC output, the sections are `config`, `warmup`, `adaptation`, `samples`, and `timing`. Then one only needs to write some parsing code for each section.
* An optimized parser based on `polars` is implemented that takes in `list[bytes]` corresponding to the lines in the CSV outputs that correspond to draws and produces a `np.array` as a drop in replacement for existing parsing.
* With these utilities, I introduce a `StanCsvMCMC` dataclass which represents the parsed output of a Stan CSV file. It includes a dict representing the sampler config (which just uses the existing `scan_config` function), the warmup draws as a numpy array (if present), the step size and mass matrix (if present), the sampling draws as a numpy array, and the timing information as a dictionary. The idea being that it will be easier to write and read code with this structured representation than have to know how the CSV files are structured.

I use these changes to update the `CmdStanMCMC._assemble_draws` method, which, with the optimized parsing, runs noticeably faster for large models.

Putting this PR as a draft for now, as I want to get some feedback and am planning on writing unit tests to cover the new code, but all existing unit tests are passing on this.

My plan for next steps is to implement a corresponding `StanCsv*` for the various inference methods (I've already done most of this because the logic is very similar) and then update how each of the Stan fit objects pull info from the CSV files. This will make things more consistent across the inference methods and hopefully clean up some parts of the library.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Myself



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

