### PR TITLE
STAN_OPENCL implies STANCFLAGS=--use-opencl, avoid duplicates

### DIFF
--- a/cmdstanpy/compilation.py
+++ b/cmdstanpy/compilation.py
@@ -189,6 +189,7 @@ class CompilerOptions:
                     self._cpp_options = {'STAN_OPENCL': 'TRUE'}
                 else:
                     self._cpp_options['STAN_OPENCL'] = 'TRUE'
+                ignore.append(key)
             elif key.startswith('O'):
                 if has_o_flag:
                     get_logger().warning(

--- a/test/test_compiler_opts.py
+++ b/test/test_compiler_opts.py
@@ -135,7 +135,8 @@ def test_opts_stanc_opencl() -> None:
     stanc_opts['use-opencl'] = 'foo'
     opts = CompilerOptions(stanc_options=stanc_opts)
     opts.validate()
-    assert opts.compose() == ['STANCFLAGS+=--use-opencl', 'STAN_OPENCL=TRUE']
+    # cmdstan STAN_OPENCL implies STANCFLAGS+=--use-opencl
+    assert opts.compose() == ['STAN_OPENCL=TRUE']
 
 
 def test_opts_stanc_ignore() -> None:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -155,11 +155,11 @@ def test_stanc_options() -> None:
         stanc_opts = model.stanc_options
         assert stanc_opts[f'O{optim}']
         assert stanc_opts['allow-undefined']
-        assert stanc_opts['use-opencl']
         assert stanc_opts['name'] == 'foo'
 
         cpp_opts = model.cpp_options
         assert cpp_opts['STAN_OPENCL'] == 'TRUE'
+        assert not stanc_opts.get('use-opencl')
 
     with pytest.raises(ValueError):
         bad_opts = {'X': True}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

See https://github.com/stan-dev/cmdstanr/issues/1111 for more details. Essentially, it is the correct behavior for CmdStan's build system to set _only_ STAN_OPENCL when the user requests opencl capabilities. This flag enables the C++ code _and_ adds the proper flag to stanc3

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

