### PR TITLE
Stop trying to munge return codes from subprocess

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -54,7 +54,6 @@ from cmdstanpy.utils import (
     cmdstan_version_before,
     do_command,
     get_logger,
-    returncode_msg,
 )
 from cmdstanpy.utils.filesystem import (
     temp_inits,
@@ -2162,14 +2161,13 @@ class CmdStanModel:
             get_logger().info('%s done processing', logger_prefix)
 
         if retcode != 0:
-            retcode_summary = returncode_msg(retcode)
             serror = ''
             try:
                 serror = os.strerror(retcode)
             except (ArithmeticError, ValueError):
                 pass
             get_logger().error(
-                '%s error: %s %s', logger_prefix, retcode_summary, serror
+                "%s error: code '%d' %s", logger_prefix, retcode, serror
             )
 
     @staticmethod

--- a/cmdstanpy/utils/__init__.py
+++ b/cmdstanpy/utils/__init__.py
@@ -20,7 +20,7 @@ from .cmdstan import (
     validate_dir,
     wrap_url_progress_hook,
 )
-from .command import do_command, returncode_msg
+from .command import do_command
 from .data_munging import build_xarray_data, flatten_chains
 from .filesystem import (
     SanitizedOrTmpFilePath,
@@ -114,7 +114,6 @@ __all__ = [
     'parse_rdump_value',
     'pushd',
     'read_metric',
-    'returncode_msg',
     'rload',
     'set_cmdstan_path',
     'set_make_env',

--- a/cmdstanpy/utils/command.py
+++ b/cmdstanpy/utils/command.py
@@ -71,25 +71,10 @@ def do_command(
                     serror = os.strerror(proc.returncode)
                 except (ArithmeticError, ValueError):
                     pass
-                msg = 'Command {}\n\t{} {}'.format(
-                    cmd, returncode_msg(proc.returncode), serror
+                msg = "Command {}\n\texited with code '{}' {}".format(
+                    cmd, proc.returncode, serror
                 )
                 raise RuntimeError(msg)
     except OSError as e:
         msg = 'Command: {}\nfailed with error {}\n'.format(cmd, str(e))
         raise RuntimeError(msg) from e
-
-
-def returncode_msg(retcode: int) -> str:
-    """interpret retcode"""
-    if retcode < 0:
-        sig = -1 * retcode
-        return f'terminated by signal {sig}'
-    if retcode <= 125:
-        return 'error during processing'
-    if retcode == 126:  # shouldn't happen
-        return ''
-    if retcode == 127:
-        return 'program not found'
-    sig = retcode - 128
-    return f'terminated by signal {sig}'


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

The existing logic doesn't really provide much additional value and does break google-ability. 

For example, [prophet has several reports](https://github.com/facebook/prophet/issues/2245) about an error code `3221225657`, which has basically 0 hits on google besides prophet's repo. That's because we're assuming the world is a unix system and subtracting 128. The real error is `3221225785`, which has _significantly_ more helpful results.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

