### PR TITLE
Update timing parsing regex to account for scientific notation.

### DIFF
--- a/cmdstanpy/utils/stancsv.py
+++ b/cmdstanpy/utils/stancsv.py
@@ -324,7 +324,7 @@ def parse_timing_lines(
 
         if not in_timing_block:
             continue
-        match = re.findall(r"([\d\.]+) seconds \((.+)\)", str(line))
+        match = re.findall(r"([\d\.e\+\-]+) seconds \((.+)\)", str(line))
         if match:
             seconds = float(match[0][0])
             phase = match[0][1]

--- a/test/test_stancsv.py
+++ b/test/test_stancsv.py
@@ -459,6 +459,22 @@ def test_parsing_timing_lines() -> None:
     assert out['Total'] == 0.001581
 
 
+def test_parsing_timing_lines_scientific_notation() -> None:
+    lines = [
+        b'# \n',
+        b'#  Elapsed Time: 630099e0 seconds (Warm-up)\n',
+        b'#                4358560.0e-1 seconds (Sampling)\n',
+        b'#                1.06595e+06 seconds (Total)\n',
+        b'# \n',
+    ]
+    out = stancsv.parse_timing_lines(lines)
+
+    assert len(out) == 3
+    assert out['Warm-up'] == 630099.0
+    assert out['Sampling'] == 435856.0
+    assert out['Total'] == 1065950.0
+
+
 def test_munge_varname() -> None:
     name1 = "a"
     name2 = "a:1"


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and open-source license: see below

#### Summary
The regex in `parse_timing_lines()` has a bug where if scientific notation is present, only the exponent is captured: 
```
In [1]: from cmdstanpy.utils.stancsv import parse_timing_lines

In [2]: lines = [
   ...:     b'# \n',
   ...:     b'#  Elapsed Time: 630099 seconds (Warm-up)\n',
   ...:     b'#                435856 seconds (Sampling)\n',
   ...:     b'#                1.06595e+06 seconds (Total)\n',
   ...:     b'# \n'
   ...: ]

In [3]: parse_timing_lines(lines)
Out[3]: {'Warm-up': 630099.0, 'Sampling': 435856.0, 'Total': 6.0}
```

This change updates the regex for the first capture group to include `e`, `+`, and `-`, so the output becomes
```
In [3]: parse_timing_lines(lines)
Out[3]: {'Warm-up': 630099.0, 'Sampling': 435856.0, 'Total': 1065950.0}
```
Not sure if support for `-` is really needed in practice, but I added it for completeness. In keeping with the existing escaped `.` in the regex, I also escape `+` and `-`, though I believe no escapes are actually needed in the character class, i.e.  `([\d.e+-]+)` is valid. 

Note that this can lead to the case where  the `Warm-Up + Sampling != Total` due to truncation from the scientific notation. In this example, `1.06595e+06` gets parsed to `1065950.0` but Warm-Up + Sampling is `630099.0 + 435856.0 = 1065955.0`. Arguably this is not a _parsing_ issue since it's correctly reading the comment, but perhaps some additional logic to set Total = Warm-Up + Sampling might be useful.




#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Myself

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)

