### PR TITLE
Add from_string classmethod constructor for CmdStanModel

### DIFF
--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -208,24 +208,24 @@ class CmdStanModel:
         """
         Initialize CmdStanModel using stan code from a string.
 
-        Internally, this method first writes the Stan code to a 
+        Internally, this method first writes the Stan code to a
         temporary file and then calls the regular CmdStanModel()
         constructor.
 
         Note that this method is only meant to be used for small
         examples and / or for development purposes. For all other
-        purposes, we recommend developing the model in a separate 
+        purposes, we recommend developing the model in a separate
         .stan file and calling CmdStanModel() directly.
 
         :param stan_code: Stan program code as a string.
-        :param **kwargs: keyword arguments passed to the CmdStanModel() 
+        :param **kwargs: keyword arguments passed to the CmdStanModel()
             constructor.
         """
-        with tempfile.TemporaryFile(mode="w", suffix=".stan", delete=False) as f:
+        with tempfile.TemporaryFile("w", suffix=".stan", delete=False) as f:
             f.writelines(stan_code)
-        
-        return cls(stan_file = f.name, **kwargs)
-        
+
+        return cls(stan_file=f.name, **kwargs)
+
     @property
     def name(self) -> str:
         """

--- a/cmdstanpy/model.py
+++ b/cmdstanpy/model.py
@@ -11,7 +11,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 from multiprocessing import cpu_count
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence, Self
 
 import numpy as np
 import pandas as pd
@@ -203,6 +203,29 @@ class CmdStanModel:
             f"exe_file={self.exe_file!r})"
         )
 
+    @classmethod
+    def from_string(cls, stan_code: str, **kwargs) -> Self:
+        """
+        Initialize CmdStanModel using stan code from a string.
+
+        Internally, this method first writes the Stan code to a 
+        temporary file and then calls the regular CmdStanModel()
+        constructor.
+
+        Note that this method is only meant to be used for small
+        examples and / or for development purposes. For all other
+        purposes, we recommend developing the model in a separate 
+        .stan file and calling CmdStanModel() directly.
+
+        :param stan_code: Stan program code as a string.
+        :param **kwargs: keyword arguments passed to the CmdStanModel() 
+            constructor.
+        """
+        with tempfile.TemporaryFile(mode="w", suffix=".stan", delete=False) as f:
+            f.writelines(stan_code)
+        
+        return cls(stan_file = f.name, **kwargs)
+        
     @property
     def name(self) -> str:
         """

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -58,6 +58,22 @@ def test_model_good() -> None:
     assert BERN_STAN == model.stan_file
     assert os.path.samefile(model.exe_file, BERN_EXE)
 
+def test_model_fromstring() -> None:
+    stan_string = """
+    data {
+        int<lower=0> N;
+        array[N] int<lower=0,upper=1> y;
+    }
+    parameters {
+        real<lower=0,upper=1> theta;
+    }
+    model {
+        theta ~ beta(1,1);
+        y ~ bernoulli(theta);
+    }
+    """
+    model = CmdStanModel.from_string(stan_string)
+    assert isinstance(model, CmdStanModel)
 
 def test_ctor_compile_arg() -> None:
     if os.path.exists(BERN_EXE):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -58,6 +58,7 @@ def test_model_good() -> None:
     assert BERN_STAN == model.stan_file
     assert os.path.samefile(model.exe_file, BERN_EXE)
 
+
 def test_model_fromstring() -> None:
     stan_string = """
     data {
@@ -74,6 +75,7 @@ def test_model_fromstring() -> None:
     """
     model = CmdStanModel.from_string(stan_string)
     assert isinstance(model, CmdStanModel)
+
 
 def test_ctor_compile_arg() -> None:
     if os.path.exists(BERN_EXE):


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
This implements a basic version of instantiating a CmdStanModel from a code string. For discussion, see #757; this implements option 3 from that discussion. I've implemented the classmethod itself as well as a (basic) unit test. I've ensured code passes both flake8 and pylint.

This is a first draft, feel free to reject this pull request, to request changes, or to completely ignore :+1: I don't want to overload you as maintainers!

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Erik-Jan van Kesteren



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

