### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/cmdstanpy/__init__.py
+++ b/cmdstanpy/__init__.py
@@ -37,13 +37,13 @@ from .stanfit import (
 from .utils import (
     cmdstan_path,
     cmdstan_version,
+    disable_logging,
+    enable_logging,
     install_cmdstan,
     set_cmdstan_path,
     set_make_env,
     show_versions,
     write_stan_json,
-    enable_logging,
-    disable_logging,
 )
 
 __all__ = [

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -105,7 +105,9 @@ class SamplerArgs:
         * length of per-chain lists equals specified # of chains
         """
         if not isinstance(chains, (int, np.integer)) or chains < 1:
-            raise ValueError('Sampler expects number of chains to be greater than 0.')
+            raise ValueError(
+                'Sampler expects number of chains to be greater than 0.'
+            )
         if not (
             self.adapt_delta is None
             and self.adapt_init_phase is None
@@ -117,13 +119,17 @@ class SamplerArgs:
                 if self.adapt_delta is not None:
                     msg = '{}, adapt_delta: {}'.format(msg, self.adapt_delta)
                 if self.adapt_init_phase is not None:
-                    msg = '{}, adapt_init_phase: {}'.format(msg, self.adapt_init_phase)
+                    msg = '{}, adapt_init_phase: {}'.format(
+                        msg, self.adapt_init_phase
+                    )
                 if self.adapt_metric_window is not None:
                     msg = '{}, adapt_metric_window: {}'.format(
                         msg, self.adapt_metric_window
                     )
                 if self.adapt_step_size is not None:
-                    msg = '{}, adapt_step_size: {}'.format(msg, self.adapt_step_size)
+                    msg = '{}, adapt_step_size: {}'.format(
+                        msg, self.adapt_step_size
+                    )
                 raise ValueError(msg)
 
         if self.iter_warmup is not None:
@@ -151,7 +157,9 @@ class SamplerArgs:
         positive_int(self.max_treedepth, 'max_treedepth')
 
         if self.step_size is not None:
-            if isinstance(self.step_size, (float, int, np.integer, np.floating)):
+            if isinstance(
+                self.step_size, (float, int, np.integer, np.floating)
+            ):
                 if self.step_size <= 0:
                     raise ValueError(
                         'Argument "step_size" must be > 0, found {}.'.format(
@@ -189,7 +197,9 @@ class SamplerArgs:
                     self.metric_file = self.metric
             elif isinstance(self.metric, dict):
                 if 'inv_metric' not in self.metric:
-                    raise ValueError('Entry "inv_metric" not found in metric dict.')
+                    raise ValueError(
+                        'Entry "inv_metric" not found in metric dict.'
+                    )
                 dims = list(np.asarray(self.metric['inv_metric']).shape)
                 if len(dims) == 1:
                     self.metric_type = 'diag_e'
@@ -218,14 +228,20 @@ class SamplerArgs:
                                 'for chain {}.'.format(i + 1)
                             )
                         if i == 0:
-                            dims = list(np.asarray(metric_dict['inv_metric']).shape)
+                            dims = list(
+                                np.asarray(metric_dict['inv_metric']).shape
+                            )
                         else:
-                            dims2 = list(np.asarray(metric_dict['inv_metric']).shape)
+                            dims2 = list(
+                                np.asarray(metric_dict['inv_metric']).shape
+                            )
                             if dims != dims2:
                                 raise ValueError(
                                     'Found inconsistent "inv_metric" entry '
                                     'for chain {}: entry has dims '
-                                    '{}, expected {}.'.format(i + 1, dims, dims2)
+                                    '{}, expected {}.'.format(
+                                        i + 1, dims, dims2
+                                    )
                                 )
                         dict_file = create_named_text_file(
                             dir=_TMPDIR, prefix="metric", suffix=".json"
@@ -249,13 +265,15 @@ class SamplerArgs:
                             dims2 = read_metric(metric)
                             if len(dims) != len(dims2):
                                 raise ValueError(
-                                    'Metrics files {}, {}, inconsistent metrics'.format(
+                                    'Metrics files {}, {},'
+                                    ' inconsistent metrics'.format(
                                         self.metric[0], metric
                                     )
                                 )
                             if dims != dims2:
                                 raise ValueError(
-                                    'Metrics files {}, {}, inconsistent metrics'.format(
+                                    'Metrics files {}, {},'
+                                    ' inconsistent metrics'.format(
                                         self.metric[0], metric
                                     )
                                 )
@@ -268,7 +286,9 @@ class SamplerArgs:
                 else:
                     raise ValueError(
                         'Argument "metric" must be a list of pathnames or '
-                        'Python dicts, found list of {}.'.format(type(self.metric[0]))
+                        'Python dicts, found list of {}.'.format(
+                            type(self.metric[0])
+                        )
                     )
             else:
                 raise ValueError(
@@ -281,9 +301,8 @@ class SamplerArgs:
         if self.adapt_delta is not None:
             if not 0 < self.adapt_delta < 1:
                 raise ValueError(
-                    'Argument "adapt_delta" must be between 0 and 1, found {}'.format(
-                        self.adapt_delta
-                    )
+                    'Argument "adapt_delta" must be between 0 and 1,'
+                    ' found {}'.format(self.adapt_delta)
                 )
         if self.adapt_init_phase is not None:
             if self.adapt_init_phase < 0 or not isinstance(
@@ -437,7 +456,9 @@ class OptimizeArgs:
                     )
         if self.algorithm.lower() != 'lbfgs':
             if self.history_size is not None:
-                raise ValueError('history_size requires that algorithm be set to lbfgs')
+                raise ValueError(
+                    'history_size requires that algorithm be set to lbfgs'
+                )
 
         positive_float(self.init_alpha, 'init_alpha')
         positive_int(self.iter, 'iter')
@@ -620,7 +641,9 @@ class GenerateQuantitiesArgs:
         """
         for csv in self.sample_csv_files:
             if not os.path.exists(csv):
-                raise ValueError('Invalid path for sample csv file: {}'.format(csv))
+                raise ValueError(
+                    'Invalid path for sample csv file: {}'.format(csv)
+                )
 
     def compose(self, idx: int, cmd: list[str]) -> list[str]:
         """
@@ -667,7 +690,10 @@ class VariationalArgs:
         """
         Check arguments correctness and consistency.
         """
-        if self.algorithm is not None and self.algorithm not in self.VARIATIONAL_ALGOS:
+        if (
+            self.algorithm is not None
+            and self.algorithm not in self.VARIATIONAL_ALGOS
+        ):
             raise ValueError(
                 'Please specify variational algorithms as one of [{}]'.format(
                     ', '.join(self.VARIATIONAL_ALGOS)
@@ -794,16 +820,19 @@ class CmdStanArgs:
                 if chain_id < 1:
                     raise ValueError('invalid chain_id {}'.format(chain_id))
         if self.output_dir is not None:
-            self.output_dir = os.path.realpath(os.path.expanduser(self.output_dir))
+            self.output_dir = os.path.realpath(
+                os.path.expanduser(self.output_dir)
+            )
             if not os.path.exists(self.output_dir):
                 try:
                     os.makedirs(self.output_dir)
-                    get_logger().info('created output directory: %s', self.output_dir)
+                    get_logger().info(
+                        'created output directory: %s', self.output_dir
+                    )
                 except (RuntimeError, PermissionError) as exc:
                     raise ValueError(
-                        'Invalid path for output files, no such dir: {}.'.format(
-                            self.output_dir
-                        )
+                        'Invalid path for output files, '
+                        'no such dir: {}.'.format(self.output_dir)
                     ) from exc
             if not os.path.isdir(self.output_dir):
                 raise ValueError(
@@ -818,12 +847,14 @@ class CmdStanArgs:
                 os.remove(testpath)  # cleanup
             except Exception as exc:
                 raise ValueError(
-                    'Invalid path for output files, cannot write to dir: {}.'.format(
-                        self.output_dir
-                    )
+                    'Invalid path for output files,'
+                    ' cannot write to dir: {}.'.format(self.output_dir)
                 ) from exc
         if self.refresh is not None:
-            if not isinstance(self.refresh, (int, np.integer)) or self.refresh < 1:
+            if (
+                not isinstance(self.refresh, (int, np.integer))
+                or self.refresh < 1
+            ):
                 raise ValueError(
                     'Argument "refresh" must be a positive integer value, '
                     'found {}.'.format(self.refresh)
@@ -895,7 +926,9 @@ class CmdStanArgs:
             if isinstance(self.inits, (float, int, np.floating, np.integer)):
                 if self.inits < 0:
                     raise ValueError(
-                        'Argument "inits" must be > 0, found {}'.format(self.inits)
+                        'Argument "inits" must be > 0, found {}'.format(
+                            self.inits
+                        )
                     )
             elif isinstance(self.inits, str):
                 if not (

--- a/cmdstanpy/cmdstan_args.py
+++ b/cmdstanpy/cmdstan_args.py
@@ -1,10 +1,11 @@
 """
 CmdStan arguments
 """
+
 import os
 from enum import Enum, auto
 from time import time
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 import numpy as np
 from numpy.random import default_rng
@@ -65,9 +66,9 @@ class SamplerArgs:
         thin: Optional[int] = None,
         max_treedepth: Optional[int] = None,
         metric: Union[
-            str, Dict[str, Any], List[str], List[Dict[str, Any]], None
+            str, dict[str, Any], list[str], list[dict[str, Any]], None
         ] = None,
-        step_size: Union[float, List[float], None] = None,
+        step_size: Union[float, list[float], None] = None,
         adapt_engaged: bool = True,
         adapt_delta: Optional[float] = None,
         adapt_init_phase: Optional[int] = None,
@@ -84,7 +85,7 @@ class SamplerArgs:
         self.max_treedepth = max_treedepth
         self.metric = metric
         self.metric_type: Optional[str] = None
-        self.metric_file: Union[str, List[str], None] = None
+        self.metric_file: Union[str, list[str], None] = None
         self.step_size = step_size
         self.adapt_engaged = adapt_engaged
         self.adapt_delta = adapt_delta
@@ -104,9 +105,7 @@ class SamplerArgs:
         * length of per-chain lists equals specified # of chains
         """
         if not isinstance(chains, (int, np.integer)) or chains < 1:
-            raise ValueError(
-                'Sampler expects number of chains to be greater than 0.'
-            )
+            raise ValueError('Sampler expects number of chains to be greater than 0.')
         if not (
             self.adapt_delta is None
             and self.adapt_init_phase is None
@@ -118,17 +117,13 @@ class SamplerArgs:
                 if self.adapt_delta is not None:
                     msg = '{}, adapt_delta: {}'.format(msg, self.adapt_delta)
                 if self.adapt_init_phase is not None:
-                    msg = '{}, adapt_init_phase: {}'.format(
-                        msg, self.adapt_init_phase
-                    )
+                    msg = '{}, adapt_init_phase: {}'.format(msg, self.adapt_init_phase)
                 if self.adapt_metric_window is not None:
                     msg = '{}, adapt_metric_window: {}'.format(
                         msg, self.adapt_metric_window
                     )
                 if self.adapt_step_size is not None:
-                    msg = '{}, adapt_step_size: {}'.format(
-                        msg, self.adapt_step_size
-                    )
+                    msg = '{}, adapt_step_size: {}'.format(msg, self.adapt_step_size)
                 raise ValueError(msg)
 
         if self.iter_warmup is not None:
@@ -156,13 +151,12 @@ class SamplerArgs:
         positive_int(self.max_treedepth, 'max_treedepth')
 
         if self.step_size is not None:
-            if isinstance(
-                self.step_size, (float, int, np.integer, np.floating)
-            ):
+            if isinstance(self.step_size, (float, int, np.integer, np.floating)):
                 if self.step_size <= 0:
                     raise ValueError(
-                        'Argument "step_size" must be > 0, '
-                        'found {}.'.format(self.step_size)
+                        'Argument "step_size" must be > 0, found {}.'.format(
+                            self.step_size
+                        )
                     )
             else:
                 if len(self.step_size) != chains:
@@ -195,9 +189,7 @@ class SamplerArgs:
                     self.metric_file = self.metric
             elif isinstance(self.metric, dict):
                 if 'inv_metric' not in self.metric:
-                    raise ValueError(
-                        'Entry "inv_metric" not found in metric dict.'
-                    )
+                    raise ValueError('Entry "inv_metric" not found in metric dict.')
                 dims = list(np.asarray(self.metric['inv_metric']).shape)
                 if len(dims) == 1:
                     self.metric_type = 'diag_e'
@@ -217,29 +209,23 @@ class SamplerArgs:
                         )
                     )
                 if all(isinstance(elem, dict) for elem in self.metric):
-                    metric_files: List[str] = []
+                    metric_files: list[str] = []
                     for i, metric in enumerate(self.metric):
-                        metric_dict: Dict[str, Any] = metric  # type: ignore
+                        metric_dict: dict[str, Any] = metric  # type: ignore
                         if 'inv_metric' not in metric_dict:
                             raise ValueError(
                                 'Entry "inv_metric" not found in metric dict '
                                 'for chain {}.'.format(i + 1)
                             )
                         if i == 0:
-                            dims = list(
-                                np.asarray(metric_dict['inv_metric']).shape
-                            )
+                            dims = list(np.asarray(metric_dict['inv_metric']).shape)
                         else:
-                            dims2 = list(
-                                np.asarray(metric_dict['inv_metric']).shape
-                            )
+                            dims2 = list(np.asarray(metric_dict['inv_metric']).shape)
                             if dims != dims2:
                                 raise ValueError(
                                     'Found inconsistent "inv_metric" entry '
                                     'for chain {}: entry has dims '
-                                    '{}, expected {}.'.format(
-                                        i + 1, dims, dims2
-                                    )
+                                    '{}, expected {}.'.format(i + 1, dims, dims2)
                                 )
                         dict_file = create_named_text_file(
                             dir=_TMPDIR, prefix="metric", suffix=".json"
@@ -263,15 +249,13 @@ class SamplerArgs:
                             dims2 = read_metric(metric)
                             if len(dims) != len(dims2):
                                 raise ValueError(
-                                    'Metrics files {}, {},'
-                                    ' inconsistent metrics'.format(
+                                    'Metrics files {}, {}, inconsistent metrics'.format(
                                         self.metric[0], metric
                                     )
                                 )
                             if dims != dims2:
                                 raise ValueError(
-                                    'Metrics files {}, {},'
-                                    ' inconsistent metrics'.format(
+                                    'Metrics files {}, {}, inconsistent metrics'.format(
                                         self.metric[0], metric
                                     )
                                 )
@@ -284,9 +268,7 @@ class SamplerArgs:
                 else:
                     raise ValueError(
                         'Argument "metric" must be a list of pathnames or '
-                        'Python dicts, found list of {}.'.format(
-                            type(self.metric[0])
-                        )
+                        'Python dicts, found list of {}.'.format(type(self.metric[0]))
                     )
             else:
                 raise ValueError(
@@ -299,8 +281,9 @@ class SamplerArgs:
         if self.adapt_delta is not None:
             if not 0 < self.adapt_delta < 1:
                 raise ValueError(
-                    'Argument "adapt_delta" must be between 0 and 1,'
-                    ' found {}'.format(self.adapt_delta)
+                    'Argument "adapt_delta" must be between 0 and 1, found {}'.format(
+                        self.adapt_delta
+                    )
                 )
         if self.adapt_init_phase is not None:
             if self.adapt_init_phase < 0 or not isinstance(
@@ -343,7 +326,7 @@ class SamplerArgs:
                 'When fixed_param=True, cannot specify adaptation parameters.'
             )
 
-    def compose(self, idx: int, cmd: List[str]) -> List[str]:
+    def compose(self, idx: int, cmd: list[str]) -> list[str]:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -454,9 +437,7 @@ class OptimizeArgs:
                     )
         if self.algorithm.lower() != 'lbfgs':
             if self.history_size is not None:
-                raise ValueError(
-                    'history_size requires that algorithm be set to lbfgs'
-                )
+                raise ValueError('history_size requires that algorithm be set to lbfgs')
 
         positive_float(self.init_alpha, 'init_alpha')
         positive_int(self.iter, 'iter')
@@ -467,7 +448,7 @@ class OptimizeArgs:
         positive_float(self.tol_param, 'tol_param')
         positive_int(self.history_size, 'history_size')
 
-    def compose(self, _idx: int, cmd: List[str]) -> List[str]:
+    def compose(self, _idx: int, cmd: list[str]) -> list[str]:
         """compose command string for CmdStan for non-default arg values."""
         cmd.append('method=optimize')
         if self.algorithm:
@@ -511,7 +492,7 @@ class LaplaceArgs:
             raise ValueError(f'Invalid path for mode file: {self.mode}')
         positive_int(self.draws, 'draws')
 
-    def compose(self, _idx: int, cmd: List[str]) -> List[str]:
+    def compose(self, _idx: int, cmd: list[str]) -> list[str]:
         """compose command string for CmdStan for non-default arg values."""
         cmd.append('method=laplace')
         cmd.append(f'mode={self.mode}')
@@ -579,7 +560,7 @@ class PathfinderArgs:
         positive_int(self.num_draws, 'num_draws')
         positive_int(self.num_elbo_draws, 'num_elbo_draws')
 
-    def compose(self, _idx: int, cmd: List[str]) -> List[str]:
+    def compose(self, _idx: int, cmd: list[str]) -> list[str]:
         """compose command string for CmdStan for non-default arg values."""
         cmd.append('method=pathfinder')
 
@@ -624,12 +605,13 @@ class PathfinderArgs:
 class GenerateQuantitiesArgs:
     """Arguments needed for generate_quantities method."""
 
-    def __init__(self, csv_files: List[str]) -> None:
+    def __init__(self, csv_files: list[str]) -> None:
         """Initialize object."""
         self.sample_csv_files = csv_files
 
     def validate(
-        self, chains: Optional[int] = None  # pylint: disable=unused-argument
+        self,
+        chains: Optional[int] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Check arguments correctness and consistency.
@@ -638,11 +620,9 @@ class GenerateQuantitiesArgs:
         """
         for csv in self.sample_csv_files:
             if not os.path.exists(csv):
-                raise ValueError(
-                    'Invalid path for sample csv file: {}'.format(csv)
-                )
+                raise ValueError('Invalid path for sample csv file: {}'.format(csv))
 
-    def compose(self, idx: int, cmd: List[str]) -> List[str]:
+    def compose(self, idx: int, cmd: list[str]) -> list[str]:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -681,15 +661,13 @@ class VariationalArgs:
         self.output_samples = output_samples
 
     def validate(
-        self, chains: Optional[int] = None  # pylint: disable=unused-argument
+        self,
+        chains: Optional[int] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Check arguments correctness and consistency.
         """
-        if (
-            self.algorithm is not None
-            and self.algorithm not in self.VARIATIONAL_ALGOS
-        ):
+        if self.algorithm is not None and self.algorithm not in self.VARIATIONAL_ALGOS:
             raise ValueError(
                 'Please specify variational algorithms as one of [{}]'.format(
                     ', '.join(self.VARIATIONAL_ALGOS)
@@ -705,7 +683,7 @@ class VariationalArgs:
         positive_int(self.output_samples, 'output_samples')
 
     # pylint: disable=unused-argument
-    def compose(self, idx: int, cmd: List[str]) -> List[str]:
+    def compose(self, idx: int, cmd: list[str]) -> list[str]:
         """
         Compose CmdStan command for method-specific non-default arguments.
         """
@@ -747,7 +725,7 @@ class CmdStanArgs:
         self,
         model_name: str,
         model_exe: OptionalPath,
-        chain_ids: Optional[List[int]],
+        chain_ids: Optional[list[int]],
         method_args: Union[
             SamplerArgs,
             OptimizeArgs,
@@ -757,8 +735,8 @@ class CmdStanArgs:
             PathfinderArgs,
         ],
         data: Union[Mapping[str, Any], str, None] = None,
-        seed: Union[int, List[int], None] = None,
-        inits: Union[int, float, str, List[str], None] = None,
+        seed: Union[int, list[int], None] = None,
+        inits: Union[int, float, str, list[str], None] = None,
         output_dir: OptionalPath = None,
         sig_figs: Optional[int] = None,
         save_latent_dynamics: bool = False,
@@ -816,19 +794,16 @@ class CmdStanArgs:
                 if chain_id < 1:
                     raise ValueError('invalid chain_id {}'.format(chain_id))
         if self.output_dir is not None:
-            self.output_dir = os.path.realpath(
-                os.path.expanduser(self.output_dir)
-            )
+            self.output_dir = os.path.realpath(os.path.expanduser(self.output_dir))
             if not os.path.exists(self.output_dir):
                 try:
                     os.makedirs(self.output_dir)
-                    get_logger().info(
-                        'created output directory: %s', self.output_dir
-                    )
+                    get_logger().info('created output directory: %s', self.output_dir)
                 except (RuntimeError, PermissionError) as exc:
                     raise ValueError(
-                        'Invalid path for output files, '
-                        'no such dir: {}.'.format(self.output_dir)
+                        'Invalid path for output files, no such dir: {}.'.format(
+                            self.output_dir
+                        )
                     ) from exc
             if not os.path.isdir(self.output_dir):
                 raise ValueError(
@@ -843,14 +818,12 @@ class CmdStanArgs:
                 os.remove(testpath)  # cleanup
             except Exception as exc:
                 raise ValueError(
-                    'Invalid path for output files,'
-                    ' cannot write to dir: {}.'.format(self.output_dir)
+                    'Invalid path for output files, cannot write to dir: {}.'.format(
+                        self.output_dir
+                    )
                 ) from exc
         if self.refresh is not None:
-            if (
-                not isinstance(self.refresh, (int, np.integer))
-                or self.refresh < 1
-            ):
+            if not isinstance(self.refresh, (int, np.integer)) or self.refresh < 1:
                 raise ValueError(
                     'Argument "refresh" must be a positive integer value, '
                     'found {}.'.format(self.refresh)
@@ -922,9 +895,7 @@ class CmdStanArgs:
             if isinstance(self.inits, (float, int, np.floating, np.integer)):
                 if self.inits < 0:
                     raise ValueError(
-                        'Argument "inits" must be > 0, found {}'.format(
-                            self.inits
-                        )
+                        'Argument "inits" must be > 0, found {}'.format(self.inits)
                     )
             elif isinstance(self.inits, str):
                 if not (
@@ -959,11 +930,11 @@ class CmdStanArgs:
         *,
         diagnostic_file: Optional[str] = None,
         profile_file: Optional[str] = None,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Compose CmdStan command for non-default arguments.
         """
-        cmd: List[str] = []
+        cmd: list[str] = []
         if idx is not None and self.chain_ids is not None:
             if idx < 0 or idx > len(self.chain_ids) - 1:
                 raise ValueError(

--- a/cmdstanpy/compilation.py
+++ b/cmdstanpy/compilation.py
@@ -11,7 +11,7 @@ import subprocess
 from copy import copy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Iterable, Optional, Union
 
 from cmdstanpy.utils import get_logger
 from cmdstanpy.utils.cmdstan import (
@@ -81,8 +81,8 @@ class CompilerOptions:
     def __init__(
         self,
         *,
-        stanc_options: Optional[Dict[str, Any]] = None,
-        cpp_options: Optional[Dict[str, Any]] = None,
+        stanc_options: Optional[dict[str, Any]] = None,
+        cpp_options: Optional[dict[str, Any]] = None,
         user_header: OptionalPath = None,
     ) -> None:
         """Initialize object."""
@@ -116,12 +116,12 @@ class CompilerOptions:
         )
 
     @property
-    def stanc_options(self) -> Dict[str, Union[bool, int, str, Iterable[str]]]:
+    def stanc_options(self) -> dict[str, Union[bool, int, str, Iterable[str]]]:
         """Stanc compiler options."""
         return self._stanc_options
 
     @property
-    def cpp_options(self) -> Dict[str, Union[bool, int]]:
+    def cpp_options(self) -> dict[str, Union[bool, int]]:
         """C++ compiler options."""
         return self._cpp_options
 
@@ -165,8 +165,7 @@ class CompilerOptions:
                     del self._stanc_options[deprecated]
                 else:
                     get_logger().warning(
-                        'compiler option "%s" is deprecated and '
-                        'should not be used',
+                        'compiler option "%s" is deprecated and should not be used',
                         deprecated,
                     )
         for key, val in self._stanc_options.items():
@@ -225,8 +224,7 @@ class CompilerOptions:
                 val = self._cpp_options[key]
                 if not isinstance(val, int) or val < 0:
                     raise ValueError(
-                        f'{key} must be a non-negative integer value,'
-                        f' found {val}.'
+                        f'{key} must be a non-negative integer value, found {val}.'
                     )
 
     def validate_user_header(self) -> None:
@@ -236,8 +234,7 @@ class CompilerOptions:
         """
         if self._user_header != "":
             if not (
-                os.path.exists(self._user_header)
-                and os.path.isfile(self._user_header)
+                os.path.exists(self._user_header) and os.path.isfile(self._user_header)
             ):
                 raise ValueError(
                     f"User header file {self._user_header} cannot be found"
@@ -275,9 +272,7 @@ class CompilerOptions:
             else:
                 for key, val in new_opts.stanc_options.items():
                     if key == 'include-paths':
-                        if isinstance(val, Iterable) and not isinstance(
-                            val, str
-                        ):
+                        if isinstance(val, Iterable) and not isinstance(val, str):
                             for path in val:
                                 self.add_include_path(str(path))
                         else:
@@ -298,7 +293,7 @@ class CompilerOptions:
         elif path not in self._stanc_options['include-paths']:
             self._stanc_options['include-paths'].append(path)
 
-    def compose_stanc(self, filename_in_msg: Optional[str]) -> List[str]:
+    def compose_stanc(self, filename_in_msg: Optional[str]) -> list[str]:
         opts = []
 
         if filename_in_msg is not None:
@@ -322,7 +317,7 @@ class CompilerOptions:
                     opts.append(f'--{key}')
         return opts
 
-    def compose(self, filename_in_msg: Optional[str] = None) -> List[str]:
+    def compose(self, filename_in_msg: Optional[str] = None) -> list[str]:
         """
         Format makefile options as list of strings.
 
@@ -342,9 +337,7 @@ class CompilerOptions:
         return opts
 
 
-def src_info(
-    stan_file: str, compiler_options: CompilerOptions
-) -> Dict[str, Any]:
+def src_info(stan_file: str, compiler_options: CompilerOptions) -> dict[str, Any]:
     """
     Get source info for Stan program file.
 
@@ -363,15 +356,15 @@ def src_info(
             f"Failed to get source info for Stan model "
             f"'{stan_file}'. Console:\n{proc.stderr}"
         )
-    result: Dict[str, Any] = json.loads(proc.stdout)
+    result: dict[str, Any] = json.loads(proc.stdout)
     return result
 
 
 def compile_stan_file(
     src: Union[str, Path],
     force: bool = False,
-    stanc_options: Optional[Dict[str, Any]] = None,
-    cpp_options: Optional[Dict[str, Any]] = None,
+    stanc_options: Optional[dict[str, Any]] = None,
+    cpp_options: Optional[dict[str, Any]] = None,
     user_header: OptionalPath = None,
 ) -> str:
     """
@@ -480,7 +473,7 @@ def compile_stan_file(
                     "If the issue persists please open a bug report"
                 )
             raise ValueError(
-                f"Failed to compile Stan model '{src}'. " f"Console:\n{console}"
+                f"Failed to compile Stan model '{src}'. Console:\n{console}"
             )
         return str(exe_target)
 
@@ -492,7 +485,7 @@ def format_stan_file(
     canonicalize: Union[bool, str, Iterable[str]] = False,
     max_line_length: int = 78,
     backup: bool = True,
-    stanc_options: Optional[Dict[str, Any]] = None,
+    stanc_options: Optional[dict[str, Any]] = None,
 ) -> None:
     """
     Run stanc's auto-formatter on the model code. Either saves directly
@@ -532,9 +525,7 @@ def format_stan_file(
                 else:
                     raise ValueError(
                         "Invalid arguments passed for current CmdStan"
-                        + " version({})\n".format(
-                            cmdstan_version() or "Unknown"
-                        )
+                        + " version({})\n".format(cmdstan_version() or "Unknown")
                         + "--canonicalize requires 2.29 or higher"
                     )
             else:

--- a/cmdstanpy/compilation.py
+++ b/cmdstanpy/compilation.py
@@ -165,7 +165,8 @@ class CompilerOptions:
                     del self._stanc_options[deprecated]
                 else:
                     get_logger().warning(
-                        'compiler option "%s" is deprecated and should not be used',
+                        'compiler option "%s" is deprecated and should '
+                        'not be used',
                         deprecated,
                     )
         for key, val in self._stanc_options.items():
@@ -224,7 +225,8 @@ class CompilerOptions:
                 val = self._cpp_options[key]
                 if not isinstance(val, int) or val < 0:
                     raise ValueError(
-                        f'{key} must be a non-negative integer value, found {val}.'
+                        f'{key} must be a non-negative integer '
+                        f'value, found {val}.'
                     )
 
     def validate_user_header(self) -> None:
@@ -234,7 +236,8 @@ class CompilerOptions:
         """
         if self._user_header != "":
             if not (
-                os.path.exists(self._user_header) and os.path.isfile(self._user_header)
+                os.path.exists(self._user_header)
+                and os.path.isfile(self._user_header)
             ):
                 raise ValueError(
                     f"User header file {self._user_header} cannot be found"
@@ -272,7 +275,9 @@ class CompilerOptions:
             else:
                 for key, val in new_opts.stanc_options.items():
                     if key == 'include-paths':
-                        if isinstance(val, Iterable) and not isinstance(val, str):
+                        if isinstance(val, Iterable) and not isinstance(
+                            val, str
+                        ):
                             for path in val:
                                 self.add_include_path(str(path))
                         else:
@@ -337,7 +342,9 @@ class CompilerOptions:
         return opts
 
 
-def src_info(stan_file: str, compiler_options: CompilerOptions) -> dict[str, Any]:
+def src_info(
+    stan_file: str, compiler_options: CompilerOptions
+) -> dict[str, Any]:
     """
     Get source info for Stan program file.
 
@@ -525,7 +532,9 @@ def format_stan_file(
                 else:
                     raise ValueError(
                         "Invalid arguments passed for current CmdStan"
-                        + " version({})\n".format(cmdstan_version() or "Unknown")
+                        + " version({})\n".format(
+                            cmdstan_version() or "Unknown"
+                        )
                         + "--canonicalize requires 2.29 or higher"
                     )
             else:

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -110,7 +110,9 @@ def latest_version() -> str:
                 print('retry ({}/5)'.format(i + 1))
                 sleep(1)
                 continue
-            raise CmdStanRetrieveError('Cannot connect to CmdStan github repo.') from e
+            raise CmdStanRetrieveError(
+                'Cannot connect to CmdStan github repo.'
+            ) from e
     content = json.loads(response.decode('utf-8'))
     tag = content['tag_name']
     match = re.search(r'v?(.+)', tag)
@@ -286,18 +288,26 @@ def build(verbose: bool = False, progress: bool = True, cores: int = 1) -> None:
         raise CmdStanInstallError(f'Command "make build" failed\n{str(e)}')
     if not os.path.exists(os.path.join('bin', 'stansummary' + EXTENSION)):
         raise CmdStanInstallError(
-            f'bin/stansummary{EXTENSION} not found, please rebuild or report a bug!'
+            f'bin/stansummary{EXTENSION} not found, please rebuild or '
+            'report a bug!'
         )
     if not os.path.exists(os.path.join('bin', 'diagnose' + EXTENSION)):
         raise CmdStanInstallError(
-            f'bin/stansummary{EXTENSION} not found, please rebuild or report a bug!'
+            f'bin/stansummary{EXTENSION} not found, please rebuild or '
+            'report a bug!'
         )
 
     if is_windows():
         # Add tbb to the $PATH on Windows
-        libtbb = os.path.join(os.getcwd(), 'stan', 'lib', 'stan_math', 'lib', 'tbb')
+        libtbb = os.path.join(
+            os.getcwd(), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
+        )
         os.environ['PATH'] = ';'.join(
-            list(OrderedDict.fromkeys([libtbb] + os.environ.get('PATH', '').split(';')))
+            list(
+                OrderedDict.fromkeys(
+                    [libtbb] + os.environ.get('PATH', '').split(';')
+                )
+            )
         )
 
 
@@ -408,9 +418,8 @@ def install_version(
         )
         if overwrite and os.path.exists('.'):
             print(
-                'Overwrite requested, remove existing build of version {}'.format(
-                    cmdstan_version
-                )
+                'Overwrite requested, remove existing build '
+                'of version {}'.format(cmdstan_version)
             )
             clean_all(verbose)
             print('Rebuilding version {}'.format(cmdstan_version))
@@ -477,9 +486,9 @@ def retrieve_version(version: str, progress: bool = True) -> None:
     for i in range(6):  # always retry to allow for transient URLErrors
         try:
             if progress and progbar.allow_show_progress():
-                progress_hook: Optional[Callable[[int, int, int], None]] = (
-                    wrap_url_progress_hook()
-                )
+                progress_hook: Optional[
+                    Callable[[int, int, int], None]
+                ] = wrap_url_progress_hook()
             else:
                 progress_hook = None
             file_tmp, _ = urllib.request.urlretrieve(
@@ -488,13 +497,14 @@ def retrieve_version(version: str, progress: bool = True) -> None:
             break
         except urllib.error.HTTPError as e:
             raise CmdStanRetrieveError(
-                'HTTPError: {}\nVersion {} not available from github.com.'.format(
-                    e.code, version
-                )
+                'HTTPError: {}\nVersion {} not available from '
+                'github.com.'.format(e.code, version)
             ) from e
         except urllib.error.URLError as e:
             print(
-                'Failed to download CmdStan version {} from github.com'.format(version)
+                'Failed to download CmdStan version {} from github.com'.format(
+                    version
+                )
             )
             print(e)
             if i < 5:
@@ -640,7 +650,8 @@ def parse_cmdline_args() -> dict[str, Any]:
         '--interactive',
         '-i',
         action='store_true',
-        help="Ignore other arguments and run the installation in " + "interactive mode",
+        help="Ignore other arguments and run the installation in "
+        + "interactive mode",
     )
     parser.add_argument(
         '--version',

--- a/cmdstanpy/install_cmdstan.py
+++ b/cmdstanpy/install_cmdstan.py
@@ -17,6 +17,7 @@ Optional command line arguments:
    --cores: int, number of cores to use when building, defaults to 1
    -c, --compiler : flag, add C++ compiler to path (Windows only)
 """
+
 import argparse
 import json
 import os
@@ -30,7 +31,7 @@ import urllib.request
 from collections import OrderedDict
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from tqdm.auto import tqdm
 
@@ -85,7 +86,7 @@ MAKE = os.getenv('MAKE', 'make' if not is_windows() else 'mingw32-make')
 EXTENSION = '.exe' if is_windows() else ''
 
 
-def get_headers() -> Dict[str, str]:
+def get_headers() -> dict[str, str]:
     """Create headers dictionary."""
     headers = {}
     GITHUB_PAT = os.environ.get("GITHUB_PAT")  # pylint:disable=invalid-name
@@ -109,9 +110,7 @@ def latest_version() -> str:
                 print('retry ({}/5)'.format(i + 1))
                 sleep(1)
                 continue
-            raise CmdStanRetrieveError(
-                'Cannot connect to CmdStan github repo.'
-            ) from e
+            raise CmdStanRetrieveError('Cannot connect to CmdStan github repo.') from e
     content = json.loads(response.decode('utf-8'))
     tag = content['tag_name']
     match = re.search(r'v?(.+)', tag)
@@ -287,26 +286,18 @@ def build(verbose: bool = False, progress: bool = True, cores: int = 1) -> None:
         raise CmdStanInstallError(f'Command "make build" failed\n{str(e)}')
     if not os.path.exists(os.path.join('bin', 'stansummary' + EXTENSION)):
         raise CmdStanInstallError(
-            f'bin/stansummary{EXTENSION} not found'
-            ', please rebuild or report a bug!'
+            f'bin/stansummary{EXTENSION} not found, please rebuild or report a bug!'
         )
     if not os.path.exists(os.path.join('bin', 'diagnose' + EXTENSION)):
         raise CmdStanInstallError(
-            f'bin/stansummary{EXTENSION} not found'
-            ', please rebuild or report a bug!'
+            f'bin/stansummary{EXTENSION} not found, please rebuild or report a bug!'
         )
 
     if is_windows():
         # Add tbb to the $PATH on Windows
-        libtbb = os.path.join(
-            os.getcwd(), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
-        )
+        libtbb = os.path.join(os.getcwd(), 'stan', 'lib', 'stan_math', 'lib', 'tbb')
         os.environ['PATH'] = ';'.join(
-            list(
-                OrderedDict.fromkeys(
-                    [libtbb] + os.environ.get('PATH', '').split(';')
-                )
-            )
+            list(OrderedDict.fromkeys([libtbb] + os.environ.get('PATH', '').split(';')))
         )
 
 
@@ -417,8 +408,9 @@ def install_version(
         )
         if overwrite and os.path.exists('.'):
             print(
-                'Overwrite requested, remove existing build of version '
-                '{}'.format(cmdstan_version)
+                'Overwrite requested, remove existing build of version {}'.format(
+                    cmdstan_version
+                )
             )
             clean_all(verbose)
             print('Rebuilding version {}'.format(cmdstan_version))
@@ -485,9 +477,9 @@ def retrieve_version(version: str, progress: bool = True) -> None:
     for i in range(6):  # always retry to allow for transient URLErrors
         try:
             if progress and progbar.allow_show_progress():
-                progress_hook: Optional[
-                    Callable[[int, int, int], None]
-                ] = wrap_url_progress_hook()
+                progress_hook: Optional[Callable[[int, int, int], None]] = (
+                    wrap_url_progress_hook()
+                )
             else:
                 progress_hook = None
             file_tmp, _ = urllib.request.urlretrieve(
@@ -496,16 +488,13 @@ def retrieve_version(version: str, progress: bool = True) -> None:
             break
         except urllib.error.HTTPError as e:
             raise CmdStanRetrieveError(
-                'HTTPError: {}\n'
-                'Version {} not available from github.com.'.format(
+                'HTTPError: {}\nVersion {} not available from github.com.'.format(
                     e.code, version
                 )
             ) from e
         except urllib.error.URLError as e:
             print(
-                'Failed to download CmdStan version {} from github.com'.format(
-                    version
-                )
+                'Failed to download CmdStan version {} from github.com'.format(version)
             )
             print(e)
             if i < 5:
@@ -645,14 +634,13 @@ def run_install(args: Union[InteractiveSettings, InstallationSettings]) -> None:
             compile_example(args.verbose)
 
 
-def parse_cmdline_args() -> Dict[str, Any]:
+def parse_cmdline_args() -> dict[str, Any]:
     parser = argparse.ArgumentParser("install_cmdstan")
     parser.add_argument(
         '--interactive',
         '-i',
         action='store_true',
-        help="Ignore other arguments and run the installation in "
-        + "interactive mode",
+        help="Ignore other arguments and run the installation in " + "interactive mode",
     )
     parser.add_argument(
         '--version',

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -244,9 +244,7 @@ def get_url(version: str) -> str:
         if version == '4.0':
             # pylint: disable=line-too-long
             if IS_64BITS:
-                url = (
-                    'https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe'  # noqa: disable=E501
-                )
+                url = 'https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe'  # noqa: disable=E501
             else:
                 url = 'https://cran.r-project.org/bin/windows/Rtools/rtools40-i686.exe'  # noqa: disable=E501
         elif version == '3.5':
@@ -311,7 +309,9 @@ def run_rtools_install(args: dict[str, Any]) -> None:
         else:
             if os.path.exists(toolchain_folder):
                 shutil.rmtree(toolchain_folder, ignore_errors=False)
-            retrieve_toolchain(toolchain_folder + EXTENSION, url, progress=progress)
+            retrieve_toolchain(
+                toolchain_folder + EXTENSION, url, progress=progress
+            )
             install_version(
                 toolchain_folder,
                 toolchain_folder + EXTENSION,
@@ -325,7 +325,9 @@ def run_rtools_install(args: dict[str, Any]) -> None:
             and (version in ('4.0', '4', '40'))
         ):
             if os.path.exists(
-                os.path.join(toolchain_folder, 'mingw64', 'bin', 'mingw32-make.exe')
+                os.path.join(
+                    toolchain_folder, 'mingw64', 'bin', 'mingw32-make.exe'
+                )
             ):
                 print('mingw32-make.exe already installed')
             else:

--- a/cmdstanpy/install_cxx_toolchain.py
+++ b/cmdstanpy/install_cxx_toolchain.py
@@ -12,6 +12,7 @@ Optional command line arguments:
    -m --no-make : don't install mingw32-make (Windows RTools 4.0 only)
    --progress : flag, when specified show progress bar for RTools download
 """
+
 import argparse
 import os
 import platform
@@ -21,7 +22,7 @@ import sys
 import urllib.request
 from collections import OrderedDict
 from time import sleep
-from typing import Any, Dict, List
+from typing import Any
 
 from cmdstanpy import _DOT_CMDSTAN
 from cmdstanpy.utils import pushd, validate_dir, wrap_url_progress_hook
@@ -44,7 +45,7 @@ def usage() -> None:
     )
 
 
-def get_config(dir: str, silent: bool) -> List[str]:
+def get_config(dir: str, silent: bool) -> list[str]:
     """Assemble config info."""
     config = []
     if platform.system() == 'Windows':
@@ -243,7 +244,9 @@ def get_url(version: str) -> str:
         if version == '4.0':
             # pylint: disable=line-too-long
             if IS_64BITS:
-                url = 'https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe'  # noqa: disable=E501
+                url = (
+                    'https://cran.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe'  # noqa: disable=E501
+                )
             else:
                 url = 'https://cran.r-project.org/bin/windows/Rtools/rtools40-i686.exe'  # noqa: disable=E501
         elif version == '3.5':
@@ -260,7 +263,7 @@ def get_toolchain_version(name: str, version: str) -> str:
     return toolchain_folder
 
 
-def run_rtools_install(args: Dict[str, Any]) -> None:
+def run_rtools_install(args: dict[str, Any]) -> None:
     """Main."""
     if platform.system() not in {'Windows'}:
         raise NotImplementedError(
@@ -308,9 +311,7 @@ def run_rtools_install(args: Dict[str, Any]) -> None:
         else:
             if os.path.exists(toolchain_folder):
                 shutil.rmtree(toolchain_folder, ignore_errors=False)
-            retrieve_toolchain(
-                toolchain_folder + EXTENSION, url, progress=progress
-            )
+            retrieve_toolchain(toolchain_folder + EXTENSION, url, progress=progress)
             install_version(
                 toolchain_folder,
                 toolchain_folder + EXTENSION,
@@ -324,16 +325,14 @@ def run_rtools_install(args: Dict[str, Any]) -> None:
             and (version in ('4.0', '4', '40'))
         ):
             if os.path.exists(
-                os.path.join(
-                    toolchain_folder, 'mingw64', 'bin', 'mingw32-make.exe'
-                )
+                os.path.join(toolchain_folder, 'mingw64', 'bin', 'mingw32-make.exe')
             ):
                 print('mingw32-make.exe already installed')
             else:
                 install_mingw32_make(toolchain_folder, verbose)
 
 
-def parse_cmdline_args() -> Dict[str, Any]:
+def parse_cmdline_args() -> dict[str, Any]:
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', '-v', help="version, defaults to latest")
     parser.add_argument(

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -16,9 +16,7 @@ from multiprocessing import cpu_count
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
-    List,
     Literal,
     Mapping,
     Optional,
@@ -115,8 +113,8 @@ class CmdStanModel:
         stan_file: OptionalPath = None,
         exe_file: OptionalPath = None,
         force_compile: bool = False,
-        stanc_options: Optional[Dict[str, Any]] = None,
-        cpp_options: Optional[Dict[str, Any]] = None,
+        stanc_options: Optional[dict[str, Any]] = None,
+        cpp_options: Optional[dict[str, Any]] = None,
         user_header: OptionalPath = None,
         *,
         compile: Union[bool, Literal['force'], None] = None,
@@ -186,9 +184,7 @@ class CmdStanModel:
                 raise ValueError('no such file {}'.format(self._stan_file))
             _, filename = os.path.split(stan_file)
             if len(filename) < 6 or not filename.endswith('.stan'):
-                raise ValueError(
-                    'invalid stan filename {}'.format(self._stan_file)
-                )
+                raise ValueError('invalid stan filename {}'.format(self._stan_file))
             if not self._name:
                 self._name, _ = os.path.splitext(filename)
 
@@ -200,9 +196,7 @@ class CmdStanModel:
                 self._compiler_options.add_include_path(path)
 
             # try to detect models w/out parameters, needed for sampler
-            if (not cmdstan_version_before(2, 27)) and cmdstan_version_before(
-                2, 36
-            ):
+            if (not cmdstan_version_before(2, 27)) and cmdstan_version_before(2, 36):
                 try:
                     model_info = self.src_info()
                     if 'parameters' in model_info:
@@ -277,14 +271,14 @@ class CmdStanModel:
         """Full path to Stan exe file."""
         return self._exe_file
 
-    def exe_info(self) -> Dict[str, str]:
+    def exe_info(self) -> dict[str, str]:
         """
         Run model with option 'info'. Parse output statements, which all
         have form 'key = value' into a Dict.
         If exe file compiled with CmdStan < 2.27, option 'info' isn't
         available and the method returns an empty dictionary.
         """
-        result: Dict[str, str] = {}
+        result: dict[str, str] = {}
         if self.exe_file is None:
             return result
         try:
@@ -301,7 +295,7 @@ class CmdStanModel:
             get_logger().debug(e)
             return result
 
-    def src_info(self) -> Dict[str, Any]:
+    def src_info(self) -> dict[str, Any]:
         """
         Run stanc with option '--info'.
 
@@ -360,12 +354,12 @@ class CmdStanModel:
         )
 
     @property
-    def stanc_options(self) -> Dict[str, Union[bool, int, str]]:
+    def stanc_options(self) -> dict[str, Union[bool, int, str]]:
         """Options to stanc compilers."""
         return self._compiler_options._stanc_options
 
     @property
-    def cpp_options(self) -> Dict[str, Union[bool, int]]:
+    def cpp_options(self) -> dict[str, Union[bool, int]]:
         """Options to C++ compilers."""
         return self._compiler_options._cpp_options
 
@@ -384,17 +378,15 @@ class CmdStanModel:
             with open(self._stan_file, 'r') as fd:
                 code = fd.read()
         except IOError:
-            get_logger().error(
-                'Cannot read file Stan file: %s', self._stan_file
-            )
+            get_logger().error('Cannot read file Stan file: %s', self._stan_file)
         return code
 
     # TODO(2.0): remove
     def compile(
         self,
         force: bool = False,
-        stanc_options: Optional[Dict[str, Any]] = None,
-        cpp_options: Optional[Dict[str, Any]] = None,
+        stanc_options: Optional[dict[str, Any]] = None,
+        cpp_options: Optional[dict[str, Any]] = None,
         user_header: OptionalPath = None,
         override_options: bool = False,
         *,
@@ -618,9 +610,10 @@ class CmdStanModel:
                 "in CmdStan 2.32 and above."
             )
 
-        with temp_single_json(data) as _data, temp_inits(
-            inits, allow_multiple=False
-        ) as _inits:
+        with (
+            temp_single_json(data) as _data,
+            temp_inits(inits, allow_multiple=False) as _inits,
+        ):
             args = CmdStanArgs(
                 self._name,
                 self._exe_file,
@@ -662,14 +655,14 @@ class CmdStanModel:
         chains: Optional[int] = None,
         parallel_chains: Optional[int] = None,
         threads_per_chain: Optional[int] = None,
-        seed: Union[int, List[int], None] = None,
-        chain_ids: Union[int, List[int], None] = None,
+        seed: Union[int, list[int], None] = None,
+        chain_ids: Union[int, list[int], None] = None,
         inits: Union[
             Mapping[str, Any],
             float,
             str,
-            List[str],
-            List[Mapping[str, Any]],
+            list[str],
+            list[Mapping[str, Any]],
             None,
         ] = None,
         iter_warmup: Optional[int] = None,
@@ -678,9 +671,9 @@ class CmdStanModel:
         thin: Optional[int] = None,
         max_treedepth: Optional[int] = None,
         metric: Union[
-            str, Dict[str, Any], List[str], List[Dict[str, Any]], None
+            str, dict[str, Any], list[str], list[dict[str, Any]], None
         ] = None,
-        step_size: Union[float, List[float], None] = None,
+        step_size: Union[float, list[float], None] = None,
         adapt_engaged: bool = True,
         adapt_delta: Optional[float] = None,
         adapt_init_phase: Optional[int] = None,
@@ -904,9 +897,7 @@ class CmdStanModel:
             chains = 4
         if chains < 1:
             raise ValueError(
-                'Chains must be a positive integer value, found {}.'.format(
-                    chains
-                )
+                'Chains must be a positive integer value, found {}.'.format(chains)
             )
 
         if parallel_chains is None:
@@ -921,8 +912,9 @@ class CmdStanModel:
             parallel_chains = chains
         elif parallel_chains < 1:
             raise ValueError(
-                'Argument parallel_chains must be a positive integer, '
-                'found {}.'.format(parallel_chains)
+                'Argument parallel_chains must be a positive integer, found {}.'.format(
+                    parallel_chains
+                )
             )
         if threads_per_chain is None:
             threads_per_chain = 1
@@ -977,8 +969,9 @@ class CmdStanModel:
             if isinstance(chain_ids, int):
                 if chain_ids < 1:
                     raise ValueError(
-                        'Chain_id must be a positive integer value,'
-                        ' found {}.'.format(chain_ids)
+                        'Chain_id must be a positive integer value, found {}.'.format(
+                            chain_ids
+                        )
                     )
                 chain_ids = [i + chain_ids for i in range(chains)]
             else:
@@ -1020,13 +1013,15 @@ class CmdStanModel:
             fixed_param=fixed_param,
         )
 
-        with temp_single_json(data) as _data, temp_inits(
-            inits, id=chain_ids[0]
-        ) as _inits:
-            cmdstan_inits: Union[str, List[str], int, float, None]
+        with (
+            temp_single_json(data) as _data,
+            temp_inits(inits, id=chain_ids[0]) as _inits,
+        ):
+            cmdstan_inits: Union[str, list[str], int, float, None]
             if one_process_per_chain and isinstance(inits, list):  # legacy
                 cmdstan_inits = [
-                    f"{_inits[:-5]}_{i}.json" for i in chain_ids  # type: ignore
+                    f"{_inits[:-5]}_{i}.json"
+                    for i in chain_ids  # type: ignore
                 ]
             else:
                 cmdstan_inits = _inits
@@ -1141,7 +1136,7 @@ class CmdStanModel:
     def generate_quantities(
         self,
         data: Union[Mapping[str, Any], str, os.PathLike, None] = None,
-        previous_fit: Union[Fit, List[str], None] = None,
+        previous_fit: Union[Fit, list[str], None] = None,
         seed: Optional[int] = None,
         gq_output_dir: OptionalPath = None,
         sig_figs: Optional[int] = None,
@@ -1150,7 +1145,7 @@ class CmdStanModel:
         time_fmt: str = "%Y%m%d%H%M%S",
         timeout: Optional[float] = None,
         *,
-        mcmc_sample: Union[CmdStanMCMC, List[str], None] = None,
+        mcmc_sample: Union[CmdStanMCMC, list[str], None] = None,
     ) -> CmdStanGQ[Fit]:
         """
         Run CmdStan's generate_quantities method which runs the generated
@@ -1235,9 +1230,7 @@ class CmdStanModel:
             fit_csv_files = previous_fit.runset.csv_files
         elif isinstance(previous_fit, list):
             if len(previous_fit) < 1:
-                raise ValueError(
-                    'Expecting list of Stan CSV files, found empty list'
-                )
+                raise ValueError('Expecting list of Stan CSV files, found empty list')
             try:
                 fit_csv_files = previous_fit
                 fit_object = from_csv(fit_csv_files)  # type: ignore
@@ -1283,9 +1276,7 @@ class CmdStanModel:
             chains = 1
             chain_ids = [1]
 
-        generate_quantities_args = GenerateQuantitiesArgs(
-            csv_files=fit_csv_files
-        )
+        generate_quantities_args = GenerateQuantitiesArgs(csv_files=fit_csv_files)
         generate_quantities_args.validate(chains)
         with temp_single_json(data) as _data:
             args = CmdStanArgs(
@@ -1481,9 +1472,10 @@ class CmdStanModel:
             output_samples=draws,
         )
 
-        with temp_single_json(data) as _data, temp_inits(
-            inits, allow_multiple=False
-        ) as _inits:
+        with (
+            temp_single_json(data) as _data,
+            temp_inits(inits, allow_multiple=False) as _inits,
+        ):
             args = CmdStanArgs(
                 self._name,
                 self._exe_file,
@@ -1531,9 +1523,7 @@ class CmdStanModel:
             transcript_file = runset.stdout_files[dummy_chain_id]
             with open(transcript_file, 'r') as transcript:
                 contents = transcript.read()
-            pat = re.compile(
-                r'stan::variational::normal_meanfield::calc_grad:', re.M
-            )
+            pat = re.compile(r'stan::variational::normal_meanfield::calc_grad:', re.M)
             if len(re.findall(pat, contents)) > 0:
                 if grad_samples is None:
                     grad_samples = 10
@@ -1571,7 +1561,7 @@ class CmdStanModel:
         calculate_lp: bool = True,
         # arguments standard to all methods
         seed: Optional[int] = None,
-        inits: Union[Dict[str, float], float, str, os.PathLike, None] = None,
+        inits: Union[dict[str, float], float, str, os.PathLike, None] = None,
         output_dir: OptionalPath = None,
         sig_figs: Optional[int] = None,
         save_profile: bool = False,
@@ -1700,8 +1690,7 @@ class CmdStanModel:
         exe_info = self.exe_info()
         if cmdstan_version_before(2, 33, exe_info):
             raise ValueError(
-                "Method 'pathfinder' not available for CmdStan versions "
-                "before 2.33"
+                "Method 'pathfinder' not available for CmdStan versions before 2.33"
             )
 
         if (not psis_resample or not calculate_lp) and cmdstan_version_before(
@@ -1713,10 +1702,7 @@ class CmdStanModel:
             )
 
         if num_threads is not None:
-            if (
-                num_threads != 1
-                and exe_info.get('STAN_THREADS', '').lower() != 'true'
-            ):
+            if num_threads != 1 and exe_info.get('STAN_THREADS', '').lower() != 'true':
                 raise ValueError(
                     "Model must be compiled with 'STAN_THREADS=true' to use"
                     " 'num_threads' argument"
@@ -1782,7 +1768,7 @@ class CmdStanModel:
 
     def log_prob(
         self,
-        params: Union[Dict[str, Any], str, os.PathLike],
+        params: Union[dict[str, Any], str, os.PathLike],
         data: Union[Mapping[str, Any], str, os.PathLike, None] = None,
         *,
         jacobian: bool = True,
@@ -1821,12 +1807,9 @@ class CmdStanModel:
 
         if cmdstan_version_before(2, 31, self.exe_info()):
             raise ValueError(
-                "Method 'log_prob' not available for CmdStan versions "
-                "before 2.31"
+                "Method 'log_prob' not available for CmdStan versions before 2.31"
             )
-        with temp_single_json(data) as _data, temp_single_json(
-            params
-        ) as _params:
+        with temp_single_json(data) as _data, temp_single_json(params) as _params:
             cmd = [
                 str(self.exe_file),
                 "log_prob",
@@ -1845,9 +1828,7 @@ class CmdStanModel:
 
             get_logger().debug("Cmd: %s", str(cmd))
 
-            proc = subprocess.run(
-                cmd, capture_output=True, check=False, text=True
-            )
+            proc = subprocess.run(cmd, capture_output=True, check=False, text=True)
             if proc.returncode:
                 get_logger().error(
                     "'log_prob' command failed!\nstdout:%s\nstderr:%s",
@@ -1855,8 +1836,7 @@ class CmdStanModel:
                     proc.stderr,
                 )
                 raise RuntimeError(
-                    "Method 'log_prob' failed with return code "
-                    + str(proc.returncode)
+                    "Method 'log_prob' failed with return code " + str(proc.returncode)
                 )
 
             result = pd.read_csv(output, comment="#")
@@ -1877,7 +1857,7 @@ class CmdStanModel:
         refresh: Optional[int] = None,
         time_fmt: str = "%Y%m%d%H%M%S",
         timeout: Optional[float] = None,
-        opt_args: Optional[Dict[str, Any]] = None,
+        opt_args: Optional[dict[str, Any]] = None,
     ) -> CmdStanLaplace:
         """
         Run a Laplace approximation around the posterior mode.
@@ -1936,13 +1916,10 @@ class CmdStanModel:
         """
         if cmdstan_version_before(2, 32, self.exe_info()):
             raise ValueError(
-                "Method 'laplace_sample' not available for CmdStan versions "
-                "before 2.32"
+                "Method 'laplace_sample' not available for CmdStan versions before 2.32"
             )
         if opt_args is not None and mode is not None:
-            raise ValueError(
-                "Cannot specify both 'opt_args' and 'mode' arguments"
-            )
+            raise ValueError("Cannot specify both 'opt_args' and 'mode' arguments")
         if mode is None:
             optimize_args = {
                 "seed": seed,
@@ -1973,9 +1950,7 @@ class CmdStanModel:
             cmdstan_mode = mode
 
         if cmdstan_mode.runset.method != Method.OPTIMIZE:
-            raise ValueError(
-                "Mode must be a CmdStanMLE or a path to an optimize CSV"
-            )
+            raise ValueError("Mode must be a CmdStanMLE or a path to an optimize CSV")
 
         mode_jacobian = (
             cmdstan_mode.runset._args.method_args.jacobian  # type: ignore
@@ -1987,9 +1962,7 @@ class CmdStanModel:
                 f"but optimize was run with jacobian={mode_jacobian}"
             )
 
-        laplace_args = LaplaceArgs(
-            cmdstan_mode.runset.csv_files[0], draws, jacobian
-        )
+        laplace_args = LaplaceArgs(cmdstan_mode.runset.csv_files[0], draws, jacobian)
 
         with temp_single_json(data) as _data:
             args = CmdStanArgs(
@@ -2120,7 +2093,7 @@ class CmdStanModel:
     @staticmethod
     @progbar.wrap_callback
     def _wrap_sampler_progress_hook(
-        chain_ids: List[int],
+        chain_ids: list[int],
         total: int,
     ) -> Optional[Callable[[str, int], None]]:
         """
@@ -2130,7 +2103,7 @@ class CmdStanModel:
         For the latter, manage array of pbars, update accordingly.
         """
         chain_pat = re.compile(r'(Chain \[(\d+)\] )?Iteration:\s+(\d+)')
-        pbars: Dict[int, tqdm] = {
+        pbars: dict[int, tqdm] = {
             chain_id: tqdm(
                 total=total,
                 desc=f'chain {chain_id}',
@@ -2161,7 +2134,7 @@ class CmdStanModel:
 
     def diagnose(
         self,
-        inits: Union[Dict[str, Any], str, os.PathLike, None] = None,
+        inits: Union[dict[str, Any], str, os.PathLike, None] = None,
         data: Union[Mapping[str, Any], str, os.PathLike, None] = None,
         *,
         epsilon: Optional[float] = None,
@@ -2235,9 +2208,7 @@ class CmdStanModel:
 
             get_logger().debug("Cmd: %s", str(cmd))
 
-            proc = subprocess.run(
-                cmd, capture_output=True, check=False, text=True
-            )
+            proc = subprocess.run(cmd, capture_output=True, check=False, text=True)
             if proc.returncode:
                 get_logger().error(
                     "'diagnose' command failed!\nstdout:%s\nstderr:%s",

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -184,7 +184,9 @@ class CmdStanModel:
                 raise ValueError('no such file {}'.format(self._stan_file))
             _, filename = os.path.split(stan_file)
             if len(filename) < 6 or not filename.endswith('.stan'):
-                raise ValueError('invalid stan filename {}'.format(self._stan_file))
+                raise ValueError(
+                    'invalid stan filename {}'.format(self._stan_file)
+                )
             if not self._name:
                 self._name, _ = os.path.splitext(filename)
 
@@ -196,7 +198,9 @@ class CmdStanModel:
                 self._compiler_options.add_include_path(path)
 
             # try to detect models w/out parameters, needed for sampler
-            if (not cmdstan_version_before(2, 27)) and cmdstan_version_before(2, 36):
+            if (not cmdstan_version_before(2, 27)) and cmdstan_version_before(
+                2, 36
+            ):
                 try:
                     model_info = self.src_info()
                     if 'parameters' in model_info:
@@ -378,7 +382,9 @@ class CmdStanModel:
             with open(self._stan_file, 'r') as fd:
                 code = fd.read()
         except IOError:
-            get_logger().error('Cannot read file Stan file: %s', self._stan_file)
+            get_logger().error(
+                'Cannot read file Stan file: %s', self._stan_file
+            )
         return code
 
     # TODO(2.0): remove
@@ -897,7 +903,9 @@ class CmdStanModel:
             chains = 4
         if chains < 1:
             raise ValueError(
-                'Chains must be a positive integer value, found {}.'.format(chains)
+                'Chains must be a positive integer value, found {}.'.format(
+                    chains
+                )
             )
 
         if parallel_chains is None:
@@ -912,9 +920,8 @@ class CmdStanModel:
             parallel_chains = chains
         elif parallel_chains < 1:
             raise ValueError(
-                'Argument parallel_chains must be a positive integer, found {}.'.format(
-                    parallel_chains
-                )
+                'Argument parallel_chains must be a positive '
+                'integer, found {}.'.format(parallel_chains)
             )
         if threads_per_chain is None:
             threads_per_chain = 1
@@ -969,9 +976,8 @@ class CmdStanModel:
             if isinstance(chain_ids, int):
                 if chain_ids < 1:
                     raise ValueError(
-                        'Chain_id must be a positive integer value, found {}.'.format(
-                            chain_ids
-                        )
+                        'Chain_id must be a positive integer value, '
+                        'found {}.'.format(chain_ids)
                     )
                 chain_ids = [i + chain_ids for i in range(chains)]
             else:
@@ -1020,8 +1026,7 @@ class CmdStanModel:
             cmdstan_inits: Union[str, list[str], int, float, None]
             if one_process_per_chain and isinstance(inits, list):  # legacy
                 cmdstan_inits = [
-                    f"{_inits[:-5]}_{i}.json"
-                    for i in chain_ids  # type: ignore
+                    f"{_inits[:-5]}_{i}.json" for i in chain_ids  # type: ignore
                 ]
             else:
                 cmdstan_inits = _inits
@@ -1230,7 +1235,9 @@ class CmdStanModel:
             fit_csv_files = previous_fit.runset.csv_files
         elif isinstance(previous_fit, list):
             if len(previous_fit) < 1:
-                raise ValueError('Expecting list of Stan CSV files, found empty list')
+                raise ValueError(
+                    'Expecting list of Stan CSV files, found empty list'
+                )
             try:
                 fit_csv_files = previous_fit
                 fit_object = from_csv(fit_csv_files)  # type: ignore
@@ -1276,7 +1283,9 @@ class CmdStanModel:
             chains = 1
             chain_ids = [1]
 
-        generate_quantities_args = GenerateQuantitiesArgs(csv_files=fit_csv_files)
+        generate_quantities_args = GenerateQuantitiesArgs(
+            csv_files=fit_csv_files
+        )
         generate_quantities_args.validate(chains)
         with temp_single_json(data) as _data:
             args = CmdStanArgs(
@@ -1523,7 +1532,9 @@ class CmdStanModel:
             transcript_file = runset.stdout_files[dummy_chain_id]
             with open(transcript_file, 'r') as transcript:
                 contents = transcript.read()
-            pat = re.compile(r'stan::variational::normal_meanfield::calc_grad:', re.M)
+            pat = re.compile(
+                r'stan::variational::normal_meanfield::calc_grad:', re.M
+            )
             if len(re.findall(pat, contents)) > 0:
                 if grad_samples is None:
                     grad_samples = 10
@@ -1690,7 +1701,8 @@ class CmdStanModel:
         exe_info = self.exe_info()
         if cmdstan_version_before(2, 33, exe_info):
             raise ValueError(
-                "Method 'pathfinder' not available for CmdStan versions before 2.33"
+                "Method 'pathfinder' not available for CmdStan versions "
+                "before 2.33"
             )
 
         if (not psis_resample or not calculate_lp) and cmdstan_version_before(
@@ -1702,7 +1714,10 @@ class CmdStanModel:
             )
 
         if num_threads is not None:
-            if num_threads != 1 and exe_info.get('STAN_THREADS', '').lower() != 'true':
+            if (
+                num_threads != 1
+                and exe_info.get('STAN_THREADS', '').lower() != 'true'
+            ):
                 raise ValueError(
                     "Model must be compiled with 'STAN_THREADS=true' to use"
                     " 'num_threads' argument"
@@ -1807,9 +1822,13 @@ class CmdStanModel:
 
         if cmdstan_version_before(2, 31, self.exe_info()):
             raise ValueError(
-                "Method 'log_prob' not available for CmdStan versions before 2.31"
+                "Method 'log_prob' not available for CmdStan versions "
+                "before 2.31"
             )
-        with temp_single_json(data) as _data, temp_single_json(params) as _params:
+        with (
+            temp_single_json(data) as _data,
+            temp_single_json(params) as _params,
+        ):
             cmd = [
                 str(self.exe_file),
                 "log_prob",
@@ -1828,7 +1847,9 @@ class CmdStanModel:
 
             get_logger().debug("Cmd: %s", str(cmd))
 
-            proc = subprocess.run(cmd, capture_output=True, check=False, text=True)
+            proc = subprocess.run(
+                cmd, capture_output=True, check=False, text=True
+            )
             if proc.returncode:
                 get_logger().error(
                     "'log_prob' command failed!\nstdout:%s\nstderr:%s",
@@ -1836,7 +1857,8 @@ class CmdStanModel:
                     proc.stderr,
                 )
                 raise RuntimeError(
-                    "Method 'log_prob' failed with return code " + str(proc.returncode)
+                    "Method 'log_prob' failed with return code "
+                    + str(proc.returncode)
                 )
 
             result = pd.read_csv(output, comment="#")
@@ -1916,10 +1938,13 @@ class CmdStanModel:
         """
         if cmdstan_version_before(2, 32, self.exe_info()):
             raise ValueError(
-                "Method 'laplace_sample' not available for CmdStan versions before 2.32"
+                "Method 'laplace_sample' not available for CmdStan versions "
+                "before 2.32"
             )
         if opt_args is not None and mode is not None:
-            raise ValueError("Cannot specify both 'opt_args' and 'mode' arguments")
+            raise ValueError(
+                "Cannot specify both 'opt_args' and 'mode' arguments"
+            )
         if mode is None:
             optimize_args = {
                 "seed": seed,
@@ -1950,7 +1975,9 @@ class CmdStanModel:
             cmdstan_mode = mode
 
         if cmdstan_mode.runset.method != Method.OPTIMIZE:
-            raise ValueError("Mode must be a CmdStanMLE or a path to an optimize CSV")
+            raise ValueError(
+                "Mode must be a CmdStanMLE or a path to an optimize CSV"
+            )
 
         mode_jacobian = (
             cmdstan_mode.runset._args.method_args.jacobian  # type: ignore
@@ -1962,7 +1989,9 @@ class CmdStanModel:
                 f"but optimize was run with jacobian={mode_jacobian}"
             )
 
-        laplace_args = LaplaceArgs(cmdstan_mode.runset.csv_files[0], draws, jacobian)
+        laplace_args = LaplaceArgs(
+            cmdstan_mode.runset.csv_files[0], draws, jacobian
+        )
 
         with temp_single_json(data) as _data:
             args = CmdStanArgs(
@@ -2208,7 +2237,9 @@ class CmdStanModel:
 
             get_logger().debug("Cmd: %s", str(cmd))
 
-            proc = subprocess.run(cmd, capture_output=True, check=False, text=True)
+            proc = subprocess.run(
+                cmd, capture_output=True, check=False, text=True
+            )
             if proc.returncode:
                 get_logger().error(
                     "'diagnose' command failed!\nstdout:%s\nstderr:%s",

--- a/cmdstanpy/progress.py
+++ b/cmdstanpy/progress.py
@@ -1,6 +1,7 @@
 """
 Record tqdm progress bar fail during session
 """
+
 import functools
 import logging
 

--- a/cmdstanpy/stanfit/__init__.py
+++ b/cmdstanpy/stanfit/__init__.py
@@ -2,7 +2,7 @@
 
 import glob
 import os
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from cmdstanpy.cmdstan_args import (
     CmdStanArgs,
@@ -36,11 +36,9 @@ __all__ = [
 
 
 def from_csv(
-    path: Union[str, List[str], os.PathLike, None] = None,
+    path: Union[str, list[str], os.PathLike, None] = None,
     method: Optional[str] = None,
-) -> Union[
-    CmdStanMCMC, CmdStanMLE, CmdStanVB, CmdStanPathfinder, CmdStanLaplace, None
-]:
+) -> Union[CmdStanMCMC, CmdStanMLE, CmdStanVB, CmdStanPathfinder, CmdStanLaplace, None]:
     """
     Instantiate a CmdStan object from a the Stan CSV files from a CmdStan run.
     CSV files are specified from either a list of Stan CSV files or a single
@@ -78,8 +76,9 @@ def from_csv(
         if splits[0] is not None:
             if not (os.path.exists(splits[0]) and os.path.isdir(splits[0])):
                 raise ValueError(
-                    'Invalid path specification, {} '
-                    ' unknown directory: {}'.format(path, splits[0])
+                    'Invalid path specification, {}  unknown directory: {}'.format(
+                        path, splits[0]
+                    )
                 )
         csvfiles = glob.glob(path)
     elif isinstance(path, (str, os.PathLike)):
@@ -99,8 +98,7 @@ def from_csv(
     for file in csvfiles:
         if not (os.path.exists(file) and os.path.splitext(file)[1] == ".csv"):
             raise ValueError(
-                'Bad CSV file path spec,'
-                ' includes non-csv file: {}'.format(file)
+                'Bad CSV file path spec, includes non-csv file: {}'.format(file)
             )
 
     try:
@@ -113,9 +111,7 @@ def from_csv(
     if method is not None and method != config_dict['method']:
         raise ValueError(
             'Expecting Stan CSV output files from method {}, '
-            ' found outputs from method {}'.format(
-                method, config_dict['method']
-            )
+            ' found outputs from method {}'.format(method, config_dict['method'])
         )
     model: str = config_dict['model']  # type: ignore
     try:
@@ -157,9 +153,7 @@ def from_csv(
                         fixed_param=True,
                     )
                 except ValueError as e:
-                    raise ValueError(
-                        'Invalid or corrupt Stan CSV output file, '
-                    ) from e
+                    raise ValueError('Invalid or corrupt Stan CSV output file, ') from e
 
             cmdstan_args = CmdStanArgs(
                 model_name=model,
@@ -177,8 +171,7 @@ def from_csv(
         elif config_dict['method'] == 'optimize':
             if 'algorithm' not in config_dict:
                 raise ValueError(
-                    "Cannot find optimization algorithm"
-                    " in file {}.".format(csvfiles[0])
+                    "Cannot find optimization algorithm in file {}.".format(csvfiles[0])
                 )
             algorithm: str = config_dict['algorithm']  # type: ignore
             save_iterations = config_dict['save_iterations'] == 1
@@ -203,8 +196,7 @@ def from_csv(
         elif config_dict['method'] == 'variational':
             if 'algorithm' not in config_dict:
                 raise ValueError(
-                    "Cannot find variational algorithm"
-                    " in file {}.".format(csvfiles[0])
+                    "Cannot find variational algorithm in file {}.".format(csvfiles[0])
                 )
             variational_args = VariationalArgs(
                 algorithm=config_dict['algorithm'],  # type: ignore

--- a/cmdstanpy/stanfit/__init__.py
+++ b/cmdstanpy/stanfit/__init__.py
@@ -38,7 +38,9 @@ __all__ = [
 def from_csv(
     path: Union[str, list[str], os.PathLike, None] = None,
     method: Optional[str] = None,
-) -> Union[CmdStanMCMC, CmdStanMLE, CmdStanVB, CmdStanPathfinder, CmdStanLaplace, None]:
+) -> Union[
+    CmdStanMCMC, CmdStanMLE, CmdStanVB, CmdStanPathfinder, CmdStanLaplace, None
+]:
     """
     Instantiate a CmdStan object from a the Stan CSV files from a CmdStan run.
     CSV files are specified from either a list of Stan CSV files or a single
@@ -76,9 +78,8 @@ def from_csv(
         if splits[0] is not None:
             if not (os.path.exists(splits[0]) and os.path.isdir(splits[0])):
                 raise ValueError(
-                    'Invalid path specification, {}  unknown directory: {}'.format(
-                        path, splits[0]
-                    )
+                    'Invalid path specification, {}  unknown '
+                    'directory: {}'.format(path, splits[0])
                 )
         csvfiles = glob.glob(path)
     elif isinstance(path, (str, os.PathLike)):
@@ -111,7 +112,9 @@ def from_csv(
     if method is not None and method != config_dict['method']:
         raise ValueError(
             'Expecting Stan CSV output files from method {}, '
-            ' found outputs from method {}'.format(method, config_dict['method'])
+            ' found outputs from method {}'.format(
+                method, config_dict['method']
+            )
         )
     model: str = config_dict['model']  # type: ignore
     try:
@@ -153,7 +156,9 @@ def from_csv(
                         fixed_param=True,
                     )
                 except ValueError as e:
-                    raise ValueError('Invalid or corrupt Stan CSV output file, ') from e
+                    raise ValueError(
+                        'Invalid or corrupt Stan CSV output file, '
+                    ) from e
 
             cmdstan_args = CmdStanArgs(
                 model_name=model,
@@ -171,7 +176,9 @@ def from_csv(
         elif config_dict['method'] == 'optimize':
             if 'algorithm' not in config_dict:
                 raise ValueError(
-                    "Cannot find optimization algorithm in file {}.".format(csvfiles[0])
+                    "Cannot find optimization algorithm in file {}.".format(
+                        csvfiles[0]
+                    )
                 )
             algorithm: str = config_dict['algorithm']  # type: ignore
             save_iterations = config_dict['save_iterations'] == 1
@@ -196,7 +203,9 @@ def from_csv(
         elif config_dict['method'] == 'variational':
             if 'algorithm' not in config_dict:
                 raise ValueError(
-                    "Cannot find variational algorithm in file {}.".format(csvfiles[0])
+                    "Cannot find variational algorithm in file {}.".format(
+                        csvfiles[0]
+                    )
                 )
             variational_args = VariationalArgs(
                 algorithm=config_dict['algorithm'],  # type: ignore

--- a/cmdstanpy/stanfit/gq.py
+++ b/cmdstanpy/stanfit/gq.py
@@ -223,11 +223,15 @@ class CmdStanGQ(Generic[Fit]):
             cols_1 = self.previous_fit.column_names
             cols_2 = self.column_names
             dups = [
-                item for item, count in Counter(cols_1 + cols_2).items() if count > 1
+                item
+                for item, count in Counter(cols_1 + cols_2).items()
+                if count > 1
             ]
             drop_cols: list[int] = []
             for dup in dups:
-                drop_cols.extend(self.previous_fit._metadata.stan_vars[dup].columns())
+                drop_cols.extend(
+                    self.previous_fit._metadata.stan_vars[dup].columns()
+                )
 
         start_idx, _ = self._draws_start(inc_warmup)
         previous_draws = self._previous_draws(True)
@@ -317,11 +321,17 @@ class CmdStanGQ(Generic[Fit]):
             for var in vars_list:
                 if var in self._metadata.stan_vars:
                     info = self._metadata.stan_vars[var]
-                    gq_cols.extend(self.column_names[info.start_idx : info.end_idx])
-                elif inc_sample and var in self.previous_fit._metadata.stan_vars:
+                    gq_cols.extend(
+                        self.column_names[info.start_idx : info.end_idx]
+                    )
+                elif (
+                    inc_sample and var in self.previous_fit._metadata.stan_vars
+                ):
                     info = self.previous_fit._metadata.stan_vars[var]
                     mcmc_vars.extend(
-                        self.previous_fit.column_names[info.start_idx : info.end_idx]
+                        self.previous_fit.column_names[
+                            info.start_idx : info.end_idx
+                        ]
                     )
                 elif var in ['chain__', 'iter__', 'draw__']:
                     gq_cols.append(var)
@@ -342,10 +352,14 @@ class CmdStanGQ(Generic[Fit]):
             .T
         )
         iter_col = (
-            np.tile(np.arange(1, n_draws + 1), n_chains).reshape(1, n_chains, n_draws).T
+            np.tile(np.arange(1, n_draws + 1), n_chains)
+            .reshape(1, n_chains, n_draws)
+            .T
         )
         draw_col = (
-            np.arange(1, (n_draws * n_chains) + 1).reshape(1, n_chains, n_draws).T
+            np.arange(1, (n_draws * n_chains) + 1)
+            .reshape(1, n_chains, n_draws)
+            .T
         )
         draws = np.concatenate([chains_col, iter_col, draw_col, draws], axis=2)
 
@@ -369,7 +383,9 @@ class CmdStanGQ(Generic[Fit]):
             cols_1 = list(previous_draws_pd.columns)
             cols_2 = list(draws_pd.columns)
             dups = [
-                item for item, count in Counter(cols_1 + cols_2).items() if count > 1
+                item
+                for item, count in Counter(cols_1 + cols_2).items()
+                if count > 1
             ]
             return pd.concat(
                 [
@@ -389,7 +405,8 @@ class CmdStanGQ(Generic[Fit]):
         vars: Union[str, list[str], None] = None,
         inc_warmup: bool = False,
         inc_sample: bool = False,
-    ) -> NoReturn: ...
+    ) -> NoReturn:
+        ...
 
     @overload
     def draws_xr(
@@ -397,7 +414,8 @@ class CmdStanGQ(Generic[Fit]):
         vars: Union[str, list[str], None] = None,
         inc_warmup: bool = False,
         inc_sample: bool = False,
-    ) -> "xr.Dataset": ...
+    ) -> "xr.Dataset":
+        ...
 
     def draws_xr(
         self,
@@ -441,7 +459,9 @@ class CmdStanGQ(Generic[Fit]):
                 vars_list = vars
             for var in vars_list:
                 if var not in self._metadata.stan_vars:
-                    if inc_sample and (var in self.previous_fit._metadata.stan_vars):
+                    if inc_sample and (
+                        var in self.previous_fit._metadata.stan_vars
+                    ):
                         mcmc_vars_list.append(var)
                         dup_vars.append(var)
                     else:
@@ -543,7 +563,8 @@ class CmdStanGQ(Generic[Fit]):
         if not (var in model_var_names or var in gq_var_names):
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are ' + ", ".join(model_var_names | gq_var_names)
+                'Available variables are '
+                + ", ".join(model_var_names | gq_var_names)
             )
         if var not in gq_var_names:
             # TODO(2.0) atleast1d may not be needed
@@ -664,7 +685,9 @@ class CmdStanGQ(Generic[Fit]):
                 )[:, None]
             return p_fit.variational_sample[:, None]
 
-    def _previous_draws_pd(self, vars: list[str], inc_warmup: bool) -> pd.DataFrame:
+    def _previous_draws_pd(
+        self, vars: list[str], inc_warmup: bool
+    ) -> pd.DataFrame:
         if vars:
             sel: Union[list[str], slice] = vars
         else:

--- a/cmdstanpy/stanfit/gq.py
+++ b/cmdstanpy/stanfit/gq.py
@@ -6,14 +6,11 @@ generate quantities (GQ) method
 from collections import Counter
 from typing import (
     Any,
-    Dict,
     Generic,
     Hashable,
-    List,
     MutableMapping,
     NoReturn,
     Optional,
-    Tuple,
     TypeVar,
     Union,
     overload,
@@ -141,12 +138,12 @@ class CmdStanGQ(Generic[Fit]):
         return self.runset.chains
 
     @property
-    def chain_ids(self) -> List[int]:
+    def chain_ids(self) -> list[int]:
         """Chain ids."""
         return self.runset.chain_ids
 
     @property
-    def column_names(self) -> Tuple[str, ...]:
+    def column_names(self) -> tuple[str, ...]:
         """
         Names of generated quantities of interest.
         """
@@ -226,15 +223,11 @@ class CmdStanGQ(Generic[Fit]):
             cols_1 = self.previous_fit.column_names
             cols_2 = self.column_names
             dups = [
-                item
-                for item, count in Counter(cols_1 + cols_2).items()
-                if count > 1
+                item for item, count in Counter(cols_1 + cols_2).items() if count > 1
             ]
-            drop_cols: List[int] = []
+            drop_cols: list[int] = []
             for dup in dups:
-                drop_cols.extend(
-                    self.previous_fit._metadata.stan_vars[dup].columns()
-                )
+                drop_cols.extend(self.previous_fit._metadata.stan_vars[dup].columns())
 
         start_idx, _ = self._draws_start(inc_warmup)
         previous_draws = self._previous_draws(True)
@@ -260,7 +253,7 @@ class CmdStanGQ(Generic[Fit]):
 
     def draws_pd(
         self,
-        vars: Union[List[str], str, None] = None,
+        vars: Union[list[str], str, None] = None,
         inc_warmup: bool = False,
         inc_sample: bool = False,
     ) -> pd.DataFrame:
@@ -318,23 +311,17 @@ class CmdStanGQ(Generic[Fit]):
 
         all_columns = ['chain__', 'iter__', 'draw__'] + list(self.column_names)
 
-        gq_cols: List[str] = []
-        mcmc_vars: List[str] = []
+        gq_cols: list[str] = []
+        mcmc_vars: list[str] = []
         if vars is not None:
             for var in vars_list:
                 if var in self._metadata.stan_vars:
                     info = self._metadata.stan_vars[var]
-                    gq_cols.extend(
-                        self.column_names[info.start_idx : info.end_idx]
-                    )
-                elif (
-                    inc_sample and var in self.previous_fit._metadata.stan_vars
-                ):
+                    gq_cols.extend(self.column_names[info.start_idx : info.end_idx])
+                elif inc_sample and var in self.previous_fit._metadata.stan_vars:
                     info = self.previous_fit._metadata.stan_vars[var]
                     mcmc_vars.extend(
-                        self.previous_fit.column_names[
-                            info.start_idx : info.end_idx
-                        ]
+                        self.previous_fit.column_names[info.start_idx : info.end_idx]
                     )
                 elif var in ['chain__', 'iter__', 'draw__']:
                     gq_cols.append(var)
@@ -355,14 +342,10 @@ class CmdStanGQ(Generic[Fit]):
             .T
         )
         iter_col = (
-            np.tile(np.arange(1, n_draws + 1), n_chains)
-            .reshape(1, n_chains, n_draws)
-            .T
+            np.tile(np.arange(1, n_draws + 1), n_chains).reshape(1, n_chains, n_draws).T
         )
         draw_col = (
-            np.arange(1, (n_draws * n_chains) + 1)
-            .reshape(1, n_chains, n_draws)
-            .T
+            np.arange(1, (n_draws * n_chains) + 1).reshape(1, n_chains, n_draws).T
         )
         draws = np.concatenate([chains_col, iter_col, draw_col, draws], axis=2)
 
@@ -386,9 +369,7 @@ class CmdStanGQ(Generic[Fit]):
             cols_1 = list(previous_draws_pd.columns)
             cols_2 = list(draws_pd.columns)
             dups = [
-                item
-                for item, count in Counter(cols_1 + cols_2).items()
-                if count > 1
+                item for item, count in Counter(cols_1 + cols_2).items() if count > 1
             ]
             return pd.concat(
                 [
@@ -405,24 +386,22 @@ class CmdStanGQ(Generic[Fit]):
     @overload
     def draws_xr(
         self: Union["CmdStanGQ[CmdStanMLE]", "CmdStanGQ[CmdStanVB]"],
-        vars: Union[str, List[str], None] = None,
+        vars: Union[str, list[str], None] = None,
         inc_warmup: bool = False,
         inc_sample: bool = False,
-    ) -> NoReturn:
-        ...
+    ) -> NoReturn: ...
 
     @overload
     def draws_xr(
         self: "CmdStanGQ[CmdStanMCMC]",
-        vars: Union[str, List[str], None] = None,
+        vars: Union[str, list[str], None] = None,
         inc_warmup: bool = False,
         inc_sample: bool = False,
-    ) -> "xr.Dataset":
-        ...
+    ) -> "xr.Dataset": ...
 
     def draws_xr(
         self,
-        vars: Union[str, List[str], None] = None,
+        vars: Union[str, list[str], None] = None,
         inc_warmup: bool = False,
         inc_sample: bool = False,
     ) -> "xr.Dataset":
@@ -462,9 +441,7 @@ class CmdStanGQ(Generic[Fit]):
                 vars_list = vars
             for var in vars_list:
                 if var not in self._metadata.stan_vars:
-                    if inc_sample and (
-                        var in self.previous_fit._metadata.stan_vars
-                    ):
+                    if inc_sample and (var in self.previous_fit._metadata.stan_vars):
                         mcmc_vars_list.append(var)
                         dup_vars.append(var)
                     else:
@@ -566,8 +543,7 @@ class CmdStanGQ(Generic[Fit]):
         if not (var in model_var_names or var in gq_var_names):
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are '
-                + ", ".join(model_var_names | gq_var_names)
+                'Available variables are ' + ", ".join(model_var_names | gq_var_names)
             )
         if var not in gq_var_names:
             # TODO(2.0) atleast1d may not be needed
@@ -586,7 +562,7 @@ class CmdStanGQ(Generic[Fit]):
         out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(draws)
         return out
 
-    def stan_variables(self, **kwargs: bool) -> Dict[str, np.ndarray]:
+    def stan_variables(self, **kwargs: bool) -> dict[str, np.ndarray]:
         """
         Return a dictionary mapping Stan program variables names
         to the corresponding numpy.ndarray containing the inferred values.
@@ -639,7 +615,7 @@ class CmdStanGQ(Generic[Fit]):
                 ) from exc
         self._draws = gq_sample
 
-    def _draws_start(self, inc_warmup: bool) -> Tuple[int, int]:
+    def _draws_start(self, inc_warmup: bool) -> tuple[int, int]:
         draw1 = 0
         p_fit = self.previous_fit
         if isinstance(p_fit, CmdStanMCMC):
@@ -688,11 +664,9 @@ class CmdStanGQ(Generic[Fit]):
                 )[:, None]
             return p_fit.variational_sample[:, None]
 
-    def _previous_draws_pd(
-        self, vars: List[str], inc_warmup: bool
-    ) -> pd.DataFrame:
+    def _previous_draws_pd(self, vars: list[str], inc_warmup: bool) -> pd.DataFrame:
         if vars:
-            sel: Union[List[str], slice] = vars
+            sel: Union[list[str], slice] = vars
         else:
             sel = slice(None, None)
 

--- a/cmdstanpy/stanfit/laplace.py
+++ b/cmdstanpy/stanfit/laplace.py
@@ -4,12 +4,9 @@ Container for the result of running a laplace approximation.
 
 from typing import (
     Any,
-    Dict,
     Hashable,
-    List,
     MutableMapping,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -41,8 +38,9 @@ class CmdStanLaplace:
         """Initialize object."""
         if not runset.method == Method.LAPLACE:
             raise ValueError(
-                'Wrong runset method, expecting laplace runset, '
-                'found method {}'.format(runset.method)
+                'Wrong runset method, expecting laplace runset, found method {}'.format(
+                    runset.method
+                )
             )
         self._runset = runset
         self._mode = mode
@@ -51,7 +49,7 @@ class CmdStanLaplace:
 
     def create_inits(
         self, seed: Optional[int] = None, chains: int = 4
-    ) -> Union[List[Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
+    ) -> Union[list[dict[str, np.ndarray]], dict[str, np.ndarray]]:
         """
         Create initial values for the parameters of the model
         by randomly selecting draws from the Laplace approximation.
@@ -118,19 +116,16 @@ class CmdStanLaplace:
         """
         self._assemble_draws()
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
-                self._draws
-            )
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(self._draws)
             return out
         except KeyError:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are '
-                + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
             )
 
-    def stan_variables(self) -> Dict[str, np.ndarray]:
+    def stan_variables(self) -> dict[str, np.ndarray]:
         """
         Return a dictionary mapping Stan program variables names
         to the corresponding numpy.ndarray containing the inferred values.
@@ -152,7 +147,7 @@ class CmdStanLaplace:
             result[name] = self.stan_variable(name)
         return result
 
-    def method_variables(self) -> Dict[str, np.ndarray]:
+    def method_variables(self) -> dict[str, np.ndarray]:
         """
         Returns a dictionary of all sampler variables, i.e., all
         output column names ending in `__`.  Assumes that all variables
@@ -177,7 +172,7 @@ class CmdStanLaplace:
 
     def draws_pd(
         self,
-        vars: Union[List[str], str, None] = None,
+        vars: Union[list[str], str, None] = None,
     ) -> pd.DataFrame:
         if vars is not None:
             if isinstance(vars, str):
@@ -193,9 +188,7 @@ class CmdStanLaplace:
                     cols.append(var)
                 elif var in self._metadata.stan_vars:
                     info = self._metadata.stan_vars[var]
-                    cols.extend(
-                        self.column_names[info.start_idx : info.end_idx]
-                    )
+                    cols.extend(self.column_names[info.start_idx : info.end_idx])
                 else:
                     raise ValueError(f'Unknown variable: {var}')
 
@@ -206,7 +199,7 @@ class CmdStanLaplace:
 
     def draws_xr(
         self,
-        vars: Union[str, List[str], None] = None,
+        vars: Union[str, list[str], None] = None,
     ) -> "xr.Dataset":
         """
         Returns the sampler draws as a xarray Dataset.
@@ -274,9 +267,7 @@ class CmdStanLaplace:
         return self._metadata
 
     def __repr__(self) -> str:
-        mode = '\n'.join(
-            ['\t' + line for line in repr(self.mode).splitlines()]
-        )[1:]
+        mode = '\n'.join(['\t' + line for line in repr(self.mode).splitlines()])[1:]
         rep = 'CmdStanLaplace: model={} \nmode=({})\n{}'.format(
             self._runset.model,
             mode,
@@ -308,7 +299,7 @@ class CmdStanLaplace:
         return self.__dict__
 
     @property
-    def column_names(self) -> Tuple[str, ...]:
+    def column_names(self) -> tuple[str, ...]:
         """
         Names of all outputs from the sampler, comprising sampler parameters
         and all components of all model parameters, transformed parameters,

--- a/cmdstanpy/stanfit/laplace.py
+++ b/cmdstanpy/stanfit/laplace.py
@@ -2,13 +2,7 @@
 Container for the result of running a laplace approximation.
 """
 
-from typing import (
-    Any,
-    Hashable,
-    MutableMapping,
-    Optional,
-    Union,
-)
+from typing import Any, Hashable, MutableMapping, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -38,9 +32,8 @@ class CmdStanLaplace:
         """Initialize object."""
         if not runset.method == Method.LAPLACE:
             raise ValueError(
-                'Wrong runset method, expecting laplace runset, found method {}'.format(
-                    runset.method
-                )
+                'Wrong runset method, expecting laplace runset, '
+                'found method {}'.format(runset.method)
             )
         self._runset = runset
         self._mode = mode
@@ -116,13 +109,16 @@ class CmdStanLaplace:
         """
         self._assemble_draws()
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(self._draws)
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                self._draws
+            )
             return out
         except KeyError:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are '
+                + ", ".join(self._metadata.stan_vars.keys())
             )
 
     def stan_variables(self) -> dict[str, np.ndarray]:
@@ -188,7 +184,9 @@ class CmdStanLaplace:
                     cols.append(var)
                 elif var in self._metadata.stan_vars:
                     info = self._metadata.stan_vars[var]
-                    cols.extend(self.column_names[info.start_idx : info.end_idx])
+                    cols.extend(
+                        self.column_names[info.start_idx : info.end_idx]
+                    )
                 else:
                     raise ValueError(f'Unknown variable: {var}')
 
@@ -267,7 +265,9 @@ class CmdStanLaplace:
         return self._metadata
 
     def __repr__(self) -> str:
-        mode = '\n'.join(['\t' + line for line in repr(self.mode).splitlines()])[1:]
+        mode = '\n'.join(
+            ['\t' + line for line in repr(self.mode).splitlines()]
+        )[1:]
         rep = 'CmdStanLaplace: model={} \nmode=({})\n{}'.format(
             self._runset.model,
             mode,

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -5,14 +5,7 @@ Container for the result of running the sample (MCMC) method
 import math
 import os
 from io import StringIO
-from typing import (
-    Any,
-    Hashable,
-    MutableMapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import Any, Hashable, MutableMapping, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -63,15 +56,16 @@ class CmdStanMCMC:
         """Initialize object."""
         if not runset.method == Method.SAMPLE:
             raise ValueError(
-                'Wrong runset method, expecting sample runset, found method {}'.format(
-                    runset.method
-                )
+                'Wrong runset method, expecting sample runset, '
+                'found method {}'.format(runset.method)
             )
         self.runset = runset
 
         # info from runset to be exposed
         sampler_args = self.runset._args.method_args
-        assert isinstance(sampler_args, SamplerArgs)  # make the typechecker happy
+        assert isinstance(
+            sampler_args, SamplerArgs
+        )  # make the typechecker happy
         self._iter_sampling: int = _CMDSTAN_SAMPLING
         if sampler_args.iter_sampling is not None:
             self._iter_sampling = sampler_args.iter_sampling
@@ -91,7 +85,9 @@ class CmdStanMCMC:
         self._metric: np.ndarray = np.array(())
         self._step_size: np.ndarray = np.array(())
         self._divergences: np.ndarray = np.zeros(self.runset.chains, dtype=int)
-        self._max_treedepths: np.ndarray = np.zeros(self.runset.chains, dtype=int)
+        self._max_treedepths: np.ndarray = np.zeros(
+            self.runset.chains, dtype=int
+        )
         self._chain_time: list[dict[str, float]] = []
 
         # info from CSV header and initial and final comment blocks
@@ -122,7 +118,9 @@ class CmdStanMCMC:
         rng = np.random.default_rng(seed)
         n_draws, n_chains = self._draws.shape[:2]
         draw_idxs = rng.choice(n_draws, size=chains, replace=False)
-        chain_idxs = rng.choice(n_chains, size=chains, replace=(n_chains <= chains))
+        chain_idxs = rng.choice(
+            n_chains, size=chains, replace=(n_chains <= chains)
+        )
         if chains == 1:
             draw = self._draws[draw_idxs[0], chain_idxs[0]]
             return {
@@ -503,7 +501,9 @@ class CmdStanMCMC:
                     ' non-empty list from (1, 99), inclusive.'
                 )
             cur_pct = pct
-        percentiles_str = f"--percentiles= {','.join(str(x) for x in percentiles)}"
+        percentiles_str = (
+            f"--percentiles= {','.join(str(x) for x in percentiles)}"
+        )
 
         if not isinstance(sig_figs, int) or sig_figs < 1 or sig_figs > 18:
             raise ValueError(
@@ -519,7 +519,9 @@ class CmdStanMCMC:
                 csv_sig_figs,
             )
         sig_figs_str = f'--sig_figs={sig_figs}'
-        cmd_path = os.path.join(cmdstan_path(), 'bin', 'stansummary' + EXTENSION)
+        cmd_path = os.path.join(
+            cmdstan_path(), 'bin', 'stansummary' + EXTENSION
+        )
         tmp_csv_file = 'stansummary-{}-'.format(self.runset._args.model_name)
         tmp_csv_path = create_named_text_file(
             dir=_TMPDIR, prefix=tmp_csv_file, suffix='.csv', name_only=True
@@ -547,7 +549,9 @@ class CmdStanMCMC:
         mask = (
             [not x.endswith('__') for x in summary_data.index]
             if self._is_fixed_param
-            else [x == 'lp__' or not x.endswith('__') for x in summary_data.index]
+            else [
+                x == 'lp__' or not x.endswith('__') for x in summary_data.index
+            ]
         )
         summary_data.index.name = None
         return summary_data[mask]
@@ -616,7 +620,9 @@ class CmdStanMCMC:
                     cols.append(var)
                 elif var in self._metadata.stan_vars:
                     info = self._metadata.stan_vars[var]
-                    cols.extend(self.column_names[info.start_idx : info.end_idx])
+                    cols.extend(
+                        self.column_names[info.start_idx : info.end_idx]
+                    )
                 elif var in ['chain__', 'iter__', 'draw__']:
                     cols.append(var)
                 else:
@@ -633,10 +639,14 @@ class CmdStanMCMC:
             .T
         )
         iter_col = (
-            np.tile(np.arange(1, n_draws + 1), n_chains).reshape(1, n_chains, n_draws).T
+            np.tile(np.arange(1, n_draws + 1), n_chains)
+            .reshape(1, n_chains, n_draws)
+            .T
         )
         draw_col = (
-            np.arange(1, (n_draws * n_chains) + 1).reshape(1, n_chains, n_draws).T
+            np.arange(1, (n_draws * n_chains) + 1)
+            .reshape(1, n_chains, n_draws)
+            .T
         )
         draws = np.concatenate([chains_col, iter_col, draw_col, draws], axis=2)
 
@@ -759,13 +769,16 @@ class CmdStanMCMC:
         """
         try:
             draws = self.draws(inc_warmup=inc_warmup, concat_chains=True)
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(draws)
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                draws
+            )
             return out
         except KeyError:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are '
+                + ", ".join(self._metadata.stan_vars.keys())
             )
 
     def stan_variables(self) -> dict[str, np.ndarray]:

--- a/cmdstanpy/stanfit/mcmc.py
+++ b/cmdstanpy/stanfit/mcmc.py
@@ -7,13 +7,10 @@ import os
 from io import StringIO
 from typing import (
     Any,
-    Dict,
     Hashable,
-    List,
     MutableMapping,
     Optional,
     Sequence,
-    Tuple,
     Union,
 )
 
@@ -66,16 +63,15 @@ class CmdStanMCMC:
         """Initialize object."""
         if not runset.method == Method.SAMPLE:
             raise ValueError(
-                'Wrong runset method, expecting sample runset, '
-                'found method {}'.format(runset.method)
+                'Wrong runset method, expecting sample runset, found method {}'.format(
+                    runset.method
+                )
             )
         self.runset = runset
 
         # info from runset to be exposed
         sampler_args = self.runset._args.method_args
-        assert isinstance(
-            sampler_args, SamplerArgs
-        )  # make the typechecker happy
+        assert isinstance(sampler_args, SamplerArgs)  # make the typechecker happy
         self._iter_sampling: int = _CMDSTAN_SAMPLING
         if sampler_args.iter_sampling is not None:
             self._iter_sampling = sampler_args.iter_sampling
@@ -95,10 +91,8 @@ class CmdStanMCMC:
         self._metric: np.ndarray = np.array(())
         self._step_size: np.ndarray = np.array(())
         self._divergences: np.ndarray = np.zeros(self.runset.chains, dtype=int)
-        self._max_treedepths: np.ndarray = np.zeros(
-            self.runset.chains, dtype=int
-        )
-        self._chain_time: List[Dict[str, float]] = []
+        self._max_treedepths: np.ndarray = np.zeros(self.runset.chains, dtype=int)
+        self._chain_time: list[dict[str, float]] = []
 
         # info from CSV header and initial and final comment blocks
         config = self._validate_csv_files()
@@ -108,7 +102,7 @@ class CmdStanMCMC:
 
     def create_inits(
         self, seed: Optional[int] = None, chains: int = 4
-    ) -> Union[List[Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
+    ) -> Union[list[dict[str, np.ndarray]], dict[str, np.ndarray]]:
         """
         Create initial values for the parameters of the model by
         randomly selecting draws from the MCMC samples. If the samples
@@ -128,9 +122,7 @@ class CmdStanMCMC:
         rng = np.random.default_rng(seed)
         n_draws, n_chains = self._draws.shape[:2]
         draw_idxs = rng.choice(n_draws, size=chains, replace=False)
-        chain_idxs = rng.choice(
-            n_chains, size=chains, replace=(n_chains <= chains)
-        )
+        chain_idxs = rng.choice(n_chains, size=chains, replace=(n_chains <= chains))
         if chains == 1:
             draw = self._draws[draw_idxs[0], chain_idxs[0]]
             return {
@@ -184,7 +176,7 @@ class CmdStanMCMC:
         return self.runset.chains
 
     @property
-    def chain_ids(self) -> List[int]:
+    def chain_ids(self) -> list[int]:
         """Chain ids."""
         return self.runset.chain_ids
 
@@ -211,7 +203,7 @@ class CmdStanMCMC:
         return self._metadata
 
     @property
-    def column_names(self) -> Tuple[str, ...]:
+    def column_names(self) -> tuple[str, ...]:
         """
         Names of all outputs from the sampler, comprising sampler parameters
         and all components of all model parameters, transformed parameters,
@@ -283,7 +275,7 @@ class CmdStanMCMC:
         return self._max_treedepths if not self._is_fixed_param else None
 
     @property
-    def time(self) -> List[Dict[str, float]]:
+    def time(self) -> list[dict[str, float]]:
         """
         List of per-chain time info scraped from CSV file.
         Each chain has dict with keys "warmup", "sampling", "total".
@@ -332,7 +324,7 @@ class CmdStanMCMC:
             return flatten_chains(self._draws[start_idx:, :, :])
         return self._draws[start_idx:, :, :]
 
-    def _validate_csv_files(self) -> Dict[str, Any]:
+    def _validate_csv_files(self) -> dict[str, Any]:
         """
         Checks that Stan CSV output files for all chains are consistent
         and returns dict containing config and column names.
@@ -407,13 +399,13 @@ class CmdStanMCMC:
                     diagnostics.append(
                         f'Chain {i + 1} had {self._divergences[i]} '
                         'divergent transitions '
-                        f'({((self._divergences[i]/ct_iters)*100):.1f}%)'
+                        f'({((self._divergences[i] / ct_iters) * 100):.1f}%)'
                     )
                 if self._max_treedepths[i] > 0:
                     diagnostics.append(
                         f'Chain {i + 1} had {self._max_treedepths[i]} '
                         'iterations at max treedepth '
-                        f'({((self._max_treedepths[i]/ct_iters)*100):.1f}%)'
+                        f'({((self._max_treedepths[i] / ct_iters) * 100):.1f}%)'
                     )
             diagnostics.append(
                 'Use the "diagnose()" method on the CmdStanMCMC object'
@@ -511,9 +503,7 @@ class CmdStanMCMC:
                     ' non-empty list from (1, 99), inclusive.'
                 )
             cur_pct = pct
-        percentiles_str = (
-            f"--percentiles= {','.join(str(x) for x in percentiles)}"
-        )
+        percentiles_str = f"--percentiles= {','.join(str(x) for x in percentiles)}"
 
         if not isinstance(sig_figs, int) or sig_figs < 1 or sig_figs > 18:
             raise ValueError(
@@ -529,9 +519,7 @@ class CmdStanMCMC:
                 csv_sig_figs,
             )
         sig_figs_str = f'--sig_figs={sig_figs}'
-        cmd_path = os.path.join(
-            cmdstan_path(), 'bin', 'stansummary' + EXTENSION
-        )
+        cmd_path = os.path.join(cmdstan_path(), 'bin', 'stansummary' + EXTENSION)
         tmp_csv_file = 'stansummary-{}-'.format(self.runset._args.model_name)
         tmp_csv_path = create_named_text_file(
             dir=_TMPDIR, prefix=tmp_csv_file, suffix='.csv', name_only=True
@@ -559,9 +547,7 @@ class CmdStanMCMC:
         mask = (
             [not x.endswith('__') for x in summary_data.index]
             if self._is_fixed_param
-            else [
-                x == 'lp__' or not x.endswith('__') for x in summary_data.index
-            ]
+            else [x == 'lp__' or not x.endswith('__') for x in summary_data.index]
         )
         summary_data.index.name = None
         return summary_data[mask]
@@ -588,7 +574,7 @@ class CmdStanMCMC:
 
     def draws_pd(
         self,
-        vars: Union[List[str], str, None] = None,
+        vars: Union[list[str], str, None] = None,
         inc_warmup: bool = False,
     ) -> pd.DataFrame:
         """
@@ -630,9 +616,7 @@ class CmdStanMCMC:
                     cols.append(var)
                 elif var in self._metadata.stan_vars:
                     info = self._metadata.stan_vars[var]
-                    cols.extend(
-                        self.column_names[info.start_idx : info.end_idx]
-                    )
+                    cols.extend(self.column_names[info.start_idx : info.end_idx])
                 elif var in ['chain__', 'iter__', 'draw__']:
                     cols.append(var)
                 else:
@@ -649,14 +633,10 @@ class CmdStanMCMC:
             .T
         )
         iter_col = (
-            np.tile(np.arange(1, n_draws + 1), n_chains)
-            .reshape(1, n_chains, n_draws)
-            .T
+            np.tile(np.arange(1, n_draws + 1), n_chains).reshape(1, n_chains, n_draws).T
         )
         draw_col = (
-            np.arange(1, (n_draws * n_chains) + 1)
-            .reshape(1, n_chains, n_draws)
-            .T
+            np.arange(1, (n_draws * n_chains) + 1).reshape(1, n_chains, n_draws).T
         )
         draws = np.concatenate([chains_col, iter_col, draw_col, draws], axis=2)
 
@@ -666,7 +646,7 @@ class CmdStanMCMC:
         )[cols]
 
     def draws_xr(
-        self, vars: Union[str, List[str], None] = None, inc_warmup: bool = False
+        self, vars: Union[str, list[str], None] = None, inc_warmup: bool = False
     ) -> "xr.Dataset":
         """
         Returns the sampler draws as a xarray Dataset.
@@ -779,19 +759,16 @@ class CmdStanMCMC:
         """
         try:
             draws = self.draws(inc_warmup=inc_warmup, concat_chains=True)
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
-                draws
-            )
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(draws)
             return out
         except KeyError:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are '
-                + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
             )
 
-    def stan_variables(self) -> Dict[str, np.ndarray]:
+    def stan_variables(self) -> dict[str, np.ndarray]:
         """
         Return a dictionary mapping Stan program variables names
         to the corresponding numpy.ndarray containing the inferred values.
@@ -810,7 +787,7 @@ class CmdStanMCMC:
             result[name] = self.stan_variable(name)
         return result
 
-    def method_variables(self) -> Dict[str, np.ndarray]:
+    def method_variables(self) -> dict[str, np.ndarray]:
         """
         Returns a dictionary of all sampler variables, i.e., all
         output column names ending in `__`.  Assumes that all variables

--- a/cmdstanpy/stanfit/metadata.py
+++ b/cmdstanpy/stanfit/metadata.py
@@ -24,15 +24,21 @@ class InferenceMetadata:
 
         vars = stanio.parse_header(config['raw_header'])  # type: ignore
 
-        self._method_vars = {k: v for (k, v) in vars.items() if k.endswith('__')}
-        self._stan_vars = {k: v for (k, v) in vars.items() if not k.endswith('__')}
+        self._method_vars = {
+            k: v for (k, v) in vars.items() if k.endswith('__')
+        }
+        self._stan_vars = {
+            k: v for (k, v) in vars.items() if not k.endswith('__')
+        }
 
     @classmethod
     def from_csv(
         cls, stan_csv: Union[str, os.PathLike, Iterator[bytes]]
     ) -> 'InferenceMetadata':
         try:
-            comments, header, _ = stancsv.parse_comments_header_and_draws(stan_csv)
+            comments, header, _ = stancsv.parse_comments_header_and_draws(
+                stan_csv
+            )
             return cls(stancsv.construct_config_header_dict(comments, header))
         except Exception as exc:
             raise ValueError(

--- a/cmdstanpy/stanfit/metadata.py
+++ b/cmdstanpy/stanfit/metadata.py
@@ -2,7 +2,7 @@
 
 import copy
 import os
-from typing import Any, Dict, Iterator, Tuple, Union
+from typing import Any, Iterator, Union
 
 import stanio
 
@@ -17,28 +17,22 @@ class InferenceMetadata:
     """
 
     def __init__(
-        self, config: Dict[str, Union[str, int, float, Tuple[str, ...]]]
+        self, config: dict[str, Union[str, int, float, tuple[str, ...]]]
     ) -> None:
         """Initialize object from CSV headers"""
         self._cmdstan_config = config
 
         vars = stanio.parse_header(config['raw_header'])  # type: ignore
 
-        self._method_vars = {
-            k: v for (k, v) in vars.items() if k.endswith('__')
-        }
-        self._stan_vars = {
-            k: v for (k, v) in vars.items() if not k.endswith('__')
-        }
+        self._method_vars = {k: v for (k, v) in vars.items() if k.endswith('__')}
+        self._stan_vars = {k: v for (k, v) in vars.items() if not k.endswith('__')}
 
     @classmethod
     def from_csv(
         cls, stan_csv: Union[str, os.PathLike, Iterator[bytes]]
     ) -> 'InferenceMetadata':
         try:
-            comments, header, _ = stancsv.parse_comments_header_and_draws(
-                stan_csv
-            )
+            comments, header, _ = stancsv.parse_comments_header_and_draws(stan_csv)
             return cls(stancsv.construct_config_header_dict(comments, header))
         except Exception as exc:
             raise ValueError(
@@ -48,11 +42,11 @@ class InferenceMetadata:
     def __repr__(self) -> str:
         return 'Metadata:\n{}\n'.format(self._cmdstan_config)
 
-    def __getitem__(self, key: str) -> Union[str, int, float, Tuple[str, ...]]:
+    def __getitem__(self, key: str) -> Union[str, int, float, tuple[str, ...]]:
         return self._cmdstan_config[key]
 
     @property
-    def cmdstan_config(self) -> Dict[str, Any]:
+    def cmdstan_config(self) -> dict[str, Any]:
         """
         Returns a dictionary containing a set of name, value pairs
         parsed out of the Stan CSV file header.  These include the
@@ -62,19 +56,19 @@ class InferenceMetadata:
         return copy.deepcopy(self._cmdstan_config)
 
     @property
-    def column_names(self) -> Tuple[str, ...]:
+    def column_names(self) -> tuple[str, ...]:
         col_names = self['column_names']
         return col_names  # type: ignore
 
     @property
-    def method_vars(self) -> Dict[str, stanio.Variable]:
+    def method_vars(self) -> dict[str, stanio.Variable]:
         """
         Method variable names always end in `__`, e.g. `lp__`.
         """
         return self._method_vars
 
     @property
-    def stan_vars(self) -> Dict[str, stanio.Variable]:
+    def stan_vars(self) -> dict[str, stanio.Variable]:
         """
         These are the user-defined variables in the Stan program.
         """

--- a/cmdstanpy/stanfit/mle.py
+++ b/cmdstanpy/stanfit/mle.py
@@ -1,7 +1,7 @@
 """Container for the result of running optimization"""
 
 from collections import OrderedDict
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -30,9 +30,7 @@ class CmdStanMLE:
         # info from runset to be exposed
         self.converged = runset._check_retcodes()
         optimize_args = self.runset._args.method_args
-        assert isinstance(
-            optimize_args, OptimizeArgs
-        )  # make the typechecker happy
+        assert isinstance(optimize_args, OptimizeArgs)  # make the typechecker happy
         self._save_iterations: bool = optimize_args.save_iterations
 
         csv_file = self.runset.csv_files[0]
@@ -41,9 +39,7 @@ class CmdStanMLE:
                 comment_lines,
                 header,
                 draws_lines,
-            ) = stancsv.parse_comments_header_and_draws(
-                self.runset.csv_files[0]
-            )
+            ) = stancsv.parse_comments_header_and_draws(self.runset.csv_files[0])
             self._metadata = InferenceMetadata(
                 stancsv.construct_config_header_dict(comment_lines, header)
             )
@@ -59,7 +55,7 @@ class CmdStanMLE:
 
     def create_inits(
         self, seed: Optional[int] = None, chains: int = 4
-    ) -> Dict[str, np.ndarray]:
+    ) -> dict[str, np.ndarray]:
         """
         Create initial values for the parameters of the model
         from the MLE.
@@ -77,9 +73,7 @@ class CmdStanMLE:
         """
         # pylint: disable=unused-argument
 
-        return {
-            name: np.array(val) for name, val in self.stan_variables().items()
-        }
+        return {name: np.array(val) for name, val in self.stan_variables().items()}
 
     def __repr__(self) -> str:
         repr = 'CmdStanMLE: model={}{}'.format(
@@ -106,7 +100,7 @@ class CmdStanMLE:
             raise AttributeError(*e.args)
 
     @property
-    def column_names(self) -> Tuple[str, ...]:
+    def column_names(self) -> tuple[str, ...]:
         """
         Names of estimated quantities, includes joint log probability,
         and all parameters, transformed parameters, and generated quantities.
@@ -130,9 +124,7 @@ class CmdStanMLE:
         as well as all Stan program variables.
         """
         if not self.converged:
-            get_logger().warning(
-                'Invalid estimate, optimization failed to converge.'
-            )
+            get_logger().warning('Invalid estimate, optimization failed to converge.')
         return self._mle
 
     @property
@@ -150,9 +142,7 @@ class CmdStanMLE:
             )
             return None
         if not self.converged:
-            get_logger().warning(
-                'Invalid estimate, optimization failed to converge.'
-            )
+            get_logger().warning('Invalid estimate, optimization failed to converge.')
         return self._all_iters
 
     @property
@@ -163,9 +153,7 @@ class CmdStanMLE:
         as well as all Stan program variables.
         """
         if not self.runset._check_retcodes():
-            get_logger().warning(
-                'Invalid estimate, optimization failed to converge.'
-            )
+            get_logger().warning('Invalid estimate, optimization failed to converge.')
         return pd.DataFrame([self._mle], columns=self.column_names)
 
     @property
@@ -183,21 +171,17 @@ class CmdStanMLE:
             )
             return None
         if not self.converged:
-            get_logger().warning(
-                'Invalid estimate, optimization failed to converge.'
-            )
+            get_logger().warning('Invalid estimate, optimization failed to converge.')
         return pd.DataFrame(self._all_iters, columns=self.column_names)
 
     @property
-    def optimized_params_dict(self) -> Dict[str, np.float64]:
+    def optimized_params_dict(self) -> dict[str, np.float64]:
         """
         Returns all estimates from the optimizer, including `lp__` as a
         Python Dict.  Only returns estimate from final iteration.
         """
         if not self.runset._check_retcodes():
-            get_logger().warning(
-                'Invalid estimate, optimization failed to converge.'
-            )
+            get_logger().warning('Invalid estimate, optimization failed to converge.')
         return OrderedDict(zip(self.column_names, self._mle))
 
     def stan_variable(
@@ -242,18 +226,14 @@ class CmdStanMLE:
                 'Rerun the optimize method with "save_iterations=True".'
             )
         if warn and not self.runset._check_retcodes():
-            get_logger().warning(
-                'Invalid estimate, optimization failed to converge.'
-            )
+            get_logger().warning('Invalid estimate, optimization failed to converge.')
         if inc_iterations and self._save_iterations:
             data = self._all_iters
         else:
             data = self._mle
 
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
-                data
-            )
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(data)
             # TODO(2.0) remove
             if out.shape == () or out.shape == (1,):
                 get_logger().warning(
@@ -267,13 +247,12 @@ class CmdStanMLE:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are '
-                + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
             )
 
     def stan_variables(
         self, inc_iterations: bool = False
-    ) -> Dict[str, Union[np.ndarray, float]]:
+    ) -> dict[str, Union[np.ndarray, float]]:
         """
         Return a dictionary mapping Stan program variables names
         to the corresponding numpy.ndarray containing the inferred values.
@@ -294,9 +273,7 @@ class CmdStanMLE:
         CmdStanLaplace.stan_variables
         """
         if not self.runset._check_retcodes():
-            get_logger().warning(
-                'Invalid estimate, optimization failed to converge.'
-            )
+            get_logger().warning('Invalid estimate, optimization failed to converge.')
         result = {}
         for name in self._metadata.stan_vars:
             result[name] = self.stan_variable(

--- a/cmdstanpy/stanfit/mle.py
+++ b/cmdstanpy/stanfit/mle.py
@@ -30,7 +30,9 @@ class CmdStanMLE:
         # info from runset to be exposed
         self.converged = runset._check_retcodes()
         optimize_args = self.runset._args.method_args
-        assert isinstance(optimize_args, OptimizeArgs)  # make the typechecker happy
+        assert isinstance(
+            optimize_args, OptimizeArgs
+        )  # make the typechecker happy
         self._save_iterations: bool = optimize_args.save_iterations
 
         csv_file = self.runset.csv_files[0]
@@ -39,7 +41,9 @@ class CmdStanMLE:
                 comment_lines,
                 header,
                 draws_lines,
-            ) = stancsv.parse_comments_header_and_draws(self.runset.csv_files[0])
+            ) = stancsv.parse_comments_header_and_draws(
+                self.runset.csv_files[0]
+            )
             self._metadata = InferenceMetadata(
                 stancsv.construct_config_header_dict(comment_lines, header)
             )
@@ -73,7 +77,9 @@ class CmdStanMLE:
         """
         # pylint: disable=unused-argument
 
-        return {name: np.array(val) for name, val in self.stan_variables().items()}
+        return {
+            name: np.array(val) for name, val in self.stan_variables().items()
+        }
 
     def __repr__(self) -> str:
         repr = 'CmdStanMLE: model={}{}'.format(
@@ -124,7 +130,9 @@ class CmdStanMLE:
         as well as all Stan program variables.
         """
         if not self.converged:
-            get_logger().warning('Invalid estimate, optimization failed to converge.')
+            get_logger().warning(
+                'Invalid estimate, optimization failed to converge.'
+            )
         return self._mle
 
     @property
@@ -142,7 +150,9 @@ class CmdStanMLE:
             )
             return None
         if not self.converged:
-            get_logger().warning('Invalid estimate, optimization failed to converge.')
+            get_logger().warning(
+                'Invalid estimate, optimization failed to converge.'
+            )
         return self._all_iters
 
     @property
@@ -153,7 +163,9 @@ class CmdStanMLE:
         as well as all Stan program variables.
         """
         if not self.runset._check_retcodes():
-            get_logger().warning('Invalid estimate, optimization failed to converge.')
+            get_logger().warning(
+                'Invalid estimate, optimization failed to converge.'
+            )
         return pd.DataFrame([self._mle], columns=self.column_names)
 
     @property
@@ -171,7 +183,9 @@ class CmdStanMLE:
             )
             return None
         if not self.converged:
-            get_logger().warning('Invalid estimate, optimization failed to converge.')
+            get_logger().warning(
+                'Invalid estimate, optimization failed to converge.'
+            )
         return pd.DataFrame(self._all_iters, columns=self.column_names)
 
     @property
@@ -181,7 +195,9 @@ class CmdStanMLE:
         Python Dict.  Only returns estimate from final iteration.
         """
         if not self.runset._check_retcodes():
-            get_logger().warning('Invalid estimate, optimization failed to converge.')
+            get_logger().warning(
+                'Invalid estimate, optimization failed to converge.'
+            )
         return OrderedDict(zip(self.column_names, self._mle))
 
     def stan_variable(
@@ -226,14 +242,18 @@ class CmdStanMLE:
                 'Rerun the optimize method with "save_iterations=True".'
             )
         if warn and not self.runset._check_retcodes():
-            get_logger().warning('Invalid estimate, optimization failed to converge.')
+            get_logger().warning(
+                'Invalid estimate, optimization failed to converge.'
+            )
         if inc_iterations and self._save_iterations:
             data = self._all_iters
         else:
             data = self._mle
 
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(data)
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                data
+            )
             # TODO(2.0) remove
             if out.shape == () or out.shape == (1,):
                 get_logger().warning(
@@ -247,7 +267,8 @@ class CmdStanMLE:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are '
+                + ", ".join(self._metadata.stan_vars.keys())
             )
 
     def stan_variables(
@@ -273,7 +294,9 @@ class CmdStanMLE:
         CmdStanLaplace.stan_variables
         """
         if not self.runset._check_retcodes():
-            get_logger().warning('Invalid estimate, optimization failed to converge.')
+            get_logger().warning(
+                'Invalid estimate, optimization failed to converge.'
+            )
         result = {}
         for name in self._metadata.stan_vars:
             result[name] = self.stan_variable(

--- a/cmdstanpy/stanfit/pathfinder.py
+++ b/cmdstanpy/stanfit/pathfinder.py
@@ -2,7 +2,7 @@
 Container for the result of running Pathfinder.
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -31,7 +31,7 @@ class CmdStanPathfinder:
 
     def create_inits(
         self, seed: Optional[int] = None, chains: int = 4
-    ) -> Union[List[Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
+    ) -> Union[list[dict[str, np.ndarray]], dict[str, np.ndarray]]:
         """
         Create initial values for the parameters of the model
         by randomly selecting draws from the Pathfinder approximation.
@@ -111,19 +111,16 @@ class CmdStanPathfinder:
         """
         self._assemble_draws()
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
-                self._draws
-            )
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(self._draws)
             return out
         except KeyError:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are '
-                + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
             )
 
-    def stan_variables(self) -> Dict[str, np.ndarray]:
+    def stan_variables(self) -> dict[str, np.ndarray]:
         """
         Return a dictionary mapping Stan program variables names
         to the corresponding numpy.ndarray containing the inferred values.
@@ -142,7 +139,7 @@ class CmdStanPathfinder:
             result[name] = self.stan_variable(name)
         return result
 
-    def method_variables(self) -> Dict[str, np.ndarray]:
+    def method_variables(self) -> dict[str, np.ndarray]:
         """
         Returns a dictionary of all sampler variables, i.e., all
         output column names ending in `__`.  Assumes that all variables
@@ -193,7 +190,7 @@ class CmdStanPathfinder:
         return self._metadata
 
     @property
-    def column_names(self) -> Tuple[str, ...]:
+    def column_names(self) -> tuple[str, ...]:
         """
         Names of all outputs from the sampler, comprising sampler parameters
         and all components of all model parameters, transformed parameters,
@@ -210,10 +207,8 @@ class CmdStanPathfinder:
         """
         return (  # type: ignore
             self._metadata.cmdstan_config.get("num_paths", 4) > 1
-            and self._metadata.cmdstan_config.get('psis_resample', 1)
-            in (1, 'true')
-            and self._metadata.cmdstan_config.get('calculate_lp', 1)
-            in (1, 'true')
+            and self._metadata.cmdstan_config.get('psis_resample', 1) in (1, 'true')
+            and self._metadata.cmdstan_config.get('calculate_lp', 1) in (1, 'true')
         )
 
     def save_csvfiles(self, dir: Optional[str] = None) -> None:

--- a/cmdstanpy/stanfit/pathfinder.py
+++ b/cmdstanpy/stanfit/pathfinder.py
@@ -111,13 +111,16 @@ class CmdStanPathfinder:
         """
         self._assemble_draws()
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(self._draws)
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                self._draws
+            )
             return out
         except KeyError:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are '
+                + ", ".join(self._metadata.stan_vars.keys())
             )
 
     def stan_variables(self) -> dict[str, np.ndarray]:
@@ -207,8 +210,10 @@ class CmdStanPathfinder:
         """
         return (  # type: ignore
             self._metadata.cmdstan_config.get("num_paths", 4) > 1
-            and self._metadata.cmdstan_config.get('psis_resample', 1) in (1, 'true')
-            and self._metadata.cmdstan_config.get('calculate_lp', 1) in (1, 'true')
+            and self._metadata.cmdstan_config.get('psis_resample', 1)
+            in (1, 'true')
+            and self._metadata.cmdstan_config.get('calculate_lp', 1)
+            in (1, 'true')
         )
 
     def save_csvfiles(self, dir: Optional[str] = None) -> None:

--- a/cmdstanpy/stanfit/runset.py
+++ b/cmdstanpy/stanfit/runset.py
@@ -53,10 +53,14 @@ class RunSet:
             self._output_dir = args.output_dir
         else:
             # make a per-run subdirectory of our master temp directory
-            self._output_dir = tempfile.mkdtemp(prefix=args.model_name, dir=_TMPDIR)
+            self._output_dir = tempfile.mkdtemp(
+                prefix=args.model_name, dir=_TMPDIR
+            )
 
         # output files prefix: ``<model_name>-<YYYYMMDDHHMM>_<chain_id>``
-        self._base_outfile = f'{args.model_name}-{datetime.now().strftime(time_fmt)}'
+        self._base_outfile = (
+            f'{args.model_name}-{datetime.now().strftime(time_fmt)}'
+        )
         # per-process outputs
         self._stdout_files = [''] * self._num_procs
         self._profile_files = [''] * self._num_procs  # optional
@@ -70,7 +74,9 @@ class RunSet:
         else:
             self._stdout_files[0] = self.file_path("-stdout.txt")
             if args.save_profile:
-                self._profile_files[0] = self.file_path(".csv", extra="-profile")
+                self._profile_files[0] = self.file_path(
+                    ".csv", extra="-profile"
+                )
 
         # per-chain output files
         self._csv_files: list[str] = [''] * chains
@@ -79,7 +85,9 @@ class RunSet:
         if chains == 1:
             self._csv_files[0] = self.file_path(".csv")
             if args.save_latent_dynamics:
-                self._diagnostic_files[0] = self.file_path(".csv", extra="-diagnostic")
+                self._diagnostic_files[0] = self.file_path(
+                    ".csv", extra="-diagnostic"
+                )
         else:
             for i in range(chains):
                 self._csv_files[i] = self.file_path(".csv", id=chain_ids[i])
@@ -101,8 +109,12 @@ class RunSet:
                 repr, self._diagnostic_files[0]
             )
         if self._args.save_profile:
-            repr = '{}\n profile_file:\n\t{}'.format(repr, self._profile_files[0])
-        repr = '{}\n console_msgs (if any):\n\t{}'.format(repr, self._stdout_files[0])
+            repr = '{}\n profile_file:\n\t{}'.format(
+                repr, self._profile_files[0]
+            )
+        repr = '{}\n console_msgs (if any):\n\t{}'.format(
+            repr, self._stdout_files[0]
+        )
         return repr
 
     @property
@@ -205,7 +217,9 @@ class RunSet:
     ) -> str:
         if id is not None:
             suffix = f"_{id}{suffix}"
-        file = os.path.join(self._output_dir, f"{self._base_outfile}{extra}{suffix}")
+        file = os.path.join(
+            self._output_dir, f"{self._base_outfile}{extra}{suffix}"
+        )
         return file
 
     def _retcode(self, idx: int) -> int:
@@ -265,11 +279,15 @@ class RunSet:
 
         for i in range(self.chains):
             if not os.path.exists(self._csv_files[i]):
-                raise ValueError('Cannot access CSV file {}'.format(self._csv_files[i]))
+                raise ValueError(
+                    'Cannot access CSV file {}'.format(self._csv_files[i])
+                )
 
             to_path = os.path.join(dir, os.path.basename(self._csv_files[i]))
             if os.path.exists(to_path):
-                raise ValueError('File exists, not overwriting: {}'.format(to_path))
+                raise ValueError(
+                    'File exists, not overwriting: {}'.format(to_path)
+                )
             try:
                 get_logger().debug(
                     'saving tmpfile: "%s" as: "%s"', self._csv_files[i], to_path
@@ -277,10 +295,13 @@ class RunSet:
                 shutil.move(self._csv_files[i], to_path)
                 self._csv_files[i] = to_path
             except (IOError, OSError, PermissionError) as e:
-                raise ValueError('Cannot save to file: {}'.format(to_path)) from e
+                raise ValueError(
+                    'Cannot save to file: {}'.format(to_path)
+                ) from e
 
     def raise_for_timeouts(self) -> None:
         if any(self._timeout_flags):
             raise TimeoutError(
-                f"{sum(self._timeout_flags)} of {self.num_procs} processes timed out"
+                f"{sum(self._timeout_flags)} of {self.num_procs} "
+                "processes timed out"
             )

--- a/cmdstanpy/stanfit/runset.py
+++ b/cmdstanpy/stanfit/runset.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 from datetime import datetime
 from time import time
-from typing import List, Optional
+from typing import Optional
 
 from cmdstanpy import _TMPDIR
 from cmdstanpy.cmdstan_args import CmdStanArgs, Method
@@ -31,7 +31,7 @@ class RunSet:
         args: CmdStanArgs,
         chains: int = 1,
         *,
-        chain_ids: Optional[List[int]] = None,
+        chain_ids: Optional[list[int]] = None,
         time_fmt: str = "%Y%m%d%H%M%S",
         one_process_per_chain: bool = True,
     ) -> None:
@@ -53,14 +53,10 @@ class RunSet:
             self._output_dir = args.output_dir
         else:
             # make a per-run subdirectory of our master temp directory
-            self._output_dir = tempfile.mkdtemp(
-                prefix=args.model_name, dir=_TMPDIR
-            )
+            self._output_dir = tempfile.mkdtemp(prefix=args.model_name, dir=_TMPDIR)
 
         # output files prefix: ``<model_name>-<YYYYMMDDHHMM>_<chain_id>``
-        self._base_outfile = (
-            f'{args.model_name}-{datetime.now().strftime(time_fmt)}'
-        )
+        self._base_outfile = f'{args.model_name}-{datetime.now().strftime(time_fmt)}'
         # per-process outputs
         self._stdout_files = [''] * self._num_procs
         self._profile_files = [''] * self._num_procs  # optional
@@ -74,20 +70,16 @@ class RunSet:
         else:
             self._stdout_files[0] = self.file_path("-stdout.txt")
             if args.save_profile:
-                self._profile_files[0] = self.file_path(
-                    ".csv", extra="-profile"
-                )
+                self._profile_files[0] = self.file_path(".csv", extra="-profile")
 
         # per-chain output files
-        self._csv_files: List[str] = [''] * chains
+        self._csv_files: list[str] = [''] * chains
         self._diagnostic_files = [''] * chains  # optional
 
         if chains == 1:
             self._csv_files[0] = self.file_path(".csv")
             if args.save_latent_dynamics:
-                self._diagnostic_files[0] = self.file_path(
-                    ".csv", extra="-diagnostic"
-                )
+                self._diagnostic_files[0] = self.file_path(".csv", extra="-diagnostic")
         else:
             for i in range(chains):
                 self._csv_files[i] = self.file_path(".csv", id=chain_ids[i])
@@ -109,12 +101,8 @@ class RunSet:
                 repr, self._diagnostic_files[0]
             )
         if self._args.save_profile:
-            repr = '{}\n profile_file:\n\t{}'.format(
-                repr, self._profile_files[0]
-            )
-        repr = '{}\n console_msgs (if any):\n\t{}'.format(
-            repr, self._stdout_files[0]
-        )
+            repr = '{}\n profile_file:\n\t{}'.format(repr, self._profile_files[0])
+        repr = '{}\n console_msgs (if any):\n\t{}'.format(repr, self._stdout_files[0])
         return repr
 
     @property
@@ -148,11 +136,11 @@ class RunSet:
         return self._chains
 
     @property
-    def chain_ids(self) -> List[int]:
+    def chain_ids(self) -> list[int]:
         """Chain ids."""
         return self._chain_ids
 
-    def cmd(self, idx: int) -> List[str]:
+    def cmd(self, idx: int) -> list[str]:
         """
         Assemble CmdStan invocation.
         When running parallel chains from single process (2.28 and up),
@@ -182,12 +170,12 @@ class RunSet:
             )
 
     @property
-    def csv_files(self) -> List[str]:
+    def csv_files(self) -> list[str]:
         """List of paths to CmdStan output files."""
         return self._csv_files
 
     @property
-    def stdout_files(self) -> List[str]:
+    def stdout_files(self) -> list[str]:
         """
         List of paths to transcript of CmdStan messages sent to the console.
         Transcripts include config information, progress, and error messages.
@@ -202,12 +190,12 @@ class RunSet:
         return True
 
     @property
-    def diagnostic_files(self) -> List[str]:
+    def diagnostic_files(self) -> list[str]:
         """List of paths to CmdStan hamiltonian diagnostic files."""
         return self._diagnostic_files
 
     @property
-    def profile_files(self) -> List[str]:
+    def profile_files(self) -> list[str]:
         """List of paths to CmdStan profiler files."""
         return self._profile_files
 
@@ -217,9 +205,7 @@ class RunSet:
     ) -> str:
         if id is not None:
             suffix = f"_{id}{suffix}"
-        file = os.path.join(
-            self._output_dir, f"{self._base_outfile}{extra}{suffix}"
-        )
+        file = os.path.join(self._output_dir, f"{self._base_outfile}{extra}{suffix}")
         return file
 
     def _retcode(self, idx: int) -> int:
@@ -279,15 +265,11 @@ class RunSet:
 
         for i in range(self.chains):
             if not os.path.exists(self._csv_files[i]):
-                raise ValueError(
-                    'Cannot access CSV file {}'.format(self._csv_files[i])
-                )
+                raise ValueError('Cannot access CSV file {}'.format(self._csv_files[i]))
 
             to_path = os.path.join(dir, os.path.basename(self._csv_files[i]))
             if os.path.exists(to_path):
-                raise ValueError(
-                    'File exists, not overwriting: {}'.format(to_path)
-                )
+                raise ValueError('File exists, not overwriting: {}'.format(to_path))
             try:
                 get_logger().debug(
                     'saving tmpfile: "%s" as: "%s"', self._csv_files[i], to_path
@@ -295,13 +277,10 @@ class RunSet:
                 shutil.move(self._csv_files[i], to_path)
                 self._csv_files[i] = to_path
             except (IOError, OSError, PermissionError) as e:
-                raise ValueError(
-                    'Cannot save to file: {}'.format(to_path)
-                ) from e
+                raise ValueError('Cannot save to file: {}'.format(to_path)) from e
 
     def raise_for_timeouts(self) -> None:
         if any(self._timeout_flags):
             raise TimeoutError(
-                f"{sum(self._timeout_flags)} of {self.num_procs} processes "
-                "timed out"
+                f"{sum(self._timeout_flags)} of {self.num_procs} processes timed out"
             )

--- a/cmdstanpy/stanfit/vb.py
+++ b/cmdstanpy/stanfit/vb.py
@@ -1,7 +1,7 @@
 """Container for the results of running autodiff variational inference"""
 
 from collections import OrderedDict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -35,9 +35,7 @@ class CmdStanVB:
                 comment_lines,
                 header,
                 draw_lines,
-            ) = stancsv.parse_comments_header_and_draws(
-                self.runset.csv_files[0]
-            )
+            ) = stancsv.parse_comments_header_and_draws(self.runset.csv_files[0])
 
             self._metadata = InferenceMetadata(
                 stancsv.construct_config_header_dict(comment_lines, header)
@@ -55,7 +53,7 @@ class CmdStanVB:
 
     def create_inits(
         self, seed: Optional[int] = None, chains: int = 4
-    ) -> Union[List[Dict[str, np.ndarray]], Dict[str, np.ndarray]]:
+    ) -> Union[list[dict[str, np.ndarray]], dict[str, np.ndarray]]:
         """
         Create initial values for the parameters of the model
         by randomly selecting draws from the variational approximation
@@ -70,9 +68,7 @@ class CmdStanVB:
         ``inits`` argument of :meth:`CmdStanModel.sample`.
         """
         rng = np.random.default_rng(seed)
-        idxs = rng.choice(
-            self.variational_sample.shape[0], size=chains, replace=False
-        )
+        idxs = rng.choice(self.variational_sample.shape[0], size=chains, replace=False)
         if chains == 1:
             draw = self.variational_sample[idxs[0]]
             return {
@@ -120,7 +116,7 @@ class CmdStanVB:
         return len(self.column_names)
 
     @property
-    def column_names(self) -> Tuple[str, ...]:
+    def column_names(self) -> tuple[str, ...]:
         """
         Names of information items returned by sampler for each draw.
         Includes approximation information and names of model parameters
@@ -150,7 +146,7 @@ class CmdStanVB:
         return pd.DataFrame([self._variational_mean], columns=self.column_names)
 
     @property
-    def variational_params_dict(self) -> Dict[str, np.ndarray]:
+    def variational_params_dict(self) -> dict[str, np.ndarray]:
         """Returns inferred parameter means as Dict."""
         return OrderedDict(zip(self.column_names, self._variational_mean))
 
@@ -216,9 +212,7 @@ class CmdStanVB:
             draws = self._variational_sample
 
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
-                draws
-            )
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(draws)
             # TODO(2.0): remove
             if out.shape == () or out.shape == (1,):
                 if mean:
@@ -234,13 +228,12 @@ class CmdStanVB:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are '
-                + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
             )
 
     def stan_variables(
         self, *, mean: Optional[bool] = None
-    ) -> Dict[str, Union[np.ndarray, float]]:
+    ) -> dict[str, Union[np.ndarray, float]]:
         """
         Return a dictionary mapping Stan program variables names
         to the corresponding numpy.ndarray containing the inferred values.

--- a/cmdstanpy/stanfit/vb.py
+++ b/cmdstanpy/stanfit/vb.py
@@ -35,7 +35,9 @@ class CmdStanVB:
                 comment_lines,
                 header,
                 draw_lines,
-            ) = stancsv.parse_comments_header_and_draws(self.runset.csv_files[0])
+            ) = stancsv.parse_comments_header_and_draws(
+                self.runset.csv_files[0]
+            )
 
             self._metadata = InferenceMetadata(
                 stancsv.construct_config_header_dict(comment_lines, header)
@@ -68,7 +70,9 @@ class CmdStanVB:
         ``inits`` argument of :meth:`CmdStanModel.sample`.
         """
         rng = np.random.default_rng(seed)
-        idxs = rng.choice(self.variational_sample.shape[0], size=chains, replace=False)
+        idxs = rng.choice(
+            self.variational_sample.shape[0], size=chains, replace=False
+        )
         if chains == 1:
             draw = self.variational_sample[idxs[0]]
             return {
@@ -212,7 +216,9 @@ class CmdStanVB:
             draws = self._variational_sample
 
         try:
-            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(draws)
+            out: np.ndarray = self._metadata.stan_vars[var].extract_reshape(
+                draws
+            )
             # TODO(2.0): remove
             if out.shape == () or out.shape == (1,):
                 if mean:
@@ -228,7 +234,8 @@ class CmdStanVB:
             # pylint: disable=raise-missing-from
             raise ValueError(
                 f'Unknown variable name: {var}\n'
-                'Available variables are ' + ", ".join(self._metadata.stan_vars.keys())
+                'Available variables are '
+                + ", ".join(self._metadata.stan_vars.keys())
             )
 
     def stan_variables(

--- a/cmdstanpy/utils/cmdstan.py
+++ b/cmdstanpy/utils/cmdstan.py
@@ -7,7 +7,7 @@ import platform
 import subprocess
 import sys
 from collections import OrderedDict
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 from tqdm.auto import tqdm
 
@@ -65,9 +65,7 @@ def validate_dir(install_dir: str) -> None:
         try:
             os.makedirs(install_dir)
         except (IOError, OSError, PermissionError) as e:
-            raise ValueError(
-                'Cannot create directory: {}'.format(install_dir)
-            ) from e
+            raise ValueError('Cannot create directory: {}'.format(install_dir)) from e
     else:
         if not os.path.isdir(install_dir):
             raise ValueError(
@@ -198,7 +196,7 @@ def cmdstan_path() -> str:
     return os.path.normpath(cmdstan)
 
 
-def cmdstan_version() -> Optional[Tuple[int, ...]]:
+def cmdstan_version() -> Optional[tuple[int, ...]]:
     """
     Parses version string out of CmdStan makefile variable CMDSTAN_VERSION,
     returns Tuple(Major, minor).
@@ -233,8 +231,7 @@ def cmdstan_version() -> Optional[Tuple[int, ...]]:
     splits = version.split('.')
     if len(splits) != 3:
         get_logger().info(
-            'Cannot parse version, expected "<major>.<minor>.<patch>", '
-            'found: "%s".',
+            'Cannot parse version, expected "<major>.<minor>.<patch>", found: "%s".',
             version,
         )
         return None
@@ -242,7 +239,7 @@ def cmdstan_version() -> Optional[Tuple[int, ...]]:
 
 
 def cmdstan_version_before(
-    major: int, minor: int, info: Optional[Dict[str, str]] = None
+    major: int, minor: int, info: Optional[dict[str, str]] = None
 ) -> bool:
     """
     Check that CmdStan version is less than Major.minor version.
@@ -265,23 +262,19 @@ def cmdstan_version_before(
             'Cannot determine whether version is before %d.%d.', major, minor
         )
         return False
-    if cur_version[0] < major or (
-        cur_version[0] == major and cur_version[1] < minor
-    ):
+    if cur_version[0] < major or (cur_version[0] == major and cur_version[1] < minor):
         return True
     return False
 
 
 def cxx_toolchain_path(
     version: Optional[str] = None, install_dir: Optional[str] = None
-) -> Tuple[str, ...]:
+) -> tuple[str, ...]:
     """
     Validate, then activate C++ toolchain directory path.
     """
     if platform.system() != 'Windows':
-        raise RuntimeError(
-            'Functionality is currently only supported on Windows'
-        )
+        raise RuntimeError('Functionality is currently only supported on Windows')
     if version is not None and not isinstance(version, str):
         raise TypeError('Format version number as a string')
     logger = get_logger()
@@ -548,9 +541,7 @@ def wrap_url_progress_hook() -> Optional[Callable[[int, int, int], None]]:
         leave=False,
     )
 
-    def download_progress_hook(
-        count: int, block_size: int, total_size: int
-    ) -> None:
+    def download_progress_hook(count: int, block_size: int, total_size: int) -> None:
         if pbar.total is None:
             pbar.total = total_size
             pbar.reset()

--- a/cmdstanpy/utils/cmdstan.py
+++ b/cmdstanpy/utils/cmdstan.py
@@ -65,7 +65,9 @@ def validate_dir(install_dir: str) -> None:
         try:
             os.makedirs(install_dir)
         except (IOError, OSError, PermissionError) as e:
-            raise ValueError('Cannot create directory: {}'.format(install_dir)) from e
+            raise ValueError(
+                'Cannot create directory: {}'.format(install_dir)
+            ) from e
     else:
         if not os.path.isdir(install_dir):
             raise ValueError(
@@ -231,7 +233,8 @@ def cmdstan_version() -> Optional[tuple[int, ...]]:
     splits = version.split('.')
     if len(splits) != 3:
         get_logger().info(
-            'Cannot parse version, expected "<major>.<minor>.<patch>", found: "%s".',
+            'Cannot parse version, expected "<major>.<minor>.<patch>", '
+            'found: "%s".',
             version,
         )
         return None
@@ -262,7 +265,9 @@ def cmdstan_version_before(
             'Cannot determine whether version is before %d.%d.', major, minor
         )
         return False
-    if cur_version[0] < major or (cur_version[0] == major and cur_version[1] < minor):
+    if cur_version[0] < major or (
+        cur_version[0] == major and cur_version[1] < minor
+    ):
         return True
     return False
 
@@ -274,7 +279,9 @@ def cxx_toolchain_path(
     Validate, then activate C++ toolchain directory path.
     """
     if platform.system() != 'Windows':
-        raise RuntimeError('Functionality is currently only supported on Windows')
+        raise RuntimeError(
+            'Functionality is currently only supported on Windows'
+        )
     if version is not None and not isinstance(version, str):
         raise TypeError('Format version number as a string')
     logger = get_logger()
@@ -541,7 +548,9 @@ def wrap_url_progress_hook() -> Optional[Callable[[int, int, int], None]]:
         leave=False,
     )
 
-    def download_progress_hook(count: int, block_size: int, total_size: int) -> None:
+    def download_progress_hook(
+        count: int, block_size: int, total_size: int
+    ) -> None:
         if pbar.total is None:
             pbar.total = total_size
             pbar.reset()

--- a/cmdstanpy/utils/command.py
+++ b/cmdstanpy/utils/command.py
@@ -1,17 +1,18 @@
 """
 Run commands and handle returncodes
 """
+
 import os
 import subprocess
 import sys
-from typing import Callable, List, Optional, TextIO
+from typing import Callable, Optional, TextIO
 
 from .filesystem import pushd
 from .logging import get_logger
 
 
 def do_command(
-    cmd: List[str],
+    cmd: list[str],
     cwd: Optional[str] = None,
     *,
     fd_out: Optional[TextIO] = sys.stdout,

--- a/cmdstanpy/utils/data_munging.py
+++ b/cmdstanpy/utils/data_munging.py
@@ -1,7 +1,8 @@
 """
 Common functions for reshaping numpy arrays
 """
-from typing import Hashable, MutableMapping, Tuple
+
+from typing import Hashable, MutableMapping
 
 import numpy as np
 import stanio
@@ -27,7 +28,7 @@ def flatten_chains(draws_array: np.ndarray) -> np.ndarray:
 
 
 def build_xarray_data(
-    data: MutableMapping[Hashable, Tuple[Tuple[str, ...], np.ndarray]],
+    data: MutableMapping[Hashable, tuple[tuple[str, ...], np.ndarray]],
     var: stanio.Variable,
     drawset: np.ndarray,
 ) -> None:
@@ -35,7 +36,7 @@ def build_xarray_data(
     Adds Stan variable name, labels, and values to a dictionary
     that will be used to construct an xarray DataSet.
     """
-    var_dims: Tuple[str, ...] = ('draw', 'chain')
+    var_dims: tuple[str, ...] = ('draw', 'chain')
     var_dims += tuple(f"{var.name}_dim_{i}" for i in range(len(var.dimensions)))
 
     data[var.name] = (

--- a/cmdstanpy/utils/filesystem.py
+++ b/cmdstanpy/utils/filesystem.py
@@ -69,7 +69,9 @@ def windows_short_path(path: str) -> str:
             output_buf_size = needed
 
     short_path = (
-        os.path.join(short_base_path, file_name) if file_name else short_base_path
+        os.path.join(short_base_path, file_name)
+        if file_name
+        else short_base_path
     )
     return short_path
 
@@ -165,7 +167,9 @@ def _temp_multiinput(
 
 @contextlib.contextmanager
 def temp_inits(
-    inits: Union[str, os.PathLike, Mapping[str, Any], float, int, list[Any], None],
+    inits: Union[
+        str, os.PathLike, Mapping[str, Any], float, int, list[Any], None
+    ],
     *,
     allow_multiple: bool = True,
     id: int = 1,

--- a/cmdstanpy/utils/filesystem.py
+++ b/cmdstanpy/utils/filesystem.py
@@ -1,13 +1,14 @@
 """
 Utilities for interacting with the filesystem on multiple platforms
 """
+
 import contextlib
 import os
 import platform
 import re
 import shutil
 import tempfile
-from typing import Any, Iterator, List, Mapping, Optional, Tuple, Union
+from typing import Any, Iterator, Mapping, Optional, Union
 
 from cmdstanpy import _TMPDIR
 
@@ -68,9 +69,7 @@ def windows_short_path(path: str) -> str:
             output_buf_size = needed
 
     short_path = (
-        os.path.join(short_base_path, file_name)
-        if file_name
-        else short_base_path
+        os.path.join(short_base_path, file_name) if file_name else short_base_path
     )
     return short_path
 
@@ -104,7 +103,7 @@ def pushd(new_dir: str) -> Iterator[None]:
 
 
 def _temp_single_json(
-    data: Union[str, os.PathLike, Mapping[str, Any], None]
+    data: Union[str, os.PathLike, Mapping[str, Any], None],
 ) -> Iterator[Optional[str]]:
     """Context manager for json files."""
     if data is None:
@@ -128,7 +127,7 @@ temp_single_json = contextlib.contextmanager(_temp_single_json)
 
 
 def _temp_multiinput(
-    input: Union[str, os.PathLike, Mapping[str, Any], List[Any], None],
+    input: Union[str, os.PathLike, Mapping[str, Any], list[Any], None],
     base: int = 1,
 ) -> Iterator[Optional[str]]:
     if isinstance(input, list):
@@ -141,7 +140,7 @@ def _temp_multiinput(
             dir=_TMPDIR, prefix='', suffix='.json', name_only=True
         )
         new_files = [
-            os.path.splitext(mother_file)[0] + f'_{i+base}.json'
+            os.path.splitext(mother_file)[0] + f'_{i + base}.json'
             for i in range(len(input))
         ]
         for init, file in zip(input, new_files):
@@ -166,9 +165,7 @@ def _temp_multiinput(
 
 @contextlib.contextmanager
 def temp_inits(
-    inits: Union[
-        str, os.PathLike, Mapping[str, Any], float, int, List[Any], None
-    ],
+    inits: Union[str, os.PathLike, Mapping[str, Any], float, int, list[Any], None],
     *,
     allow_multiple: bool = True,
     id: int = 1,
@@ -228,7 +225,7 @@ class SanitizedOrTmpFilePath:
         else:
             self._path = file_path
 
-    def __enter__(self) -> Tuple[str, bool]:
+    def __enter__(self) -> tuple[str, bool]:
         return self._path, self._tmpdir is not None
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore

--- a/cmdstanpy/utils/json.py
+++ b/cmdstanpy/utils/json.py
@@ -1,6 +1,7 @@
 """
 Delegated to stanio - https://github.com/WardBrian/stanio
 """
+
 from stanio import write_stan_json
 
 __all__ = ['write_stan_json']

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -146,7 +146,9 @@ def extract_key_val_pairs(
 ) -> Iterator[tuple[str, str]]:
     """Yields cleaned key = val pairs from stan csv comments.
     Removes '(Default)' text from values if remove_default_text is True."""
-    cleaned_lines = (line.decode().lstrip("# ").strip() for line in comment_lines)
+    cleaned_lines = (
+        line.decode().lstrip("# ").strip() for line in comment_lines
+    )
     for line in cleaned_lines:
         split_on_eq = line.split(" = ")
         # Only want lines with key = value
@@ -281,7 +283,9 @@ def count_warmup_and_sampling_draws(
                 if line.startswith(b"lp__"):
                     header_line_idx = i
                     if not is_fixed_param:
-                        is_fixed_param = is_sneaky_fixed_param(line.strip().decode())
+                        is_fixed_param = is_sneaky_fixed_param(
+                            line.strip().decode()
+                        )
                 continue
 
             if not is_fixed_param and adaptation_block_idx is None:
@@ -300,7 +304,9 @@ def count_warmup_and_sampling_draws(
                 break
         else:
             # Will raise if lines exhausts without all blocks being identified
-            raise ValueError("Unable to count warmup and sampling draws from Stan csv")
+            raise ValueError(
+                "Unable to count warmup and sampling draws from Stan csv"
+            )
 
         if is_fixed_param:
             num_warmup = 0
@@ -318,7 +324,9 @@ def count_warmup_and_sampling_draws(
         return determine_draw_counts(stan_csv)
 
 
-def raise_on_inconsistent_draws_shape(header: str, draw_lines: list[bytes]) -> None:
+def raise_on_inconsistent_draws_shape(
+    header: str, draw_lines: list[bytes]
+) -> None:
     """Throws a ValueError if any draws are found to have an inconsistent
     shape, i.e. too many/few columns compared to the header"""
 
@@ -333,7 +341,8 @@ def raise_on_inconsistent_draws_shape(header: str, draw_lines: list[bytes]) -> N
     for i, draw in enumerate(draw_lines, start=1):
         if (draw_size := column_count(draw)) != num_cols:
             raise ValueError(
-                f"line {i}: bad draw, expecting {num_cols} items, found {draw_size}"
+                f"line {i}: bad draw, expecting {num_cols} items, "
+                f"found {draw_size}"
             )
 
 
@@ -382,7 +391,9 @@ def raise_on_invalid_adaptation_block(comment_lines: list[bytes]) -> None:
         (metric == "diag_e" and line.startswith(b"# Diagonal elements of "))
         or (metric == "dense_e" and line.startswith(b"# Elements of inverse"))
     ):
-        raise ValueError(f"line {num}: invalid or missing mass matrix specification")
+        raise ValueError(
+            f"line {num}: invalid or missing mass matrix specification"
+        )
 
     # Validating mass matrix shape
     _, line = next(ln_iter)
@@ -432,7 +443,8 @@ def check_sampler_csv(
     if thin > _CMDSTAN_THIN:
         if 'thin' not in meta:
             raise ValueError(
-                f'Bad Stan CSV file {path}, config error, expected thin = {thin}'
+                f'Bad Stan CSV file {path}, config error, '
+                f'expected thin = {thin}'
             )
         if meta['thin'] != thin:
             raise ValueError(
@@ -449,7 +461,8 @@ def check_sampler_csv(
     if save_warmup:
         if not ('save_warmup' in meta and meta['save_warmup'] == 1):
             raise ValueError(
-                f'Bad Stan CSV file {path}, config error, expected save_warmup = 1'
+                f'Bad Stan CSV file {path}, config error, expected '
+                'save_warmup = 1'
             )
         if meta['draws_warmup'] != draws_warmup:
             raise ValueError(

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -498,7 +498,7 @@ def parse_sampler_metadata_from_csv(
         "ct_max_treedepth": max_tree_hits,
         "time": {key_renames[k]: v for k, v in timings.items()},
     }
-    return {**config, **addtl}
+    return config | addtl
 
 
 def munge_varname(name: str) -> str:

--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -8,7 +8,7 @@ import math
 import os
 import re
 import warnings
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Iterator, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -18,7 +18,7 @@ from cmdstanpy import _CMDSTAN_SAMPLING, _CMDSTAN_THIN, _CMDSTAN_WARMUP
 
 def parse_comments_header_and_draws(
     stan_csv: Union[str, os.PathLike, Iterator[bytes]],
-) -> Tuple[List[bytes], Optional[str], List[bytes]]:
+) -> tuple[list[bytes], Optional[str], list[bytes]]:
     """Parses lines of a Stan CSV file into comment lines, the header line,
     and draws lines.
 
@@ -27,9 +27,9 @@ def parse_comments_header_and_draws(
 
     def partition_csv(
         lines: Iterator[bytes],
-    ) -> Tuple[List[bytes], Optional[str], List[bytes]]:
-        comment_lines: List[bytes] = []
-        draws_lines: List[bytes] = []
+    ) -> tuple[list[bytes], Optional[str], list[bytes]]:
+        comment_lines: list[bytes] = []
+        draws_lines: list[bytes] = []
         header = None
         for line in lines:
             if line.startswith(b"#"):  # is comment line
@@ -48,8 +48,8 @@ def parse_comments_header_and_draws(
 
 
 def filter_csv_bytes_by_columns(
-    csv_bytes_list: List[bytes], indexes_to_keep: List[int]
-) -> List[bytes]:
+    csv_bytes_list: list[bytes], indexes_to_keep: list[int]
+) -> list[bytes]:
     """Given the list of bytes representing the lines of a CSV file
     and the indexes of columns to keep, will return a new list of bytes
     containing only those columns in the index order provided. Assumes
@@ -62,7 +62,7 @@ def filter_csv_bytes_by_columns(
 
 
 def csv_bytes_list_to_numpy(
-    csv_bytes_list: List[bytes],
+    csv_bytes_list: list[bytes],
 ) -> npt.NDArray[np.float64]:
     """Efficiently converts a list of bytes representing whose concatenation
     represents a CSV file into a numpy array.
@@ -104,8 +104,8 @@ def csv_bytes_list_to_numpy(
 
 
 def parse_hmc_adaptation_lines(
-    comment_lines: List[bytes],
-) -> Tuple[Optional[float], Optional[npt.NDArray[np.float64]]]:
+    comment_lines: list[bytes],
+) -> tuple[Optional[float], Optional[npt.NDArray[np.float64]]]:
     """Extracts step size/mass matrix information from the Stan CSV comment
     lines by parsing the adaptation section. If the diag_e metric is used,
     the returned mass matrix will be a 1D array of the diagnoal elements,
@@ -142,13 +142,11 @@ def parse_hmc_adaptation_lines(
 
 
 def extract_key_val_pairs(
-    comment_lines: List[bytes], remove_default_text: bool = True
-) -> Iterator[Tuple[str, str]]:
+    comment_lines: list[bytes], remove_default_text: bool = True
+) -> Iterator[tuple[str, str]]:
     """Yields cleaned key = val pairs from stan csv comments.
     Removes '(Default)' text from values if remove_default_text is True."""
-    cleaned_lines = (
-        line.decode().lstrip("# ").strip() for line in comment_lines
-    )
+    cleaned_lines = (line.decode().lstrip("# ").strip() for line in comment_lines)
     for line in cleaned_lines:
         split_on_eq = line.split(" = ")
         # Only want lines with key = value
@@ -162,11 +160,11 @@ def extract_key_val_pairs(
 
 
 def parse_config(
-    comment_lines: List[bytes],
-) -> Dict[str, Union[str, int, float]]:
+    comment_lines: list[bytes],
+) -> dict[str, Union[str, int, float]]:
     """Extracts the key=value config settings from Stan CSV comment
     lines and returns a dictionary."""
-    out: Dict[str, Union[str, int, float]] = {}
+    out: dict[str, Union[str, int, float]] = {}
     for key, val in extract_key_val_pairs(comment_lines):
         if key == 'file':
             if not val.endswith('csv'):
@@ -188,25 +186,25 @@ def parse_config(
     return out
 
 
-def parse_header(header: str) -> Tuple[str, ...]:
+def parse_header(header: str) -> tuple[str, ...]:
     """Returns munged variable names from a Stan csv header line"""
     return tuple(munge_varname(name) for name in header.split(","))
 
 
 def construct_config_header_dict(
-    comment_lines: List[bytes], header: Optional[str]
-) -> Dict[str, Union[str, int, float, Tuple[str, ...]]]:
+    comment_lines: list[bytes], header: Optional[str]
+) -> dict[str, Union[str, int, float, tuple[str, ...]]]:
     """Extracts config and header info from comment/draws lines parsed
     from a Stan CSV file."""
     config = parse_config(comment_lines)
-    out: Dict[str, Union[str, int, float, Tuple[str, ...]]] = {**config}
+    out: dict[str, Union[str, int, float, tuple[str, ...]]] = {**config}
     if header:
         out["raw_header"] = header
         out["column_names"] = parse_header(header)
     return out
 
 
-def parse_variational_eta(comment_lines: List[bytes]) -> float:
+def parse_variational_eta(comment_lines: list[bytes]) -> float:
     """Extracts the variational eta parameter from stancsv comment lines"""
     for i, line in enumerate(comment_lines):
         if line.startswith(b"# Stepsize adaptation") and (
@@ -224,8 +222,8 @@ def parse_variational_eta(comment_lines: List[bytes]) -> float:
 
 
 def extract_max_treedepth_and_divergence_counts(
-    header: str, draws_lines: List[bytes], max_treedepth: int, warmup_draws: int
-) -> Tuple[int, int]:
+    header: str, draws_lines: list[bytes], max_treedepth: int, warmup_draws: int
+) -> tuple[int, int]:
     """Extracts the max treedepth and divergence counts from the header
     and draw lines of the MCMC stan csv output."""
     if len(draws_lines) <= 1:  # Empty draws
@@ -265,12 +263,12 @@ def is_sneaky_fixed_param(header: str) -> bool:
 
 def count_warmup_and_sampling_draws(
     stan_csv: Union[str, os.PathLike, Iterator[bytes]],
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     """Scans through a Stan CSV file to count the number of lines in the
     warmup/sampling blocks to determine counts for warmup and sampling draws.
     """
 
-    def determine_draw_counts(lines: Iterator[bytes]) -> Tuple[int, int]:
+    def determine_draw_counts(lines: Iterator[bytes]) -> tuple[int, int]:
         is_fixed_param = False
         header_line_idx = None
         adaptation_block_idx = None
@@ -283,9 +281,7 @@ def count_warmup_and_sampling_draws(
                 if line.startswith(b"lp__"):
                     header_line_idx = i
                     if not is_fixed_param:
-                        is_fixed_param = is_sneaky_fixed_param(
-                            line.strip().decode()
-                        )
+                        is_fixed_param = is_sneaky_fixed_param(line.strip().decode())
                 continue
 
             if not is_fixed_param and adaptation_block_idx is None:
@@ -304,9 +300,7 @@ def count_warmup_and_sampling_draws(
                 break
         else:
             # Will raise if lines exhausts without all blocks being identified
-            raise ValueError(
-                "Unable to count warmup and sampling draws from Stan csv"
-            )
+            raise ValueError("Unable to count warmup and sampling draws from Stan csv")
 
         if is_fixed_param:
             num_warmup = 0
@@ -324,9 +318,7 @@ def count_warmup_and_sampling_draws(
         return determine_draw_counts(stan_csv)
 
 
-def raise_on_inconsistent_draws_shape(
-    header: str, draw_lines: List[bytes]
-) -> None:
+def raise_on_inconsistent_draws_shape(header: str, draw_lines: list[bytes]) -> None:
     """Throws a ValueError if any draws are found to have an inconsistent
     shape, i.e. too many/few columns compared to the header"""
 
@@ -341,12 +333,11 @@ def raise_on_inconsistent_draws_shape(
     for i, draw in enumerate(draw_lines, start=1):
         if (draw_size := column_count(draw)) != num_cols:
             raise ValueError(
-                f"line {i}: bad draw, expecting {num_cols} items,"
-                f" found {draw_size}"
+                f"line {i}: bad draw, expecting {num_cols} items, found {draw_size}"
             )
 
 
-def raise_on_invalid_adaptation_block(comment_lines: List[bytes]) -> None:
+def raise_on_invalid_adaptation_block(comment_lines: list[bytes]) -> None:
     """Throws ValueErrors if the parsed adaptation block is invalid, e.g.
     the metric information is not present, consistent with the rest of
     the file, or the step size info cannot be processed."""
@@ -373,8 +364,7 @@ def raise_on_invalid_adaptation_block(comment_lines: List[bytes]) -> None:
     num, line = next(ln_iter)
     if not line.startswith(b"# Step size"):
         raise ValueError(
-            f"line {num}: expecting step size, "
-            f"found:\n\t \"{line.decode()}\""
+            f"line {num}: expecting step size, found:\n\t \"{line.decode()}\""
         )
     _, step_size = line.split(b" = ")
     try:
@@ -392,9 +382,7 @@ def raise_on_invalid_adaptation_block(comment_lines: List[bytes]) -> None:
         (metric == "diag_e" and line.startswith(b"# Diagonal elements of "))
         or (metric == "dense_e" and line.startswith(b"# Elements of inverse"))
     ):
-        raise ValueError(
-            f"line {num}: invalid or missing mass matrix specification"
-        )
+        raise ValueError(f"line {num}: invalid or missing mass matrix specification")
 
     # Validating mass matrix shape
     _, line = next(ln_iter)
@@ -409,12 +397,12 @@ def raise_on_invalid_adaptation_block(comment_lines: List[bytes]) -> None:
 
 
 def parse_timing_lines(
-    comment_lines: List[bytes],
-) -> Dict[str, float]:
+    comment_lines: list[bytes],
+) -> dict[str, float]:
     """Parse the timing lines into a dictionary with key corresponding
     to the phase, e.g. Warm-up, Sampling, Total, and value the elapsed seconds
     """
-    out: Dict[str, float] = {}
+    out: dict[str, float] = {}
 
     cleaned_lines = (ln.lstrip(b"# ") for ln in comment_lines)
     in_timing_block = False
@@ -438,14 +426,13 @@ def check_sampler_csv(
     iter_warmup: int = _CMDSTAN_WARMUP,
     save_warmup: bool = False,
     thin: int = _CMDSTAN_THIN,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Capture essential config, shape from stan_csv file."""
     meta = parse_sampler_metadata_from_csv(path)
     if thin > _CMDSTAN_THIN:
         if 'thin' not in meta:
             raise ValueError(
-                f'Bad Stan CSV file {path}, config error, '
-                f'expected thin = {thin}'
+                f'Bad Stan CSV file {path}, config error, expected thin = {thin}'
             )
         if meta['thin'] != thin:
             raise ValueError(
@@ -462,8 +449,7 @@ def check_sampler_csv(
     if save_warmup:
         if not ('save_warmup' in meta and meta['save_warmup'] == 1):
             raise ValueError(
-                f'Bad Stan CSV file {path}, '
-                'config error, expected save_warmup = 1'
+                f'Bad Stan CSV file {path}, config error, expected save_warmup = 1'
             )
         if meta['draws_warmup'] != draws_warmup:
             raise ValueError(
@@ -475,7 +461,7 @@ def check_sampler_csv(
 
 def parse_sampler_metadata_from_csv(
     path: Union[str, os.PathLike],
-) -> Dict[str, Union[int, float, str, Tuple[str, ...], Dict[str, float]]]:
+) -> dict[str, Union[int, float, str, tuple[str, ...], dict[str, float]]]:
     """Parses sampling metadata from a given Stan CSV path for a sample run"""
     try:
         comments, header, draws = parse_comments_header_and_draws(path)
@@ -505,7 +491,7 @@ def parse_sampler_metadata_from_csv(
         "Sampling": "sampling",
         "Total": "total",
     }
-    addtl: Dict[str, Union[int, Dict[str, float]]] = {
+    addtl: dict[str, Union[int, dict[str, float]]] = {
         "draws_warmup": num_warmup,
         "draws_sampling": num_sampling,
         "ct_divergences": divs,
@@ -531,7 +517,7 @@ def munge_varname(name: str) -> str:
     return '.'.join(tuple_parts)
 
 
-def read_metric(path: str) -> List[int]:
+def read_metric(path: str) -> list[int]:
     """
     Read metric file in JSON or Rdump format.
     Return dimensions of entry "inv_metric".
@@ -544,20 +530,18 @@ def read_metric(path: str) -> List[int]:
             return list(dims_np.shape)
         else:
             raise ValueError(
-                'metric file {}, bad or missing'
-                ' entry "inv_metric"'.format(path)
+                'metric file {}, bad or missing entry "inv_metric"'.format(path)
             )
     else:
         dims = list(read_rdump_metric(path))
         if dims is None:
             raise ValueError(
-                'metric file {}, bad or missing'
-                ' entry "inv_metric"'.format(path)
+                'metric file {}, bad or missing entry "inv_metric"'.format(path)
             )
         return dims
 
 
-def read_rdump_metric(path: str) -> List[int]:
+def read_rdump_metric(path: str) -> list[int]:
     """
     Find dimensions of variable named 'inv_metric' in Rdump data file.
     """
@@ -572,7 +556,7 @@ def read_rdump_metric(path: str) -> List[int]:
     return list(metric_dict['inv_metric'].shape)
 
 
-def rload(fname: str) -> Optional[Dict[str, Union[int, float, np.ndarray]]]:
+def rload(fname: str) -> Optional[dict[str, Union[int, float, np.ndarray]]]:
     """Parse data and parameter variable values from an R dump format file.
     This parser only supports the subset of R dump data as described
     in the "Dump Data Format" section of the CmdStan manual, i.e.,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python interface to CmdStan"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }
 authors = [{ name = "Stan Dev Team" }]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["pandas", "numpy>=1.21", "tqdm", "stanio>=0.4.0,<2.0.0"]
 dynamic = ["version"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ warn_redundant_casts = true
 strict_equality = true
 disallow_untyped_calls = true
 
+[tool.ruff.format]
+quote-style = "preserve"
+
 [[tool.mypy.overrides]]
 module = ['tqdm.auto', 'pandas']
 ignore_missing_imports = true


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR bumps the required Python version of the library to 3.9. Resolves #802 .

Also uses the 3.9 features of typing with generics for `dict, list, tuple` and dictionary unions with `|`. 

I also removed 3.8 testing from the Github workflow for CI/CD and added 3.13 (I think the way I did it is correct? I've not used it before).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): myself



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

