### PR TITLE
Use new codecov uploader, avoid rate limiting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,8 @@ jobs:
           pytest -v ../test --cov=../cmdstanpy
 
       - name: Submit codecov
-        run: |
-          pip install codecov
-          cd run_tests
-          codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          directory: ./run_tests


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary

Code coverage was usually failing to upload some of the coverage reports due to rate limiting. This 
switches uploaders and uses a token to avoid that issue

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

